### PR TITLE
Add ens-primary-name skill

### DIFF
--- a/ens-primary-name/scripts/set-avatar.sh
+++ b/ens-primary-name/scripts/set-avatar.sh
@@ -15,6 +15,8 @@ ENS_NAME="${1:?Usage: set-avatar.sh <ens-name> <avatar-url>}"
 AVATAR_URL="${2:?Usage: set-avatar.sh <ens-name> <avatar-url>}"
 
 # Find bankr.sh in common locations
+# Bankr provides wallet/signing via the Bankr API
+# If you don't have bankr, modify this function to use your own signer
 find_bankr() {
   local locations=(
     "$SCRIPT_DIR/../../bankr/scripts/bankr.sh"
@@ -27,14 +29,20 @@ find_bankr() {
       return 0
     fi
   done
-  echo "ERROR: bankr.sh not found. Install the bankr skill first." >&2
+  echo "ERROR: bankr.sh not found." >&2
+  echo "" >&2
+  echo "This skill requires a transaction signer. Options:" >&2
+  echo "1. Install the bankr skill from https://github.com/BankrBot/openclaw-skills" >&2
+  echo "2. Modify find_bankr() in this script to use your own wallet/signer" >&2
+  echo "" >&2
+  echo "The script needs to submit: {to, data, value, chainId} transactions" >&2
   exit 1
 }
 
 BANKR_SH=$(find_bankr)
 
 # Avatars are text records stored on L1
-RPC_URL="https://1.rpc.thirdweb.com"
+RPC_URL="https://eth.publicnode.com"
 CHAIN_ID=1
 EXPLORER="etherscan.io"
 

--- a/ens-primary-name/scripts/set-primary.sh
+++ b/ens-primary-name/scripts/set-primary.sh
@@ -10,6 +10,8 @@ ENS_NAME="${1:?Usage: set-primary.sh <ens-name> [chain]}"
 CHAIN="${2:-base}"
 
 # Find bankr.sh in common locations
+# Bankr provides wallet/signing via the Bankr API
+# If you don't have bankr, modify this function to use your own signer
 find_bankr() {
   local locations=(
     "$SCRIPT_DIR/../../bankr/scripts/bankr.sh"
@@ -22,7 +24,13 @@ find_bankr() {
       return 0
     fi
   done
-  echo "ERROR: bankr.sh not found. Install the bankr skill first." >&2
+  echo "ERROR: bankr.sh not found." >&2
+  echo "" >&2
+  echo "This skill requires a transaction signer. Options:" >&2
+  echo "1. Install the bankr skill from https://github.com/BankrBot/openclaw-skills" >&2
+  echo "2. Modify find_bankr() in this script to use your own wallet/signer" >&2
+  echo "" >&2
+  echo "The script needs to submit: {to, data, value, chainId} transactions" >&2
   exit 1
 }
 

--- a/ens-primary-name/scripts/verify-primary.sh
+++ b/ens-primary-name/scripts/verify-primary.sh
@@ -32,7 +32,7 @@ case "$CHAIN" in
     IS_L2=true
     ;;
   ethereum|mainnet)
-    RPC_URL="https://1.rpc.thirdweb.com"
+    RPC_URL="https://eth.publicnode.com"
     CHAIN_ID=1
     REVERSE_REGISTRAR="0x283F227c4Bd38ecE252C4Ae7ECE650B0e913f1f9"
     IS_L2=false


### PR DESCRIPTION
## ENS Primary Name Skill

Set primary ENS names on Base, Arbitrum, Optimism, and Ethereum mainnet.

### Scripts

- **set-primary.sh** - Set reverse record (primary name) for your address
- **verify-primary.sh** - Verify primary name is correctly configured  
- **set-avatar.sh** - Set avatar text record

### Usage

```bash
# Set primary name on Base
./scripts/set-primary.sh myname.eth

# Set on Ethereum mainnet
./scripts/set-primary.sh myname.eth ethereum

# Verify it worked
./scripts/verify-primary.sh 0x1234... base

# Set avatar (requires L1 ETH)
./scripts/set-avatar.sh myname.eth https://example.com/avatar.png
```

---

## Changes from Original

### New Features
- ✅ **verify-primary.sh** - New script to verify reverse/forward resolution
- ✅ **Ethereum mainnet support** - L1 verification uses viem `getEnsName()`
- ✅ **Auto-verification** - set-primary.sh now verifies after setting

### Bug Fixes
- 🐛 **set-avatar.sh** - Now looks up resolver dynamically instead of hardcoding public resolver (fixes names with custom resolvers like subdomains)
- 🐛 **L1 verification** - Fixed to work with mainnet's different reverse resolution pattern

### Portability Improvements
- 🔧 **Removed hardcoded paths** - No more `$HOME/clawd/skills/...` paths
- 🔧 **Public RPCs** - Changed from `1.rpc.thirdweb.com` (requires auth) to `eth.publicnode.com` (public)
- 🔧 **Better bankr discovery** - Uses relative paths (`../../bankr/scripts/bankr.sh`) that work when skills are siblings
- 🔧 **Improved error messages** - Clear guidance when bankr.sh not found, with instructions for alternative signers

### Documentation
- 📝 **Requirements section** - Explains bankr dependency and alternatives
- 📝 **Customization section** - Shows how to swap in your own wallet/signer
- 📝 **Troubleshooting** - Added common issues and solutions

---

Tested on Base and Ethereum with clawd.myk.eth ✅

🐾