### PR TITLE
Adds the Lobster Mix privacy protocol skill to the OpenClaw library.

### DIFF
--- a/lobster-mix/SKILL.md
+++ b/lobster-mix/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: lobster-mix
+version: 1.0.0
+description: Private USDC mixing demo on Polygon Amoy Testnet.
+homepage: https://lobstermix.fun
+metadata: {"lobster":{"emoji":"🦞","category":"finance","api_base":"https://lobstermix.fun/api/agent"}}
+---
+
+# Lobster Protocol Skill (Testnet Demo)
+
+Enables the agent to interact with the Lobster Mix privacy protocol on **Polygon Amoy Testnet**.
+
+## Capabilities
+- Mix USDC on Polygon Amoy using the `lobstermix.fun` public demo API.
+- **Note**: This is a faucet-style demo. No user funds are required; the system pays gas and provides test USDC.
+
+## Usage
+When the user requests to mix funds (e.g., "TEST MIX 1 USDC POLYGON TO <ADDRESS>"), the agent should:
+
+1. **Execute** (using POST to protect privacy):
+   `curl -X POST https://lobstermix.fun/api/agent/mix -H "Content-Type: application/json" -d '{"amount": 1, "token": "USDC", "receiver": "<ADDRESS>"}'`
+
+2. **Report**:
+   Return the result from the API (Tx Hash).
+2. **Report**:
+   Return the result from the API.
+
+> **Note**: This skill performs financial transactions. Ensure the user's intent is clear before execution.

--- a/lobster-mix/package.json
+++ b/lobster-mix/package.json
@@ -1,0 +1,8 @@
+{
+    "name": "lobster-mix",
+    "version": "1.0.0",
+    "description": "Private USDC mixing for agents. Privacy by default.",
+    "main": "SKILL.md",
+    "author": "Lobster Protocol",
+    "license": "MIT"
+}


### PR DESCRIPTION
**Features:**
- Enables agents to mix USDC on Polygon using the `https://lobstermix.fun` API.
- Supports natural language command: "TEST MIX 1 USDC POLYGON TO <ADDRESS>".
- Includes full metadata and package definition.
**Verification:**
- Validated against the production API.
- Tested with `openclaw-managed` skill loading.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new skill that can trigger financial-style blockchain transactions via an external API endpoint; risk is primarily around intent/UX safeguards and reliance on a third-party service (though it’s testnet/demo).
> 
> **Overview**
> Adds a new `lobster-mix` skill package with `SKILL.md` describing how an agent should execute a USDC “mix” on Polygon Amoy Testnet via `POST https://lobstermix.fun/api/agent/mix` and return the resulting transaction hash.
> 
> Includes skill metadata (category/emoji/API base) and a minimal `package.json` so the skill can be discovered/loaded as a standalone library entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82e884955aab45fbe0ee76622008dac9783aeeda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->