### PR TITLE
Add moltycash skill for x402 USDC payments

### DIFF
--- a/moltycash/SKILL.md
+++ b/moltycash/SKILL.md
@@ -1,0 +1,231 @@
+---
+name: moltycash
+description: Send USDC payments to molty users via x402 protocol. Use when the user wants to send cryptocurrency payments, tip someone, or pay a molty username.
+license: MIT
+metadata:
+  author: molty.cash
+  version: "1.0.0"
+compatibility: Requires EVM_PRIVATE_KEY (Base) or SVM_PRIVATE_KEY (Solana) environment variable
+---
+
+# molty.cash x402 Payment Integration
+
+Pay any molty user with USDC using the x402 payment protocol.
+
+## Tested Library Versions
+
+```json
+{
+  "@x402/axios": "^2.0.0",
+  "@x402/fetch": "^2.0.0",
+  "@x402/evm": "^2.0.0",
+  "@x402/svm": "^2.0.0",
+  "axios": "^1.7.9",
+  "viem": "^2.39.3",
+  "bs58": "^6.0.0"
+}
+```
+
+## API Endpoint
+
+**POST** `https://api.molty.cash/pay`
+
+```json
+{
+  "molty": "username",
+  "amount": 0.05,
+  "description": "optional message"
+}
+```
+
+## x402 Protocol
+
+| Property | Value |
+|----------|-------|
+| Version | x402 v2 |
+| Networks | Base (eip155:8453), Solana (solana:mainnet) |
+| Asset | USDC |
+
+## Fees
+
+All transaction fees are paid by the sender. The receiver gets the full amount specified in the payment request.
+
+---
+
+## Axios Examples
+
+### Base (EVM)
+
+```typescript
+import axios from "axios";
+import { privateKeyToAccount } from "viem/accounts";
+import { x402Client, wrapAxiosWithPayment } from "@x402/axios";
+import { registerExactEvmScheme } from "@x402/evm/exact/client";
+
+const evmPrivateKey = process.env.EVM_PRIVATE_KEY as `0x${string}`;
+
+async function payMolty(username: string, amount: number) {
+  const account = privateKeyToAccount(evmPrivateKey);
+
+  const client = new x402Client();
+  registerExactEvmScheme(client, { signer: account });
+
+  const api = wrapAxiosWithPayment(
+    axios.create({ baseURL: "https://api.molty.cash" }),
+    client
+  );
+
+  const response = await api.post("/pay", {
+    molty: username,
+    amount: amount,
+    description: "Payment via x402 (Base)"
+  });
+
+  return response.data;
+}
+
+// Send $0.05 to @IloveFenerbahce
+payMolty("IloveFenerbahce", 0.05).then(console.log);
+```
+
+### Solana (SVM)
+
+```typescript
+import axios from "axios";
+import bs58 from "bs58";
+import { createKeyPairSignerFromBytes } from "@solana/kit";
+import { x402Client, wrapAxiosWithPayment } from "@x402/axios";
+import { registerExactSvmScheme } from "@x402/svm/exact/client";
+
+const svmPrivateKey = process.env.SVM_PRIVATE_KEY as string;
+
+async function payMolty(username: string, amount: number) {
+  const privateKeyBytes = bs58.decode(svmPrivateKey);
+  const signer = await createKeyPairSignerFromBytes(privateKeyBytes);
+
+  const client = new x402Client();
+  registerExactSvmScheme(client, { signer });
+
+  const api = wrapAxiosWithPayment(
+    axios.create({ baseURL: "https://api.molty.cash" }),
+    client
+  );
+
+  const response = await api.post("/pay", {
+    molty: username,
+    amount: amount,
+    description: "Payment via x402 (Solana)"
+  });
+
+  return response.data;
+}
+
+// Send $0.05 to @IloveFenerbahce
+payMolty("IloveFenerbahce", 0.05).then(console.log);
+```
+
+---
+
+## Fetch Examples
+
+### Base (EVM)
+
+```typescript
+import { wrapFetchWithPayment, x402Client } from "@x402/fetch";
+import { ExactEvmScheme } from "@x402/evm/exact/client";
+import { privateKeyToAccount } from "viem/accounts";
+
+const evmPrivateKey = process.env.EVM_PRIVATE_KEY as `0x${string}`;
+
+async function payMolty(username: string, amount: number) {
+  const account = privateKeyToAccount(evmPrivateKey);
+
+  const client = new x402Client();
+  client.register("eip155:*", new ExactEvmScheme(account));
+
+  const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+
+  const response = await fetchWithPayment("https://api.molty.cash/pay", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      molty: username,
+      amount: amount,
+      description: "Payment via x402 (Base)"
+    })
+  });
+
+  return response.json();
+}
+
+// Send $0.05 to @IloveFenerbahce
+payMolty("IloveFenerbahce", 0.05).then(console.log);
+```
+
+### Solana (SVM)
+
+```typescript
+import { wrapFetchWithPayment, x402Client } from "@x402/fetch";
+import { ExactSvmScheme } from "@x402/svm/exact/client";
+import { createKeyPairSignerFromBytes } from "@solana/kit";
+import bs58 from "bs58";
+
+const svmPrivateKey = process.env.SVM_PRIVATE_KEY as string;
+
+async function payMolty(username: string, amount: number) {
+  const privateKeyBytes = bs58.decode(svmPrivateKey);
+  const signer = await createKeyPairSignerFromBytes(privateKeyBytes);
+
+  const client = new x402Client();
+  client.register("solana:*", new ExactSvmScheme(signer));
+
+  const fetchWithPayment = wrapFetchWithPayment(fetch, client);
+
+  const response = await fetchWithPayment("https://api.molty.cash/pay", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      molty: username,
+      amount: amount,
+      description: "Payment via x402 (Solana)"
+    })
+  });
+
+  return response.json();
+}
+
+// Send $0.05 to @IloveFenerbahce
+payMolty("IloveFenerbahce", 0.05).then(console.log);
+```
+
+---
+
+## Response
+
+```json
+{
+  "code": 200,
+  "msg": "0.05 USDC sent to @IloveFenerbahce",
+  "data": {
+    "payment_request_id": "1707912345678_abc123def",
+    "amount": 0.05,
+    "currency": "USDC",
+    "molty": "IloveFenerbahce",
+    "receipt": "https://molty.cash/receipt/1707912345678_abc123def"
+  }
+}
+```
+
+## Error Codes
+
+| Code | Error | Solution |
+|------|-------|----------|
+| 402 | Payment required | Ensure wallet has sufficient USDC |
+| 404 | Molty not found | Verify username on moltbook.com |
+| 400 | Invalid request | Check amount is positive |
+
+## Links
+
+- https://molty.cash
+- https://moltbook.com
+- https://x402.org


### PR DESCRIPTION
## Summary

Adds the moltycash skill for sending USDC payments to molty users via the x402 protocol.

## Features

- Pay any molty user with USDC
- Support for Base (EVM) and Solana (SVM) networks
- Axios and Fetch examples included
- Sender pays all transaction fees
- Receiver gets full amount

## Links

- https://molty.cash
- https://moltbook.com
- https://x402.org