### PR TITLE
Add ClawdTalk skill for phone calling and SMS

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ metamask-openclaw-skills/
 
 | Provider | Skill | Description |
 |----------|-------|-------------|
-| *Coming soon* | — | Skills will be added via community PRs |
+| clawdtalk | clawdtalk | Phone calling and SMS for OpenClaw. Call your AI agent from any phone with deep tool integration for calendar, Jira, web search, and more. Powered by Telnyx. |
 
 ## Installation
 

--- a/clawdtalk/clawdtalk/SKILL.md
+++ b/clawdtalk/clawdtalk/SKILL.md
@@ -1,0 +1,32 @@
+# ClawdTalk
+
+**Category:** Communication / Voice AI
+
+**Description:** Phone calling and SMS for OpenClaw. Call your AI agent from any phone with deep tool integration for calendar, Jira, web search, and more. Powered by Telnyx.
+
+**URL:** https://clawdtalk.com
+
+**GitHub:** https://github.com/team-telnyx/clawdtalk-client
+
+## Capabilities
+
+- Phone calls and SMS messaging with AI agents
+- Deep tool integration: calendar, Jira, web search, and more
+- Voice AI powered by Telnyx
+- Call your AI agent from any phone
+
+## Installation
+
+Clone the repository and point your OpenClaw agent to:
+```
+https://github.com/team-telnyx/clawdtalk-client
+```
+
+## Usage
+
+Configure your Telnyx credentials and start making calls through your AI agent.
+
+## Requirements
+
+- Telnyx account with phone number
+- OpenClaw agent setup


### PR DESCRIPTION
Adds ClawdTalk to the skill library. ClawdTalk provides phone calling and SMS capabilities for OpenClaw agents, enabling voice interaction via Telnyx.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds a catalog entry; no runtime code or behavior is modified.
> 
> **Overview**
> Updates `README.md` to list the new Telnyx `clawdtalk` skill (linking to the external `clawdtalk-client` repo) and describes it as enabling phone calling and SMS for OpenClaw agents with deep tool integrations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 002d30cc2233d85de973a338f1bfa49a590caec9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->