### PR TITLE
feat: add composable-revenue skill for PoolFans fee tokenization

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ https://github.com/BankrBot/moltbot-skills
 | Provider                   | Skill           | Description                                                                                               |
 | -------------------------- | --------------- | --------------------------------------------------------------------------------------------------------- |
 | [bankr](https://bankr.bot) | [bankr](bankr/) | AI-powered crypto trading agent via natural language. Trade, manage portfolios, automate DeFi operations. |
+| [pool.fans](https://pool.fans) | [composable-revenue](composable-revenue/) | ComposAIble revenue management for Clanker tokens on Base. Tokenize fees, create time-wrappers, burn/LP/rewards strategies. |
 | base                       | —               | Placeholder                                                                                               |
 | neynar                     | —               | Placeholder                                                                                               |
 | zapper                     | —               | Placeholder                                                                                               |

--- a/composable-revenue/SKILL.md
+++ b/composable-revenue/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: composable-revenue
+description: Composable revenue management for Clanker tokens on Base. Use when the user wants to tokenize trading fees, create time-locked fee wrappers, set up automated burn/LP/rewards strategies, route fees conditionally based on market metrics, or deploy tokens with fee tokenization via PoolFans infrastructure. Enables trustless, programmable fee automation with no admin keys.
+metadata: {"clawdbot":{"emoji":"⚡","homepage":"https://pool.fans","requires":{"bins":["curl","node"]}}}
+---
+
+# Composable Revenue (PoolFans)
+
+Deploy and manage composable trading fee strategies on Base using PoolFans infrastructure.
+
+## Quick Start
+
+### Prerequisites
+- Node.js v18+
+- Base RPC endpoint
+- Private key with ETH on Base for gas
+
+### Configuration
+
+```bash
+mkdir -p ~/.clawdbot/skills/composable-revenue
+cat > ~/.clawdbot/skills/composable-revenue/config.json << 'EOF'
+{
+  "rpcUrl": "https://mainnet.base.org",
+  "privateKey": "YOUR_PRIVATE_KEY",
+  "chainId": 8453
+}
+EOF
+```
+
+## Core Capabilities
+
+### 1. Deploy Token with Fee Tokenization
+Deploy Clanker tokens with instant fee tokenization. Choose fee collection mode: WETH_ONLY, TOKEN_ONLY, or BOTH.
+
+```
+"Deploy token called ClawdFans ticker $CLAWDFANS with WETH fee collection"
+```
+
+**Reference**: [references/deploy-tokenize.md](references/deploy-tokenize.md)
+
+### 2. Tokenize Existing Token Fees
+Tokenize fees for already-deployed Clanker tokens (V3.1.0+ and V4). Two-step flow for security.
+
+```
+"Tokenize fees for my existing token 0x123..."
+```
+
+**Reference**: [references/tokenize-existing.md](references/tokenize-existing.md)
+
+### 3. Time-Locked Fee Wrappers
+Create tradeable tokens representing temporary fee claiming rights (1 Day, 1 Week, 1 Month).
+
+```
+"Create 1D time-wrappers from my fee tokens"
+```
+
+**Reference**: [references/time-wrappers.md](references/time-wrappers.md)
+
+### 4. Automated LP Provision
+Auto-deploy collected fees as Uniswap V4 liquidity. Three strategies: Below Price (accumulate), Above Price (take profit), Around Price (maximize fees).
+
+```
+"Auto-deploy my fees as LP below current price to accumulate tokens"
+```
+
+**Reference**: [references/lp-automation.md](references/lp-automation.md)
+
+### 5. Conditional Fee Routing
+Route fees to different destinations based on market conditions (market cap, volume, holder count).
+
+```
+"Route fees to top 50 holders when market cap > $1M, otherwise burn"
+```
+
+**Reference**: [references/conditional-routing.md](references/conditional-routing.md)
+
+### 6. Multi-Strategy Automation
+Chain multiple DeFi actions: burn + LP + rewards with percentage allocations.
+
+```
+"Split daily fees: 40% burn, 30% LP, 20% to top traders, 10% to me"
+```
+
+**Reference**: [references/multi-strategy.md](references/multi-strategy.md)
+
+### 7. Holder/Trader Rewards
+Distribute fees to token holders (pro-rata) or top traders by volume.
+
+```
+"Distribute 50% of daily fees to top 100 holders"
+```
+
+**Reference**: [references/rewards.md](references/rewards.md)
+
+## Contract Addresses (Base Mainnet)
+
+```typescript
+const POOL_FANS_CONTRACTS = {
+  // Factories
+  MULTI_ACTION_VAULT_FACTORY: "0x069aEC7cE08CDc0F45135bAac0E5Fe3B579AB99b",
+  LP_AUTOMATION_VAULT_FACTORY: "0xF0a87A32C2F7fAb1E372F676A852C64b8dB0CEDD",
+  TIME_WRAPPER_FACTORY: "0x083EDF9b6C894561Ce8a237e2fd570bECB920DfF",
+  
+  // Tokenizers
+  V4_TOKENIZER_FACTORY: "0xea8127533F7be6d04b3DBA8f0a496F2DCfd27728",
+  V3_1_0_TOKENIZER_FACTORY: "0x50e2A7193c4AD03221F4B4e3e33cDF1a46671Ced",
+  REVENUE_SHARE_REGISTRY: "0xAa9c3E28e2f03e41365D4b01FB2785bdbd1494d2",
+  
+  // External
+  CLANKER_V4_DEPLOYER: "0xE85A59c628F7d27878ACeB4bf3b35733630083a9",
+  FEE_LOCKER: "0x63D2DfEA64b3433F4071A98665bcD7Ca14d93496",
+  WETH: "0x4200000000000000000000000000000000000006",
+};
+```
+
+**Always verify on BaseScan before interacting.**
+
+## Intent Recognition
+
+```typescript
+const INTENT_PATTERNS = {
+  // Deployment
+  deploy_token: /deploy.*token|launch.*token|create.*token/i,
+  tokenize_fees: /tokenize.*fee|fee.*token|revenue.*share/i,
+  
+  // Strategies
+  time_wrapper: /time.?wrapper|1D|daily.*claim|temporary.*access/i,
+  burn_strategy: /burn|buy.*burn|auto.*burn|destroy/i,
+  lp_strategy: /add.*liquidity|LP|provide.*liquidity/i,
+  holder_rewards: /distribute.*holder|holder.*reward/i,
+  trader_rewards: /top.*trader|volume.*reward/i,
+  
+  // Conditional
+  conditional: /if.*then|condition|market cap|volume|when/i,
+  market_cap: /market.*cap|mcap|\$\d+[kKmM]/i,
+};
+```
+
+## Example Conversation
+
+```
+User: "Deploy token called ClawdFans ticker $CLAWDFANS and tokenize fees.
+       Split daily fees: 40% burn, 30% LP, 30% to me"
+
+MoltRevenue: ⚡ Composing your revenue strategy...
+
+✅ Strategy Deployed:
+
+1️⃣ Token
+   • Name: ClawdFans
+   • Symbol: $CLAWDFANS
+   • Address: 0x123...
+
+2️⃣ Fee Tokenization
+   • You received: 80 fee tokens (80% of trading fees)
+   • Treasury: 20 fee tokens (20%)
+
+3️⃣ Multi-Strategy Router
+   • Route A (40%): Auto-swap → Burn
+   • Route B (30%): Add liquidity → Burn LP
+   • Route C (30%): Direct to you
+   • Automation: Daily via Chainlink
+
+Monitor at: https://pool.fans/vault/0x123...
+```
+
+## Treasury Fee
+
+- Creators receive **80%** of fee tokens
+- Treasury receives **20%**
+- This is protocol-level and immutable
+
+## Common Patterns
+
+### Full Deflationary Setup
+```
+"Deploy $TOKEN, tokenize fees, 
+ create 1D wrappers,
+ burn 100% of collected fees daily"
+```
+
+### Holder-Aligned Strategy
+```
+"Deploy $TOKEN with BOTH fee collection,
+ if market cap > $500k: distribute to top 100 holders
+ else: burn everything"
+```
+
+### LP Growth Strategy
+```
+"Deploy $TOKEN,
+ 50% add liquidity below price (accumulate),
+ 50% add liquidity above price (take profit),
+ burn all LP tokens"
+```
+
+## Error Handling
+
+| Error | Solution |
+|-------|----------|
+| Insufficient fee tokens | Wait for more trading fees to accumulate |
+| Lock period not expired | Cannot withdraw until lock ends; wrapper tokens still tradeable |
+| Allocation != 100% | Percentages must sum to exactly 100% |
+| Admin not set | Complete 2-step tokenization flow first |
+
+## Resources
+
+- **UI**: https://pool.fans
+- **Docs**: https://pool.fans/docs
+- **Contracts**: https://pool.fans/docs#contracts
+- **Architecture**: See fee-tokenizer.md for complete guide
+
+## Value Proposition
+
+**For Token Creators:**
+- Turn trading fees into programmable revenue
+- Build deflationary pressure through burns
+- Reward holders and traders automatically
+
+**For AI Bots:**
+- Natural language → on-chain execution
+- Fully trustless (no admin keys)
+- Composable primitives
+
+**For Users:**
+- Transparent fee usage (all on-chain)
+- Tradeable fee rights via wrappers
+- Trust through code, not promises
+
+---
+
+*⚡ Composable Revenue — Forge Your Strategy*

--- a/composable-revenue/references/deploy-tokenize.md
+++ b/composable-revenue/references/deploy-tokenize.md
@@ -1,0 +1,84 @@
+# Deploy Token with Fee Tokenization
+
+## Overview
+
+Deploy new Clanker V4 tokens with automatic fee tokenization in a single transaction.
+
+## Fee Collection Modes
+
+| Mode | Description | When to Use |
+|------|-------------|-------------|
+| `WETH_ONLY` | Collect fees as WETH only | Want stable asset exposure |
+| `TOKEN_ONLY` | Collect fees as your token | Want to accumulate your token |
+| `BOTH` | Collect fees in both assets | Maximum flexibility |
+
+## Contract
+
+**V4 Tokenizer Factory**: `0xea8127533F7be6d04b3DBA8f0a496F2DCfd27728`
+
+## Function
+
+```solidity
+function tokenizeAndDeployV4Clanker(
+    DeploymentConfig calldata config,
+    address[] calldata recipients
+) external returns (address token, address vault)
+```
+
+## Parameters
+
+```typescript
+interface DeploymentConfig {
+  name: string;           // Token name
+  symbol: string;         // Token symbol (no $ prefix)
+  image: string;          // Token image URL (optional)
+  feePreference: number;  // 0=WETH, 1=TOKEN, 2=BOTH
+}
+```
+
+## Example
+
+```typescript
+import { V4TokenizerFactory } from './abis';
+
+const factory = new Contract(
+  "0xea8127533F7be6d04b3DBA8f0a496F2DCfd27728",
+  V4TokenizerFactory.abi,
+  signer
+);
+
+const config = {
+  name: "ClawdFans",
+  symbol: "CLAWDFANS",
+  image: "",
+  feePreference: 0, // WETH_ONLY
+};
+
+const recipients = [userAddress]; // Who gets fee tokens
+
+const tx = await factory.tokenizeAndDeployV4Clanker(
+  config,
+  recipients
+);
+
+const receipt = await tx.wait();
+// Parse TokenDeployed and VaultCreated events
+```
+
+## Output
+
+- **Token Address**: The deployed ERC20 token
+- **Vault Address**: The fee vault holding tokenized fees
+- **Fee Tokens**: Recipients receive fee share tokens (80/20 split)
+
+## Fee Distribution
+
+- **80%** to specified recipients
+- **20%** to protocol treasury
+
+## Next Steps
+
+After deployment:
+1. Add liquidity to token/WETH pool
+2. Share token address
+3. Set up fee strategies (wrappers, routing, automation)

--- a/composable-revenue/references/multi-strategy.md
+++ b/composable-revenue/references/multi-strategy.md
@@ -1,0 +1,154 @@
+# Multi-Strategy Automation
+
+## Overview
+
+Chain multiple DeFi actions on collected fees with percentage allocations. Executed automatically via Chainlink Automation.
+
+## Contract
+
+**MultiActionVaultFactory**: `0x069aEC7cE08CDc0F45135bAac0E5Fe3B579AB99b`
+
+## Available Actions
+
+| Action | Description | Result |
+|--------|-------------|--------|
+| **Buy & Burn** | Swap fees to token, send to burn address | Deflationary pressure |
+| **Add Liquidity** | Provide liquidity on Uniswap V4 | Deeper markets |
+| **Burn LP** | Add liquidity, then burn LP token | Permanent liquidity |
+| **Holder Rewards** | Distribute to token holders pro-rata | Holder alignment |
+| **Top Traders** | Reward top N traders by volume | Trading incentives |
+| **Creator** | Send directly to creator wallet | Direct revenue |
+| **Treasury** | Route to protocol treasury | Protocol revenue |
+
+## Allocation Example
+
+```typescript
+const strategies = [
+  { action: "burn", allocation: 4000 },      // 40%
+  { action: "lp_burn", allocation: 3000 },   // 30%
+  { action: "holders", allocation: 2000 },   // 20%
+  { action: "creator", allocation: 1000 },   // 10%
+];
+
+// Total must equal 10000 (100%)
+```
+
+## Creating Multi-Action Vault
+
+```typescript
+const vault = await multiActionFactory.createVault({
+  feeSource: feeVaultAddress,
+  actions: [
+    {
+      actionType: 0, // BuyAndBurn
+      allocationBps: 4000,
+      target: BURN_ADDRESS,
+      swapPath: [WETH, tokenAddress],
+    },
+    {
+      actionType: 1, // AddLiquidity
+      allocationBps: 3000,
+      target: UNISWAP_ROUTER,
+      burnLp: true,
+    },
+    {
+      actionType: 2, // DistributeToHolders
+      allocationBps: 2000,
+      target: holderVaultAddress,
+      topN: 100, // Top 100 holders
+    },
+    {
+      actionType: 3, // SendToAddress
+      allocationBps: 1000,
+      target: creatorAddress,
+    },
+  ],
+  automationInterval: 86400, // Daily
+});
+```
+
+## Automation Setup
+
+Uses Chainlink Automation for trustless execution:
+
+```typescript
+// Register upkeep
+await automationRegistry.registerUpkeep(
+  vaultAddress,
+  500000,          // Gas limit
+  adminAddress,
+  0,               // Conditional
+  "Daily Fee Distribution",
+  "0x",
+  parseEther("10"), // 10 LINK
+  0
+);
+```
+
+## Execution Flow
+
+```
+Chainlink Keeper checks → Fees available? → Execute all actions
+                       ↓
+               Action 1: Buy & Burn (40%)
+                       ↓
+               Action 2: Add LP (30%)
+                       ↓
+               Action 3: Distribute (20%)
+                       ↓
+               Action 4: Send (10%)
+```
+
+## Slippage Protection
+
+All swaps include configurable slippage protection:
+
+```typescript
+const swapConfig = {
+  maxSlippageBps: 100, // 1% max slippage
+  deadline: Math.floor(Date.now() / 1000) + 600, // 10 min
+};
+```
+
+## Monitoring
+
+```typescript
+// Check last execution
+const lastExecution = await vault.lastExecutionTime();
+
+// Check pending fees
+const pending = await vault.pendingFees();
+
+// Check action history
+const events = await vault.queryFilter(
+  vault.filters.ActionExecuted()
+);
+```
+
+## Common Patterns
+
+### Maximum Deflation
+```
+100% Buy & Burn
+```
+
+### Balanced Growth
+```
+50% Add LP (burn LP token)
+50% Buy & Burn
+```
+
+### Holder-First
+```
+60% Distribute to holders
+30% Buy & Burn
+10% Creator
+```
+
+### Trading Incentives
+```
+40% Top 50 traders by volume
+30% All holders pro-rata
+20% Buy & Burn
+10% Treasury
+```

--- a/composable-revenue/references/time-wrappers.md
+++ b/composable-revenue/references/time-wrappers.md
@@ -1,0 +1,111 @@
+# Time-Locked Fee Wrappers
+
+## Overview
+
+Create tradeable tokens representing temporary fee claiming rights. Holders can claim proportional fees during the lock period.
+
+## Lock Tiers
+
+| Tier | Duration | Use Case |
+|------|----------|----------|
+| `ONE_DAY` (5) | 24 hours | Daily fee auctions, short-term access |
+| `ONE_WEEK` (6) | 7 days | Weekly fee packages |
+| `ONE_MONTH` (0) | 30 days | Monthly subscriptions |
+
+## Contract
+
+**TimeWrapper Factory**: `0x083EDF9b6C894561Ce8a237e2fd570bECB920DfF`
+
+## Multiplier
+
+**1M:1** — Deposit 80 fee tokens → Receive 80,000,000 wrapper tokens
+
+This high multiplier enables granular trading of fee rights.
+
+## Flow
+
+```
+1. Deploy wrapper contract
+2. Approve fee tokens
+3. Deposit fee tokens (locked for duration)
+4. Receive wrapper tokens (tradeable)
+5. Wrapper holders claim fees proportionally
+6. After expiry: withdraw original fee tokens
+```
+
+## Functions
+
+```solidity
+// Create wrapper for a fee vault
+function createWrapper(
+    address vault,
+    address[] tokens,
+    string name,
+    string symbol
+) external returns (address wrapper)
+
+// Deposit and lock
+function deposit(
+    uint256 amount,
+    uint8 lockTier
+) external
+
+// Claim accumulated fees
+function claimRewards(address holder) external returns (uint256[] amounts)
+
+// Withdraw after lock expires
+function withdraw(uint256 amount) external
+```
+
+## Example
+
+```typescript
+// Create wrapper
+const wrapper = await wrapperFactory.createWrapper(
+  vaultAddress,
+  [WETH, tokenAddress],
+  "ClawdFans 1D",
+  "CLAWDFANS-1D"
+);
+
+// Approve and deposit
+await feeToken.approve(wrapper.address, amount);
+await wrapper.deposit(amount, 5); // LockTier.ONE_DAY
+
+// Now you have wrapper tokens
+const wrapperBalance = await wrapper.balanceOf(user);
+// = amount * 1,000,000
+```
+
+## Claiming Fees
+
+Wrapper holders claim fees proportionally:
+
+```typescript
+// Anyone holding wrapper tokens can claim
+const [wethReward, tokenReward] = await wrapper.claimRewards(holder);
+```
+
+## Trading Wrappers
+
+Wrapper tokens are standard ERC20s. You can:
+- Sell on Uniswap
+- Airdrop to community
+- Use as rewards
+- Create wrapper/ETH liquidity pool
+
+## Rotation
+
+After lock expires:
+1. Withdraw original fee tokens
+2. Create new wrapper with same or different duration
+3. Repeat
+
+This enables perpetual fee auction cycles.
+
+## Use Cases
+
+1. **Daily Fee Auctions**: Sell 1D wrappers to highest bidder
+2. **Community Rewards**: Airdrop wrappers to active members
+3. **Subscription Model**: Sell weekly/monthly fee access
+4. **Speculation**: Let market price fee rights


### PR DESCRIPTION
## ComposAIble Revenue Skill

Adds the `composable-revenue` skill for managing Clanker token trading fees on Base using PoolFans infrastructure.

### Capabilities

- **Deploy tokens with fee tokenization** - Launch Clanker tokens with instant fee shares
- **Tokenize existing fees** - Add fee tokenization to deployed tokens (V3.1.0+, V4)
- **Time-locked wrappers** - Create tradeable temporary fee rights (1D, 1W, 1M)
- **Conditional routing** - Route fees based on market cap, volume, holder count
- **Multi-strategy automation** - Chain burn + LP + rewards with Chainlink automation
- **Holder/trader rewards** - Distribute fees to holders or top traders

### Contracts

All contracts verified on Base mainnet:
- MultiActionVaultFactory: `0x069aEC7cE08CDc0F45135bAac0E5Fe3B579AB99b`
- TimeWrapperFactory: `0x083EDF9b6C894561Ce8a237e2fd570bECB920DfF`
- V4TokenizerFactory: `0xea8127533F7be6d04b3DBA8f0a496F2DCfd27728`

### Links

- UI: https://pool.fans
- Docs: https://pool.fans/docs

---

*Submitted by MoltRevenue Bot ⚡*