### PR TITLE
feat: add promptr auction skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ moltbot-skills/
 │   └── scripts/
 │       └── bankr.sh
 │
+├── promptr/
+│   ├── SKILL.md
+│   ├── references/
+│   │   └── contract-abi.md
+│   └── scripts/
+│       └── promptr.sh
+│
 ├── base/                         # Base (placeholder)
 │   └── SKILL.md
 ├── neynar/                       # Neynar (placeholder)
@@ -38,12 +45,13 @@ https://github.com/BankrBot/moltbot-skills
 
 ## Available Skills
 
-| Provider                   | Skill           | Description                                                                                               |
-| -------------------------- | --------------- | --------------------------------------------------------------------------------------------------------- |
-| [bankr](https://bankr.bot) | [bankr](bankr/) | AI-powered crypto trading agent via natural language. Trade, manage portfolios, automate DeFi operations. |
-| base                       | —               | Placeholder                                                                                               |
-| neynar                     | —               | Placeholder                                                                                               |
-| zapper                     | —               | Placeholder                                                                                               |
+| Provider                       | Skill               | Description                                                                                               |
+| ------------------------------ | ------------------- | --------------------------------------------------------------------------------------------------------- |
+| [bankr](https://bankr.bot)     | [bankr](bankr/)     | AI-powered crypto trading agent via natural language. Trade, manage portfolios, automate DeFi operations. |
+| [promptr](https://promptr.live) | [promptr](promptr/) | Participate in the Promptr auction on Base — submit prompts, vote, claim refunds, and earn keeper rewards. |
+| base                           | —                   | Placeholder                                                                                               |
+| neynar                         | —                   | Placeholder                                                                                               |
+| zapper                         | —                   | Placeholder                                                                                               |
 
 ## Contributing
 

--- a/promptr/SKILL.md
+++ b/promptr/SKILL.md
@@ -1,0 +1,275 @@
+---
+name: promptr
+description: Participate in the Promptr auction on Base. Use when the user wants to submit prompts to @promptrbot, vote on existing prompts, check auction status, claim refunds, or finalize rounds for keeper rewards. Promptr is a community-controlled AI agent where users bid USDC to have their prompts executed.
+metadata: {"clawdbot":{"emoji":"🎯","homepage":"https://promptr.live","requires":{"bins":["cast","jq"]}}}
+---
+
+# Promptr Auction
+
+Submit prompts and vote in the Promptr auction — the first community-controlled AI agent on Base.
+
+## Quick Start
+
+### Prerequisites
+
+1. **Foundry** — Install via [getfoundry.sh](https://getfoundry.sh):
+   ```bash
+   curl -L https://foundry.paradigm.xyz | bash
+   foundryup
+   ```
+
+2. **Base RPC** — Public RPC works, but consider [Alchemy](https://alchemy.com) or [Infura](https://infura.io) for reliability.
+
+3. **Wallet with USDC** — You need USDC on Base to participate.
+
+### Setup
+
+Create config with your wallet and RPC:
+
+```bash
+mkdir -p ~/.clawdbot/skills/promptr
+cat > ~/.clawdbot/skills/promptr/config.json << 'EOF'
+{
+  "rpcUrl": "https://mainnet.base.org",
+  "privateKey": "YOUR_PRIVATE_KEY_HERE"
+}
+EOF
+chmod 600 ~/.clawdbot/skills/promptr/config.json
+```
+
+**⚠️ Security**: Never share your private key. Consider using a dedicated wallet with limited funds.
+
+### Verify Setup
+
+```bash
+# Check current round info
+scripts/promptr.sh status
+
+# Check your USDC balance
+scripts/promptr.sh balance
+```
+
+## How It Works
+
+1. **Submit or Vote** — Users submit prompts with USDC bids, or vote on existing prompts
+2. **Auction Ends** — When time runs out, the highest-voted prompt wins
+3. **Execution** — @promptrbot executes the winning prompt and tweets the result
+4. **Settlement** — Winners' USDC goes to promptr, losers can claim refunds
+5. **Keeper Reward** — Anyone who calls `finalizeRound()` gets 0.5% of the pot
+
+## Usage
+
+### Check Status
+
+```bash
+# Current round info
+scripts/promptr.sh status
+
+# Time remaining in current round
+scripts/promptr.sh time
+
+# List prompts in current round
+scripts/promptr.sh prompts
+
+# List prompts in specific round
+scripts/promptr.sh prompts 42
+```
+
+### Submit a Prompt
+
+```bash
+# Submit prompt with USDC bid
+scripts/promptr.sh submit "gm from moltbot" 5
+
+# Submit with minimum amount
+scripts/promptr.sh submit "tell me a joke" 1
+```
+
+The USDC amount is your initial vote weight. Higher bids = more competitive.
+
+### Vote on Existing Prompt
+
+```bash
+# Add votes to a prompt (requires promptId)
+scripts/promptr.sh vote 0x1234...abcd 10
+
+# Get prompt IDs from the prompts list
+scripts/promptr.sh prompts
+```
+
+### Claim Refunds
+
+```bash
+# Check unclaimed refunds for a round
+scripts/promptr.sh refunds 42
+
+# Claim refund for a specific prompt
+scripts/promptr.sh claim 42 0x1234...abcd
+
+# Batch claim multiple refunds
+scripts/promptr.sh claim-batch 42 0x1234...abcd,0x5678...efgh
+```
+
+### Finalize Round (Keeper)
+
+```bash
+# Finalize ended round and collect 0.5% reward
+scripts/promptr.sh finalize
+```
+
+Anyone can call this. If you're first, you get the keeper fee.
+
+### Emergency Withdrawal
+
+If a round isn't finalized within 24 hours:
+
+```bash
+# Check if emergency withdrawal is available
+scripts/promptr.sh can-emergency 42
+
+# Emergency withdraw (after 24h grace period)
+scripts/promptr.sh emergency 42 0x1234...abcd
+```
+
+## Contract Details
+
+| Item | Value |
+|------|-------|
+| **Proxy** | `0x40E164E2B005C9bfd56a44634047c3bc2629371d` |
+| **Implementation** | `0x67745fE3157Ca72B06418d526D85f62C8039e888` |
+| **Chain** | Base Mainnet (8453) |
+| **USDC** | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+| **Keeper Fee** | 0.5% of pot |
+
+## Common Patterns
+
+### Monitor and Snipe
+
+```bash
+# Watch time remaining
+scripts/promptr.sh time
+
+# Check current leading prompt
+scripts/promptr.sh prompts | head -20
+
+# Last-minute vote to win
+scripts/promptr.sh vote 0xleading... 50
+```
+
+### Keeper Strategy
+
+```bash
+# Check if round ended but not finalized
+scripts/promptr.sh status
+
+# If ended, finalize for reward
+scripts/promptr.sh finalize
+```
+
+### Recovery Flow
+
+```bash
+# After losing, check refunds
+scripts/promptr.sh refunds 42
+
+# Claim everything back
+scripts/promptr.sh claim-batch 42 0xprompt1,0xprompt2
+```
+
+## View Functions Reference
+
+| Function | Description |
+|----------|-------------|
+| `currentRound()` | Current round number |
+| `timeRemaining()` | Seconds until round ends |
+| `minPromptAmount()` | Minimum USDC to submit/vote |
+| `getRoundPrompts(round)` | All prompts in a round |
+| `getPrompt(promptId)` | Details of specific prompt |
+| `getVotes(promptId, voter)` | User's votes on a prompt |
+| `getRoundResult(round)` | Winner and pot for completed round |
+| `getUserPrompts(round, user)` | Prompts user voted on |
+| `getUnclaimedRefundsForRound(user, round)` | Check unclaimed refunds |
+| `canEmergencyWithdraw(round)` | Check if emergency available |
+
+## Write Functions Reference
+
+| Function | Description |
+|----------|-------------|
+| `submitPrompt(text, amount)` | Submit new prompt with USDC |
+| `vote(promptId, amount)` | Add USDC votes to prompt |
+| `finalizeRound()` | Finalize ended round (0.5% reward) |
+| `claimRefund(round, promptId)` | Claim refund for losing prompt |
+| `batchClaimRefunds(round, promptIds[])` | Batch claim refunds |
+| `emergencyWithdraw(round, promptId)` | Withdraw after 24h grace |
+| `batchEmergencyWithdraw(round, promptIds[])` | Batch emergency withdraw |
+
+## Error Handling
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| Insufficient allowance | USDC not approved | Run `scripts/promptr.sh approve <amount>` |
+| Round not ended | Trying to finalize active round | Wait for `timeRemaining()` to reach 0 |
+| Already claimed | Refund already claimed | Check transaction history |
+| Not a loser | Trying to claim winning prompt | Winners don't get refunds |
+| Grace period active | Emergency withdraw too early | Wait 24h after round ends |
+
+## Best Practices
+
+### Security
+- Use a dedicated wallet with limited funds
+- Never share private keys
+- Start with small test amounts
+- Verify contract addresses before interacting
+
+### Strategy
+- Monitor rounds to find good entry points
+- Larger bids early attract more attention
+- Last-minute votes can flip outcomes
+- Being a keeper is profitable for attentive bots
+
+### Gas
+- Base has very low gas costs (~$0.01 per tx)
+- Batch operations save gas on multiple claims
+- Approve large USDC amounts to avoid repeat approvals
+
+## Resources
+
+- **Live Auction**: https://promptr.live
+- **Twitter**: https://twitter.com/promptrbot
+- **Contract**: [BaseScan](https://basescan.org/address/0x40E164E2B005C9bfd56a44634047c3bc2629371d)
+
+## Troubleshooting
+
+### Scripts Not Working
+
+```bash
+# Check Foundry installation
+cast --version
+
+# Test RPC connection
+cast block-number --rpc-url https://mainnet.base.org
+
+# Verify config
+cat ~/.clawdbot/skills/promptr/config.json | jq .
+```
+
+### Transaction Failures
+
+1. Check USDC balance: `scripts/promptr.sh balance`
+2. Check USDC allowance: `scripts/promptr.sh allowance`
+3. Approve if needed: `scripts/promptr.sh approve 1000`
+4. Verify round is active: `scripts/promptr.sh status`
+
+### RPC Issues
+
+If public RPC is slow/unreliable:
+- Use Alchemy: `https://base-mainnet.g.alchemy.com/v2/YOUR_KEY`
+- Use Infura: `https://base-mainnet.infura.io/v3/YOUR_KEY`
+
+---
+
+**💡 Tip**: Start by checking `status` and `prompts` to understand the current state before submitting.
+
+**⚠️ Risk**: Only bid what you're willing to lose. Winning prompts are executed by @promptrbot — you're paying for AI execution, not guaranteed outcomes.
+
+**🤖 For Agents**: This skill lets your agent participate in community-controlled AI. Submit interesting prompts, vote strategically, or run keeper bots for passive income.

--- a/promptr/references/contract-abi.md
+++ b/promptr/references/contract-abi.md
@@ -1,0 +1,165 @@
+# Promptr Contract ABI Reference
+
+## Contract Addresses
+
+| Contract | Address |
+|----------|---------|
+| Proxy | `0x40E164E2B005C9bfd56a44634047c3bc2629371d` |
+| Implementation | `0x67745fE3157Ca72B06418d526D85f62C8039e888` |
+| USDC | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+
+## User-Callable Functions
+
+### Core Actions
+
+#### submitPrompt
+Submit a new prompt with USDC bid.
+
+```solidity
+function submitPrompt(string calldata text, uint256 amount) external returns (bytes32 promptId)
+```
+
+- `text`: The prompt text to submit
+- `amount`: USDC amount (6 decimals) as initial votes
+- Returns: `promptId` (bytes32 hash)
+- Requires: USDC approval for `amount`
+
+#### vote
+Add votes to an existing prompt.
+
+```solidity
+function vote(bytes32 promptId, uint256 amount) external
+```
+
+- `promptId`: Hash of the prompt to vote on
+- `amount`: USDC amount to add as votes
+- Requires: USDC approval for `amount`
+
+#### finalizeRound
+Finalize an ended round. Caller receives 0.5% keeper reward.
+
+```solidity
+function finalizeRound() external
+```
+
+- Can only be called when `timeRemaining() == 0`
+- Caller gets 0.5% of total pot as reward
+
+### Refund Functions
+
+#### claimRefund
+Claim refund for a losing prompt.
+
+```solidity
+function claimRefund(uint256 round, bytes32 promptId) external
+```
+
+- `round`: Round number
+- `promptId`: Hash of losing prompt
+- Only works for non-winning prompts after round finalized
+
+#### batchClaimRefunds
+Batch claim multiple refunds.
+
+```solidity
+function batchClaimRefunds(uint256 round, bytes32[] calldata promptIds) external
+```
+
+- `round`: Round number
+- `promptIds`: Array of prompt hashes to claim
+
+### Emergency Functions
+
+Available 24 hours after round end if not finalized.
+
+#### emergencyWithdraw
+```solidity
+function emergencyWithdraw(uint256 round, bytes32 promptId) external
+```
+
+#### batchEmergencyWithdraw
+```solidity
+function batchEmergencyWithdraw(uint256 round, bytes32[] calldata promptIds) external
+```
+
+## View Functions
+
+### Round Info
+
+```solidity
+function currentRound() external view returns (uint256)
+function timeRemaining() external view returns (uint256)
+function minPromptAmount() external view returns (uint256)
+```
+
+### Prompt Data
+
+```solidity
+function getRoundPrompts(uint256 round) external view returns (bytes32[] memory)
+function getPrompt(bytes32 promptId) external view returns (
+    address submitter,
+    string memory text,
+    uint256 totalVotes,
+    uint256 timestamp,
+    bool claimed
+)
+function getVotes(bytes32 promptId, address voter) external view returns (uint256)
+```
+
+### User Data
+
+```solidity
+function getUserPrompts(uint256 round, address user) external view returns (bytes32[] memory)
+function getUnclaimedRefundsForRound(address user, uint256 round) external view returns (
+    bytes32[] memory promptIds,
+    uint256[] memory amounts
+)
+```
+
+### Results
+
+```solidity
+function getRoundResult(uint256 round) external view returns (
+    bytes32 winningPromptId,
+    uint256 totalPot
+)
+function canEmergencyWithdraw(uint256 round) external view returns (bool)
+```
+
+## Events
+
+```solidity
+event PromptSubmitted(uint256 indexed round, bytes32 indexed promptId, address indexed submitter, string text, uint256 amount)
+event Voted(uint256 indexed round, bytes32 indexed promptId, address indexed voter, uint256 amount)
+event RoundFinalized(uint256 indexed round, bytes32 indexed winningPromptId, uint256 totalPot, address keeper, uint256 keeperReward)
+event RefundClaimed(uint256 indexed round, bytes32 indexed promptId, address indexed claimer, uint256 amount)
+event EmergencyWithdraw(uint256 indexed round, bytes32 indexed promptId, address indexed claimer, uint256 amount)
+```
+
+## USDC Approval
+
+Before submitting or voting, approve USDC spending:
+
+```solidity
+// USDC contract
+function approve(address spender, uint256 amount) external returns (bool)
+```
+
+Example with cast:
+```bash
+cast send 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 \
+  "approve(address,uint256)" \
+  0x40E164E2B005C9bfd56a44634047c3bc2629371d \
+  1000000000 \
+  --private-key $KEY \
+  --rpc-url https://mainnet.base.org
+```
+
+## PromptId Calculation
+
+The `promptId` is calculated as:
+```solidity
+keccak256(abi.encodePacked(round, submitter, text, block.timestamp))
+```
+
+This ensures unique IDs even for identical text in the same round.

--- a/promptr/scripts/promptr.sh
+++ b/promptr/scripts/promptr.sh
@@ -1,0 +1,470 @@
+#!/bin/bash
+# Promptr Auction CLI - interact with the community-controlled AI agent auction
+# Usage: promptr.sh <command> [args]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SKILL_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Contract addresses (Base Mainnet)
+AUCTION_CONTRACT="0x40E164E2B005C9bfd56a44634047c3bc2629371d"
+USDC_CONTRACT="0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+USDC_DECIMALS=6
+
+# Find config file
+if [ -f "$SKILL_DIR/config.json" ]; then
+    CONFIG_FILE="$SKILL_DIR/config.json"
+elif [ -f "$HOME/.clawdbot/skills/promptr/config.json" ]; then
+    CONFIG_FILE="$HOME/.clawdbot/skills/promptr/config.json"
+else
+    echo '{"error": "config.json not found. Create it with your RPC URL and private key."}' >&2
+    exit 1
+fi
+
+# Extract config
+RPC_URL=$(jq -r '.rpcUrl // "https://mainnet.base.org"' "$CONFIG_FILE")
+PRIVATE_KEY=$(jq -r '.privateKey // empty' "$CONFIG_FILE")
+
+# Get wallet address from private key (if available)
+get_wallet_address() {
+    if [ -n "$PRIVATE_KEY" ]; then
+        cast wallet address "$PRIVATE_KEY" 2>/dev/null || echo ""
+    fi
+}
+
+WALLET_ADDRESS=$(get_wallet_address)
+
+# Helper: convert USDC amount to raw (6 decimals)
+to_usdc_raw() {
+    local amount=$1
+    # Multiply by 10^6 using bc for decimal handling
+    echo "scale=0; $amount * 1000000 / 1" | bc
+}
+
+# Helper: convert raw USDC to human readable
+from_usdc_raw() {
+    local raw=$1
+    echo "scale=6; $raw / 1000000" | bc
+}
+
+# Commands
+cmd_status() {
+    local round time_left min_amount
+    round=$(cast call "$AUCTION_CONTRACT" "currentRound()(uint256)" --rpc-url "$RPC_URL")
+    time_left=$(cast call "$AUCTION_CONTRACT" "timeRemaining()(uint256)" --rpc-url "$RPC_URL")
+    min_amount=$(cast call "$AUCTION_CONTRACT" "minPromptAmount()(uint256)" --rpc-url "$RPC_URL")
+    
+    echo "{"
+    echo "  \"currentRound\": $round,"
+    echo "  \"timeRemaining\": $time_left,"
+    echo "  \"timeRemainingFormatted\": \"$(printf '%02d:%02d:%02d' $((time_left/3600)) $((time_left%3600/60)) $((time_left%60)))\"," 
+    echo "  \"minPromptAmount\": $(from_usdc_raw "$min_amount"),"
+    echo "  \"contract\": \"$AUCTION_CONTRACT\""
+    echo "}"
+}
+
+cmd_time() {
+    local time_left
+    time_left=$(cast call "$AUCTION_CONTRACT" "timeRemaining()(uint256)" --rpc-url "$RPC_URL")
+    printf '%02d:%02d:%02d\n' $((time_left/3600)) $((time_left%3600/60)) $((time_left%60))
+}
+
+cmd_balance() {
+    if [ -z "$WALLET_ADDRESS" ]; then
+        echo '{"error": "privateKey not configured"}' >&2
+        exit 1
+    fi
+    
+    local usdc_balance eth_balance
+    usdc_balance=$(cast call "$USDC_CONTRACT" "balanceOf(address)(uint256)" "$WALLET_ADDRESS" --rpc-url "$RPC_URL")
+    eth_balance=$(cast balance "$WALLET_ADDRESS" --rpc-url "$RPC_URL")
+    
+    echo "{"
+    echo "  \"address\": \"$WALLET_ADDRESS\","
+    echo "  \"usdc\": $(from_usdc_raw "$usdc_balance"),"
+    echo "  \"eth\": \"$eth_balance\""
+    echo "}"
+}
+
+cmd_allowance() {
+    if [ -z "$WALLET_ADDRESS" ]; then
+        echo '{"error": "privateKey not configured"}' >&2
+        exit 1
+    fi
+    
+    local allowance
+    allowance=$(cast call "$USDC_CONTRACT" "allowance(address,address)(uint256)" "$WALLET_ADDRESS" "$AUCTION_CONTRACT" --rpc-url "$RPC_URL")
+    
+    echo "{"
+    echo "  \"allowance\": $(from_usdc_raw "$allowance"),"
+    echo "  \"allowanceRaw\": \"$allowance\""
+    echo "}"
+}
+
+cmd_approve() {
+    if [ -z "$PRIVATE_KEY" ]; then
+        echo '{"error": "privateKey not configured"}' >&2
+        exit 1
+    fi
+    
+    local amount=${1:-1000000}  # Default to 1M USDC
+    local raw_amount=$(to_usdc_raw "$amount")
+    
+    echo "Approving $amount USDC for auction contract..." >&2
+    
+    local tx_hash
+    tx_hash=$(cast send "$USDC_CONTRACT" "approve(address,uint256)" \
+        "$AUCTION_CONTRACT" "$raw_amount" \
+        --private-key "$PRIVATE_KEY" \
+        --rpc-url "$RPC_URL" \
+        --json | jq -r '.transactionHash')
+    
+    echo "{"
+    echo "  \"success\": true,"
+    echo "  \"amount\": $amount,"
+    echo "  \"txHash\": \"$tx_hash\""
+    echo "}"
+}
+
+cmd_prompts() {
+    local round=${1:-$(cast call "$AUCTION_CONTRACT" "currentRound()(uint256)" --rpc-url "$RPC_URL")}
+    
+    # Get prompt IDs for the round
+    local prompts_data
+    prompts_data=$(cast call "$AUCTION_CONTRACT" "getRoundPrompts(uint256)(bytes32[])" "$round" --rpc-url "$RPC_URL")
+    
+    # Parse the array - cast returns it as [0x..., 0x..., ...]
+    # Remove brackets and split
+    local prompt_ids
+    prompt_ids=$(echo "$prompts_data" | tr -d '[]' | tr ',' '\n' | sed 's/^ *//')
+    
+    echo "{"
+    echo "  \"round\": $round,"
+    echo "  \"prompts\": ["
+    
+    local first=true
+    while IFS= read -r prompt_id; do
+        [ -z "$prompt_id" ] && continue
+        
+        # Get prompt details
+        local prompt_data
+        prompt_data=$(cast call "$AUCTION_CONTRACT" "getPrompt(bytes32)((address,string,uint256,uint256,bool))" "$prompt_id" --rpc-url "$RPC_URL" 2>/dev/null || echo "")
+        
+        if [ -n "$prompt_data" ]; then
+            # Parse tuple: (submitter, text, totalVotes, timestamp, claimed)
+            local submitter text total_votes
+            submitter=$(echo "$prompt_data" | grep -oP '0x[a-fA-F0-9]{40}' | head -1 || echo "unknown")
+            total_votes=$(echo "$prompt_data" | grep -oP '\d+' | head -1 || echo "0")
+            
+            [ "$first" = false ] && echo ","
+            first=false
+            
+            echo "    {"
+            echo "      \"promptId\": \"$prompt_id\","
+            echo "      \"submitter\": \"$submitter\","
+            echo "      \"totalVotes\": $(from_usdc_raw "$total_votes")"
+            echo -n "    }"
+        fi
+    done <<< "$prompt_ids"
+    
+    echo ""
+    echo "  ]"
+    echo "}"
+}
+
+cmd_submit() {
+    if [ -z "$PRIVATE_KEY" ]; then
+        echo '{"error": "privateKey not configured"}' >&2
+        exit 1
+    fi
+    
+    local text=$1
+    local amount=$2
+    
+    if [ -z "$text" ] || [ -z "$amount" ]; then
+        echo '{"error": "Usage: promptr.sh submit <text> <usdc_amount>"}' >&2
+        exit 1
+    fi
+    
+    local raw_amount=$(to_usdc_raw "$amount")
+    
+    echo "Submitting prompt with $amount USDC..." >&2
+    
+    local tx_hash
+    tx_hash=$(cast send "$AUCTION_CONTRACT" "submitPrompt(string,uint256)" \
+        "$text" "$raw_amount" \
+        --private-key "$PRIVATE_KEY" \
+        --rpc-url "$RPC_URL" \
+        --json | jq -r '.transactionHash')
+    
+    echo "{"
+    echo "  \"success\": true,"
+    echo "  \"text\": \"$text\","
+    echo "  \"amount\": $amount,"
+    echo "  \"txHash\": \"$tx_hash\""
+    echo "}"
+}
+
+cmd_vote() {
+    if [ -z "$PRIVATE_KEY" ]; then
+        echo '{"error": "privateKey not configured"}' >&2
+        exit 1
+    fi
+    
+    local prompt_id=$1
+    local amount=$2
+    
+    if [ -z "$prompt_id" ] || [ -z "$amount" ]; then
+        echo '{"error": "Usage: promptr.sh vote <promptId> <usdc_amount>"}' >&2
+        exit 1
+    fi
+    
+    local raw_amount=$(to_usdc_raw "$amount")
+    
+    echo "Voting $amount USDC on prompt $prompt_id..." >&2
+    
+    local tx_hash
+    tx_hash=$(cast send "$AUCTION_CONTRACT" "vote(bytes32,uint256)" \
+        "$prompt_id" "$raw_amount" \
+        --private-key "$PRIVATE_KEY" \
+        --rpc-url "$RPC_URL" \
+        --json | jq -r '.transactionHash')
+    
+    echo "{"
+    echo "  \"success\": true,"
+    echo "  \"promptId\": \"$prompt_id\","
+    echo "  \"amount\": $amount,"
+    echo "  \"txHash\": \"$tx_hash\""
+    echo "}"
+}
+
+cmd_finalize() {
+    if [ -z "$PRIVATE_KEY" ]; then
+        echo '{"error": "privateKey not configured"}' >&2
+        exit 1
+    fi
+    
+    echo "Finalizing round (0.5% keeper reward)..." >&2
+    
+    local tx_hash
+    tx_hash=$(cast send "$AUCTION_CONTRACT" "finalizeRound()" \
+        --private-key "$PRIVATE_KEY" \
+        --rpc-url "$RPC_URL" \
+        --json | jq -r '.transactionHash')
+    
+    echo "{"
+    echo "  \"success\": true,"
+    echo "  \"txHash\": \"$tx_hash\""
+    echo "}"
+}
+
+cmd_refunds() {
+    if [ -z "$WALLET_ADDRESS" ]; then
+        echo '{"error": "privateKey not configured"}' >&2
+        exit 1
+    fi
+    
+    local round=$1
+    
+    if [ -z "$round" ]; then
+        echo '{"error": "Usage: promptr.sh refunds <round>"}' >&2
+        exit 1
+    fi
+    
+    local refunds
+    refunds=$(cast call "$AUCTION_CONTRACT" "getUnclaimedRefundsForRound(address,uint256)((bytes32[],uint256[]))" "$WALLET_ADDRESS" "$round" --rpc-url "$RPC_URL")
+    
+    echo "{"
+    echo "  \"round\": $round,"
+    echo "  \"address\": \"$WALLET_ADDRESS\","
+    echo "  \"refunds\": \"$refunds\""
+    echo "}"
+}
+
+cmd_claim() {
+    if [ -z "$PRIVATE_KEY" ]; then
+        echo '{"error": "privateKey not configured"}' >&2
+        exit 1
+    fi
+    
+    local round=$1
+    local prompt_id=$2
+    
+    if [ -z "$round" ] || [ -z "$prompt_id" ]; then
+        echo '{"error": "Usage: promptr.sh claim <round> <promptId>"}' >&2
+        exit 1
+    fi
+    
+    echo "Claiming refund for prompt $prompt_id in round $round..." >&2
+    
+    local tx_hash
+    tx_hash=$(cast send "$AUCTION_CONTRACT" "claimRefund(uint256,bytes32)" \
+        "$round" "$prompt_id" \
+        --private-key "$PRIVATE_KEY" \
+        --rpc-url "$RPC_URL" \
+        --json | jq -r '.transactionHash')
+    
+    echo "{"
+    echo "  \"success\": true,"
+    echo "  \"round\": $round,"
+    echo "  \"promptId\": \"$prompt_id\","
+    echo "  \"txHash\": \"$tx_hash\""
+    echo "}"
+}
+
+cmd_claim_batch() {
+    if [ -z "$PRIVATE_KEY" ]; then
+        echo '{"error": "privateKey not configured"}' >&2
+        exit 1
+    fi
+    
+    local round=$1
+    local prompt_ids=$2  # comma-separated
+    
+    if [ -z "$round" ] || [ -z "$prompt_ids" ]; then
+        echo '{"error": "Usage: promptr.sh claim-batch <round> <promptId1,promptId2,...>"}' >&2
+        exit 1
+    fi
+    
+    # Convert comma-separated to array format
+    local ids_array="[$(echo "$prompt_ids" | sed 's/,/","/g' | sed 's/^/"/;s/$/"/')]"
+    
+    echo "Batch claiming refunds in round $round..." >&2
+    
+    local tx_hash
+    tx_hash=$(cast send "$AUCTION_CONTRACT" "batchClaimRefunds(uint256,bytes32[])" \
+        "$round" "$ids_array" \
+        --private-key "$PRIVATE_KEY" \
+        --rpc-url "$RPC_URL" \
+        --json | jq -r '.transactionHash')
+    
+    echo "{"
+    echo "  \"success\": true,"
+    echo "  \"round\": $round,"
+    echo "  \"txHash\": \"$tx_hash\""
+    echo "}"
+}
+
+cmd_can_emergency() {
+    local round=$1
+    
+    if [ -z "$round" ]; then
+        echo '{"error": "Usage: promptr.sh can-emergency <round>"}' >&2
+        exit 1
+    fi
+    
+    local can_withdraw
+    can_withdraw=$(cast call "$AUCTION_CONTRACT" "canEmergencyWithdraw(uint256)(bool)" "$round" --rpc-url "$RPC_URL")
+    
+    echo "{"
+    echo "  \"round\": $round,"
+    echo "  \"canEmergencyWithdraw\": $can_withdraw"
+    echo "}"
+}
+
+cmd_emergency() {
+    if [ -z "$PRIVATE_KEY" ]; then
+        echo '{"error": "privateKey not configured"}' >&2
+        exit 1
+    fi
+    
+    local round=$1
+    local prompt_id=$2
+    
+    if [ -z "$round" ] || [ -z "$prompt_id" ]; then
+        echo '{"error": "Usage: promptr.sh emergency <round> <promptId>"}' >&2
+        exit 1
+    fi
+    
+    echo "Emergency withdrawing from round $round..." >&2
+    
+    local tx_hash
+    tx_hash=$(cast send "$AUCTION_CONTRACT" "emergencyWithdraw(uint256,bytes32)" \
+        "$round" "$prompt_id" \
+        --private-key "$PRIVATE_KEY" \
+        --rpc-url "$RPC_URL" \
+        --json | jq -r '.transactionHash')
+    
+    echo "{"
+    echo "  \"success\": true,"
+    echo "  \"round\": $round,"
+    echo "  \"promptId\": \"$prompt_id\","
+    echo "  \"txHash\": \"$tx_hash\""
+    echo "}"
+}
+
+cmd_result() {
+    local round=$1
+    
+    if [ -z "$round" ]; then
+        echo '{"error": "Usage: promptr.sh result <round>"}' >&2
+        exit 1
+    fi
+    
+    local result
+    result=$(cast call "$AUCTION_CONTRACT" "getRoundResult(uint256)((bytes32,uint256))" "$round" --rpc-url "$RPC_URL")
+    
+    echo "{"
+    echo "  \"round\": $round,"
+    echo "  \"result\": \"$result\""
+    echo "}"
+}
+
+cmd_help() {
+    cat << 'EOF'
+Promptr Auction CLI
+
+Usage: promptr.sh <command> [args]
+
+Read Commands:
+  status              Show current round info
+  time                Show time remaining (HH:MM:SS)
+  balance             Show your USDC and ETH balance
+  allowance           Show USDC allowance for auction contract
+  prompts [round]     List prompts in round (default: current)
+  refunds <round>     Check unclaimed refunds for a round
+  result <round>      Get round result (winner, pot)
+  can-emergency <r>   Check if emergency withdrawal available
+
+Write Commands:
+  approve [amount]    Approve USDC spending (default: 1M)
+  submit <text> <amt> Submit a new prompt with USDC bid
+  vote <id> <amount>  Add USDC votes to existing prompt
+  finalize            Finalize ended round (0.5% reward)
+  claim <r> <id>      Claim refund for losing prompt
+  claim-batch <r> <ids> Batch claim (comma-separated ids)
+  emergency <r> <id>  Emergency withdraw (after 24h)
+
+Examples:
+  promptr.sh status
+  promptr.sh submit "gm world" 5
+  promptr.sh vote 0x1234...abcd 10
+  promptr.sh finalize
+EOF
+}
+
+# Main dispatch
+case "${1:-help}" in
+    status)      cmd_status ;;
+    time)        cmd_time ;;
+    balance)     cmd_balance ;;
+    allowance)   cmd_allowance ;;
+    approve)     cmd_approve "${2:-}" ;;
+    prompts)     cmd_prompts "${2:-}" ;;
+    submit)      cmd_submit "${2:-}" "${3:-}" ;;
+    vote)        cmd_vote "${2:-}" "${3:-}" ;;
+    finalize)    cmd_finalize ;;
+    refunds)     cmd_refunds "${2:-}" ;;
+    claim)       cmd_claim "${2:-}" "${3:-}" ;;
+    claim-batch) cmd_claim_batch "${2:-}" "${3:-}" ;;
+    can-emergency) cmd_can_emergency "${2:-}" ;;
+    emergency)   cmd_emergency "${2:-}" "${3:-}" ;;
+    result)      cmd_result "${2:-}" ;;
+    help|--help|-h) cmd_help ;;
+    *)
+        echo "Unknown command: $1" >&2
+        echo "Run 'promptr.sh help' for usage" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

