### PR TITLE
Add Garden Temp Market (GTM) skill

### DIFF
--- a/potdealer/garden-temp-market/SKILL.md
+++ b/potdealer/garden-temp-market/SKILL.md
@@ -4,7 +4,7 @@ Bet on daily garden temperature predictions on Base.
 
 ## Contract
 
-- **Address**: `0xA3F09E6792351e95d1fd9d966447504B5668daF6`
+- **Address**: `TBD` (v2 — pending redeployment)
 - **Chain**: Base (8453)
 - **Source**: https://github.com/Potdealer/prediction-market
 
@@ -15,6 +15,7 @@ A daily prediction market: "Will today's 18:00 UTC garden temperature be HIGHER 
 - **HIGHER**: Bet the temperature will increase
 - **LOWER**: Bet the temperature will stay the same or decrease
 - Winners split 98% of the pot proportionally
+- Winners call `claim()` to collect (pull-based payouts)
 - Settlement: 18:00 UTC daily
 - Data source: Netclawd's SensorNet
 
@@ -32,14 +33,14 @@ Bet that today's temperature will be higher than yesterday's baseline.
 **Transaction:**
 ```json
 {
-  "to": "0xA3F09E6792351e95d1fd9d966447504B5668daF6",
+  "to": "GTM_CONTRACT_ADDRESS",
   "data": "0xb3dd0f5a",
   "value": "<amount_in_wei>",
   "chainId": 8453
 }
 ```
 
-**Example:** "bet 0.01 ETH on higher at GTM"
+**Example:** "bet 0.001 ETH on higher at GTM"
 
 ### Bet LOWER
 
@@ -53,20 +54,56 @@ Bet that today's temperature will be the same or lower than yesterday's baseline
 **Transaction:**
 ```json
 {
-  "to": "0xA3F09E6792351e95d1fd9d966447504B5668daF6",
-  "data": "0x7a5ce755",
+  "to": "GTM_CONTRACT_ADDRESS",
+  "data": "0x771a2ab3",
   "value": "<amount_in_wei>",
   "chainId": 8453
 }
 ```
 
-**Example:** "bet 0.005 ETH on lower at GTM"
+**Example:** "bet 0.001 ETH on lower at GTM"
+
+### Claim Winnings
+
+After a round settles, winners must claim their payout.
+
+**Trigger phrases:**
+- "claim my GTM winnings for round [number]"
+- "claim GTM round [number]"
+- "collect my garden temp market payout"
+
+**Transaction (round 1 example):**
+```json
+{
+  "to": "GTM_CONTRACT_ADDRESS",
+  "data": "0x379607f50000000000000000000000000000000000000000000000000000000000000001",
+  "value": "0",
+  "chainId": 8453
+}
+```
+
+**Example:** "claim my GTM winnings for round 1"
+
+### Check Claimable
+
+Check if you have unclaimed winnings.
+
+**Trigger phrases:**
+- "check my GTM claimable winnings"
+- "do I have GTM winnings to claim?"
+- "check GTM round [number] claimable"
+
+**Read call:**
+```
+claimable(uint256 round, address user) → uint256 amount (wei)
+```
 
 ## Value Conversions
 
 | ETH | Wei |
 |-----|-----|
 | 0.001 (min) | 1000000000000000 |
+| 0.002 (max in safe mode) | 2000000000000000 |
 | 0.005 | 5000000000000000 |
 | 0.01 | 10000000000000000 |
 | 0.05 | 50000000000000000 |
@@ -75,22 +112,25 @@ Bet that today's temperature will be the same or lower than yesterday's baseline
 ## Rules
 
 - **Minimum bet**: 0.001 ETH
-- **One bet per round**: Cannot bet both HIGHER and LOWER
+- **Maximum bet**: 0.002 ETH while safe mode is on (~$5 cap for testing)
+- **Multiple bets allowed**: Can bet multiple times per round, even on both sides
 - **Betting closes**: 12:00 UTC (6 hours before settlement)
 - **Settlement**: 18:00 UTC daily
-- **Ties**: Pot rolls over to next day
-- **One-sided market**: Everyone gets refunded
+- **Claiming**: Winners must call `claim(round)` to collect — they pay gas
+- **Ties**: Pot rolls over to next day, nothing to claim
+- **One-sided market**: Everyone claims a refund
 
 ## Function Selectors
 
 | Function | Selector | Description |
 |----------|----------|-------------|
 | `betHigher()` | `0xb3dd0f5a` | Bet temperature goes up |
-| `betLower()` | `0x7a5ce755` | Bet temperature stays same or goes down |
+| `betLower()` | `0x771a2ab3` | Bet temperature stays same or goes down |
+| `claim(uint256)` | `0x379607f5` | Claim winnings for a settled round |
+| `claimable(uint256,address)` | `0xa0c7f71c` | Check claimable amount (view) |
 
 ## Links
 
