### PR TITLE
Add farcaster-agent skill

### DIFF
--- a/farcaster-agent/SKILL.md
+++ b/farcaster-agent/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: farcaster-agent
+description: Create Farcaster accounts and post casts autonomously. Official skill from the Farcaster team.
+metadata: {"openclaw":{"emoji":"🟣","requires":{"bins":["node","npm"],"env":[]}}}
+---
+
+# Farcaster Agent
+
+Official skill from the Farcaster team. Create and manage a Farcaster account autonomously. Register a new Farcaster identity (FID), add signing keys, set up a profile with username, and post casts to the network.
+
+## When to Use
+
+- Create a Farcaster account from scratch
+- Post casts (messages) to Farcaster
+- Set up a profile with username, bio, and profile picture
+- Establish autonomous presence on Farcaster
+
+## Prerequisites
+
+You need approximately **$1 of ETH or USDC** on any major chain (Ethereum, Optimism, Base, Arbitrum, or Polygon).
+
+## Quick Start
+
+### Step 1: Clone and Install
+
+```bash
+git clone https://github.com/rishavmukherji/farcaster-agent.git
+cd farcaster-agent
+npm install
+```
+
+### Step 2: Generate Wallet and Request Funding
+
+```javascript
+const { Wallet } = require('ethers');
+const wallet = Wallet.createRandom();
+console.log('Address:', wallet.address);
+console.log('Private Key:', wallet.privateKey);
+```
+
+**Ask your human:** "Please send ~$1 of ETH or USDC to `<address>` on Ethereum, Optimism, Base, Arbitrum, or Polygon."
+
+### Step 3: Run Auto-Setup
+
+```bash
+PRIVATE_KEY=0x... node src/auto-setup.js "Your first cast text"
+```
+
+This will:
+1. Detect funds across all chains
+2. Bridge/swap to get ETH on Optimism and USDC on Base
+3. Register your FID
+4. Add a signer key
+5. Post your first cast
+6. Return credentials to save
+
+### Step 4: Save Credentials
+
+After setup, save:
+- **FID** - Your Farcaster ID
+- **Signer Private Key** - Ed25519 key for signing casts
+
+## Post Additional Casts
+
+```bash
+PRIVATE_KEY=0x... SIGNER_PRIVATE_KEY=... FID=123 node src/post-cast.js "Hello Farcaster!"
+```
+
+## Set Up Profile
+
+```bash
+PRIVATE_KEY=0x... SIGNER_PRIVATE_KEY=... FID=123 npm run profile myusername "Display Name" "Bio" "https://pfp-url.png"
+```
+
+### Profile Picture Options
+
+- **DiceBear**: `https://api.dicebear.com/7.x/bottts/png?seed=yourname`
+- Any public HTTPS image URL
+
+## Cost Breakdown
+
+| Operation | Cost |
+|-----------|------|
+| FID Registration | ~$0.20 |
+| Add Signer | ~$0.05 |
+| Bridging | ~$0.10-0.20 |
+| Each API call | $0.001 |
+| **Total** | **~$0.50** |
+
+## Common Errors
+
+| Error | Fix |
+|-------|-----|
+| "invalid hash" | `npm install @farcaster/hub-nodejs@latest` |
+| "unknown fid" | Wait 30-60 seconds for hub sync |
+| "fname not registered" | Wait 30 seconds after fname registration |
+
+## Source
+
+Full documentation: https://github.com/rishavmukherji/farcaster-agent

--- a/farcaster-agent/references/api.md
+++ b/farcaster-agent/references/api.md
@@ -1,0 +1,118 @@
+# Farcaster Agent API Reference
+
+## Programmatic Usage
+
+```javascript
+const {
+  // Full autonomous setup
+  autoSetup,
+  checkAllBalances,
+
+  // Core functions
+  registerFid,
+  addSigner,
+  postCast,
+  swapEthToUsdc,
+
+  // Profile setup
+  setProfileData,
+  registerFname,
+  setupFullProfile,
+
+  // Utilities
+  checkFidSync,
+  checkSignerSync,
+  getCast
+} = require('farcaster-agent/src');
+```
+
+## Functions
+
+### autoSetup(privateKey, castText)
+
+Complete autonomous setup from any funded wallet.
+
+```javascript
+const result = await autoSetup('0x...privateKey', 'My first cast!');
+// Returns: { fid, signerPrivateKey, castHash }
+```
+
+### registerFid(privateKey)
+
+Register a new Farcaster ID on Optimism.
+
+```javascript
+const { fid } = await registerFid('0x...privateKey');
+```
+
+### addSigner(privateKey)
+
+Add an Ed25519 signer key for the FID.
+
+```javascript
+const { signerPrivateKey } = await addSigner('0x...privateKey');
+```
+
+### postCast(options)
+
+Post a cast to the network.
+
+```javascript
+const { hash, verified } = await postCast({
+  privateKey: '0x...',      // For x402 payment
+  signerPrivateKey: '...',  // Ed25519 key (hex, no 0x)
+  fid: 123,
+  text: 'Hello Farcaster!'
+});
+```
+
+### setupFullProfile(options)
+
+Set up complete profile with fname, display name, bio, and PFP.
+
+```javascript
+await setupFullProfile({
+  privateKey: '0x...',
+  signerPrivateKey: '...',
+  fid: 123,
+  fname: 'myusername',
+  displayName: 'My Name',
+  bio: 'My bio text',
+  pfpUrl: 'https://example.com/pfp.png'
+});
+```
+
+## Contract Addresses
+
+### Optimism
+
+| Contract | Address |
+|----------|---------|
+| IdGateway | `0x00000000Fc25870C6eD6b6c7E41Fb078b7656f69` |
+| IdRegistry | `0x00000000Fc6c5F01Fc30151999387Bb99A9f489b` |
+| KeyGateway | `0x00000000fC56947c7E7183f8Ca4B62398CaAdf0B` |
+| SignedKeyRequestValidator | `0x00000000FC700472606ED4fA22623Acf62c60553` |
+
+### Base
+
+| Contract | Address |
+|----------|---------|
+| USDC | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+
+### Neynar
+
+| Endpoint | URL |
+|----------|-----|
+| Hub API | `hub-api.neynar.com` |
+| Payment Address | `0xA6a8736f18f383f1cc2d938576933E5eA7Df01A1` |
+
+## x402 Micropayments
+
+Neynar hub requires x402 payments (0.001 USDC per call on Base).
+
+The payment uses EIP-3009 `transferWithAuthorization` - a gasless signature-based USDC transfer included in the `X-PAYMENT` header.
+
+## Key Types
+
+- **Custody Key:** Ethereum wallet that owns the FID (secp256k1)
+- **Signer Key:** Ed25519 key for signing casts (separate from custody)


### PR DESCRIPTION
## Summary

Add official farcaster-agent skill from the Farcaster team for autonomous Farcaster account creation.

## Features

- Register FID on Optimism via IdGateway
- Add Ed25519 signer keys via KeyGateway
- Post casts via Neynar hub with x402 micropayments
- Set up profile with fname (username), bio, and PFP
- Multi-chain fund detection (ETH/USDC on Ethereum, Optimism, Base, Arbitrum, Polygon)
- Automatic bridging and swapping to required chains

## Cost

~$0.50-1.00 total for full setup

## Source

Full implementation: https://github.com/rishavmukherji/farcaster-agent

---

Generated with [Claude Code](https://claude.com/claude-code)