Adds a skill for participating in the **Promptr auction** on Base — a community-controlled AI agent where users bid USDC to have their prompts executed by @promptrbot.

## What's Included

- `promptr/SKILL.md` — Full skill documentation with setup, usage, and examples
- `promptr/scripts/promptr.sh` — CLI wrapper using Foundry's `cast` for contract interactions
- `promptr/references/contract-abi.md` — Contract ABI reference

## Features

| Command | Description |
|---------|-------------|
| `status` | Check current round, time remaining, min bid |
| `submit <text> <amount>` | Submit a new prompt with USDC bid |
| `vote <id> <amount>` | Add votes to existing prompt |
| `prompts [round]` | List prompts in a round |
| `finalize` | Finalize ended round (0.5% keeper reward) |
| `claim <round> <id>` | Claim refund for losing prompt |
| `emergency <round> <id>` | Emergency withdraw after 24h |

## Contract

- **Proxy:** `0x40E164E2B005C9bfd56a44634047c3bc2629371d` (Base Mainnet)
- **Implementation:** `0x67745fE3157Ca72B06418d526D85f62C8039e888`
- **USDC:** `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
- **Keeper Fee:** 0.5% of pot for finalizing rounds

## Links

- 🌐 [promptr.live](https://promptr.live)
- 🐦 [@promptrbot](https://twitter.com/promptrbot)
- 📜 [BaseScan](https://basescan.org/address/0x40E164E2B005C9bfd56a44634047c3bc2629371d)

---

*This allows other Moltbot agents to participate in the community-controlled AI experiment.*