-- **Basescan**: https://basescan.org/address/0xA3F09E6792351e95d1fd9d966447504B5668daF6
 - **GitHub**: https://github.com/Potdealer/prediction-market
 - **ClawhHub**: `clawhub install prediction-market`
 

--- a/potdealer/garden-temp-market/references/contract-abi.md
+++ b/potdealer/garden-temp-market/references/contract-abi.md
@@ -1,27 +1,47 @@
 # GTM Contract ABI Reference
 
 ## Contract Address
-`0xA3F09E6792351e95d1fd9d966447504B5668daF6` on Base (chainId 8453)
+`TBD` on Base (chainId 8453) — v2 pending redeployment
 
 ## Betting Functions
 
 ### betHigher()
-Bet that today's temp will be HIGHER than yesterday's.
+Bet that today's temp will be HIGHER than yesterday's. Multiple bets allowed per round.
 
 ```solidity
 function betHigher() external payable
 ```
 - **Selector**: `0xb3dd0f5a`
-- **Value**: Amount to bet (min 0.001 ETH)
+- **Value**: Amount to bet (min 0.001 ETH, max 0.002 ETH in safe mode)
 
 ### betLower()
-Bet that today's temp will be LOWER or equal to yesterday's.
+Bet that today's temp will be LOWER or equal to yesterday's. Multiple bets allowed per round.
 
 ```solidity
 function betLower() external payable
 ```
-- **Selector**: `0x7a5ce755`
-- **Value**: Amount to bet (min 0.001 ETH)
+- **Selector**: `0x771a2ab3`
+- **Value**: Amount to bet (min 0.001 ETH, max 0.002 ETH in safe mode)
+
+## Claim Functions
+
+### claim(uint256)
+Claim winnings (or refund) for a settled round. Winners pay their own gas.
+
+```solidity
+function claim(uint256 round) external
+```
+- **Selector**: `0x379607f5`
+- **Reverts**: "Round not settled", "Already claimed", "Nothing to claim"
+
+### claimable(uint256,address)
+Check how much a user can claim for a given round.
+
+```solidity
+function claimable(uint256 round, address user) external view returns (uint256)
+```
+- **Selector**: `0xa0c7f71c`
+- Returns 0 if not settled, already claimed, or no winnings
 
 ## Read Functions
 
@@ -56,9 +76,31 @@ function yesterdayTemp() external view returns (int256)
 ```
 Returns temperature with 2 decimal places (e.g., 1210 = 12.10°C)
 
+### getMyBet(address)
+Get a user's bet for current round.
+
+```solidity
+function getMyBet(address user) external view returns (uint256 higherAmt, uint256 lowerAmt)
+```
+
+### safeMode()
+Check if safe mode is active (bet cap enforced).
+
+```solidity
+function safeMode() external view returns (bool)
+```
+
+### maxBet()
+Get the maximum bet amount (0 = no limit).
+
+```solidity
+function maxBet() external view returns (uint256)
+```
+
 ## Events
 
 ```solidity
 event BetPlaced(uint256 indexed round, address indexed bettor, bool isHigher, uint256 amount, int256 baseline);
 event RoundSettled(uint256 indexed round, int256 todayTemp, int256 yesterdayTemp, bool higherWon, bool wasTie, uint256 totalPot, uint256 houseFee);
+event WinningsClaimed(uint256 indexed round, address indexed bettor, uint256 amount);
 ```


### PR DESCRIPTION
## Summary

Adds a skill for Garden Temp Market (GTM) - a daily temperature prediction market on Base.

**What is GTM?**
- Bet HIGHER or LOWER on whether today's 18:00 UTC garden temp will beat yesterday's
- Uses Netclawd's SensorNet for real temperature data
- Winners split 98% of pot, settlement daily at 18:00 UTC

## Commands

- `bet [amount] ETH on higher at GTM` - bet temperature goes up
- `bet [amount] ETH on lower at GTM` - bet temperature stays same or down

## Contract

- **Address**: `0xA3F09E6792351e95d1fd9d966447504B5668daF6`
- **Chain**: Base (8453)
- **Min bet**: 0.001 ETH

## Links

- [GitHub](https://github.com/Potdealer/prediction-market)
- [Basescan](https://basescan.org/address/0xA3F09E6792351e95d1fd9d966447504B5668daF6)
- ClawhHub: `clawhub install prediction-market`

Built by **potdealer x Ollie** for **Netclawd's SensorNet**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only addition with no runtime code changes; primary risk is users following incorrect/placeholder contract address details.
> 
> **Overview**
> Adds a new `garden-temp-market` skill documentation package, describing how to place HIGHER/LOWER bets and claim winnings for a daily temperature prediction market on Base.
> 
> Includes concrete transaction payload examples and function selectors for `betHigher()`, `betLower()`, `claim(uint256)`, and `claimable(uint256,address)`, plus an ABI reference doc covering additional read methods/events; contract address is currently marked `TBD` pending v2 redeploy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d211c42042e636057513da5b675e31d3d5d6a689. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->