### PR TITLE
update skill for sdk 3

### DIFF
--- a/veil/README.md
+++ b/veil/README.md
@@ -1,9 +1,6 @@
-# Veil skill (draft)
+# Veil skill
 
-This is a draft skill folder intended for submission to:
-https://github.com/BankrBot/openclaw-skills
-
-It wraps the `@veil-cash/sdk` (v3) CLI and optionally uses Bankr Agent API to sign & submit unsigned deposit/register transactions. Supports **ETH, USDC, and cbBTC** privacy pools.
+Wraps the [@veil-cash/sdk](https://github.com/veildotcash/veildotcash-sdk) CLI and optionally uses Bankr Agent API to sign & submit unsigned deposit/register transactions. Supports **ETH and USDC** privacy pools on Base.
 
 ## Assumptions
 
@@ -48,18 +45,14 @@ scripts/veil-bankr-prompt.sh "What is my Base wallet address? Respond with just 
 # Check balances (ETH pool — default)
 scripts/veil-balance.sh --address 0x...
 
-# Check balances (USDC or cbBTC pool)
+# Check balances (USDC pool)
 scripts/veil-balance.sh --address 0x... --pool usdc
-scripts/veil-balance.sh --address 0x... --pool cbbtc
 
 # Deposit via Bankr — ETH (build unsigned tx + submit)
 scripts/veil-deposit-via-bankr.sh ETH 0.011 --address 0x...
 
 # Deposit via Bankr — USDC (auto-handles approve + deposit)
 scripts/veil-deposit-via-bankr.sh USDC 100 --address 0x...
-
-# Deposit via Bankr — cbBTC
-scripts/veil-deposit-via-bankr.sh CBBTC 0.001 --address 0x...
 
 # Withdraw / transfer / merge (local VEIL_KEY required)
 scripts/veil-withdraw.sh ETH 0.007 0x...
@@ -73,5 +66,5 @@ scripts/veil-merge.sh USDC 100
 ## Notes
 
 - `veil-bankr-prompt.sh` implements the same submit/poll loop as the Bankr skill, but localized here so this skill is self-contained.
-- For USDC and cbBTC deposits via Bankr, `veil-deposit-via-bankr.sh` automatically submits the ERC20 approval transaction first, then the deposit transaction.
-- All action scripts take asset as the first argument: `ETH`, `USDC`, or `CBBTC`.
+- For USDC deposits via Bankr, `veil-deposit-via-bankr.sh` automatically submits the ERC20 approval transaction first, then the deposit transaction.
+- All action scripts take asset as the first argument: `ETH` or `USDC`.

--- a/veil/SKILL.md
+++ b/veil/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: veil
-description: Privacy and shielded transactions on Base via Veil Cash (veil.cash). Deposit ETH, USDC, or cbBTC into private pools, withdraw/transfer privately using ZK proofs. Manage Veil keypairs, check private/queue balances across all pools, and submit deposits via Bankr. Use when the user wants anonymous or private transactions, shielded transfers, or ZK-based privacy on Base.
+description: Privacy and shielded transactions on Base via Veil Cash (veil.cash). Deposit ETH or USDC into private pools, withdraw/transfer privately using ZK proofs. Manage Veil keypairs, check private/queue balances across all pools, and submit deposits via Bankr. Use when the user wants anonymous or private transactions, shielded transfers, or ZK-based privacy on Base.
 metadata: {"clawdbot": {"emoji": "🌪️", "homepage": "https://veil.cash", "requires": {"bins": ["node", "curl", "jq"]}}}
 ---
 
 # Veil
 
-This skill wraps the `@veil-cash/sdk` (v3) CLI to make Veil operations agent-friendly.
+This skill wraps the `@veil-cash/sdk` CLI to make Veil operations agent-friendly.
 
 ## Supported Assets
 
@@ -14,15 +14,14 @@ This skill wraps the `@veil-cash/sdk` (v3) CLI to make Veil operations agent-fri
 |-------|----------|-------------|
 | ETH   | 18       | Native ETH (via WETH) |
 | USDC  | 6        | USDC on Base |
-| CBBTC | 8        | Coinbase Wrapped BTC on Base |
 
 ## What it does
 
 - **Key management**: generate and store a Veil keypair locally
 - **Status check**: verify configuration, registration, and relay health
-- **Balances**: combined `balance`, `queue-balance`, `private-balance` — supports `--pool eth|usdc|cbbtc`
-- **Deposits via Bankr**: build **Bankr-compatible unsigned transactions** and ask Bankr to sign & submit (handles ERC20 approve + deposit for USDC/cbBTC)
-- **Private actions**: `withdraw`, `transfer`, `merge` for ETH, USDC, or cbBTC — executed locally using `VEIL_KEY` (ZK/proof flow)
+- **Balances**: `veil balance` (queue + private) — supports `--pool eth|usdc`
+- **Deposits via Bankr**: build **Bankr-compatible unsigned transactions** and ask Bankr to sign & submit (handles ERC20 approve + deposit for USDC)
+- **Private actions**: `withdraw`, `transfer`, `merge` for ETH or USDC — executed locally using `VEIL_KEY` (ZK/proof flow)
 
 ## File locations (recommended)
 
@@ -98,9 +97,6 @@ scripts/veil-balance.sh --address 0xYOUR_BANKR_ADDRESS
 
 # USDC pool
 scripts/veil-balance.sh --address 0xYOUR_BANKR_ADDRESS --pool usdc
-
-# cbBTC pool
-scripts/veil-balance.sh --address 0xYOUR_BANKR_ADDRESS --pool cbbtc
 ```
 
 ### 8) Deposit via Bankr (sign & submit)
@@ -111,9 +107,6 @@ scripts/veil-deposit-via-bankr.sh ETH 0.011 --address 0xYOUR_BANKR_ADDRESS
 
 # Deposit USDC (auto-handles approve + deposit)
 scripts/veil-deposit-via-bankr.sh USDC 100 --address 0xYOUR_BANKR_ADDRESS
-
-# Deposit cbBTC
-scripts/veil-deposit-via-bankr.sh CBBTC 0.001 --address 0xYOUR_BANKR_ADDRESS
 ```
 
 ### 9) Withdraw (private to public)
@@ -121,7 +114,6 @@ scripts/veil-deposit-via-bankr.sh CBBTC 0.001 --address 0xYOUR_BANKR_ADDRESS
 ```bash
 scripts/veil-withdraw.sh ETH 0.007 0xYOUR_BANKR_ADDRESS
 scripts/veil-withdraw.sh USDC 50 0xRECIPIENT
-scripts/veil-withdraw.sh CBBTC 0.0005 0xRECIPIENT
 ```
 
 ### 10) Transfer privately
@@ -146,5 +138,5 @@ scripts/veil-merge.sh USDC 100
 ## Notes
 
 - For **Bankr signing**, this skill uses Bankr's Agent API via your local `~/.clawdbot/skills/bankr/config.json`.
-- For **USDC/cbBTC deposits** via Bankr, the skill automatically submits the ERC20 approval transaction first, then the deposit transaction.
+- For **USDC deposits** via Bankr, the skill automatically submits the ERC20 approval transaction first, then the deposit transaction.
 - For privacy safety: never commit `.env.veil` or `.env` files to git.

--- a/veil/references/troubleshooting.md
+++ b/veil/references/troubleshooting.md
@@ -58,19 +58,18 @@ Look at the `queue` vs `private` balances in the output.
 ```bash
 scripts/veil-balance.sh --address 0xYOUR_ADDRESS
 scripts/veil-balance.sh --address 0xYOUR_ADDRESS --pool usdc
-scripts/veil-balance.sh --address 0xYOUR_ADDRESS --pool cbbtc
 ```
 
-### ERC20 Approval Failures (USDC/cbBTC)
+### ERC20 Approval Failures (USDC)
 
-**Symptom**: USDC or cbBTC deposit fails at the approval step.
+**Symptom**: USDC deposit fails at the approval step.
 
-**Cause**: The wallet may not have enough USDC/cbBTC balance, or there may be an existing allowance conflict.
+**Cause**: The wallet may not have enough USDC balance, or there may be an existing allowance conflict.
 
 **Solution**:
 1. Verify you have sufficient token balance in your Bankr wallet.
 2. If depositing via Bankr, the `veil-deposit-via-bankr.sh` script automatically sends the approval transaction first. Ensure the first (approve) transaction completes before the second (deposit) is submitted.
-3. If using `--unsigned` directly, note that USDC/cbBTC returns a JSON array of two transactions — submit the `step: "approve"` tx first, wait for confirmation, then submit the `step: "deposit"` tx.
+3. If using `--unsigned` directly, note that USDC returns a JSON array of two transactions — submit the `step: "approve"` tx first, wait for confirmation, then submit the `step: "deposit"` tx.
 
 ### Wrong Pool / Asset Mismatch
 
@@ -82,7 +81,6 @@ scripts/veil-balance.sh --address 0xYOUR_ADDRESS --pool cbbtc
 
 ```bash
 scripts/veil-balance.sh --address 0xYOUR_ADDRESS --pool usdc
-scripts/veil-balance.sh --address 0xYOUR_ADDRESS --pool cbbtc
 ```
 
 ### Bankr API Errors
@@ -109,11 +107,11 @@ chmod +x scripts/*.sh
 ## Debugging Tips
 
 1. **Check balances first** — Most issues stem from funds being in queue vs private pool
-2. **Check the right pool** — Use `--pool usdc` or `--pool cbbtc` to check non-ETH balances
+2. **Check the right pool** — Use `--pool usdc` to check USDC balances
 3. **Use `--quiet` flag** — Suppresses progress output for cleaner JSON parsing
 4. **Check Bankr job status** — If a deposit via Bankr hangs, the job ID is printed for manual status checks
 5. **Verify RPC connectivity** — `curl -s YOUR_RPC_URL -X POST -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'`
-6. **ERC20 deposits need two txs** — For USDC/cbBTC, ensure the approval tx confirms before the deposit tx is submitted
+6. **ERC20 deposits need two txs** — For USDC, ensure the approval tx confirms before the deposit tx is submitted
 
 ## Getting Help
 

--- a/veil/scripts/veil-bankr-prompt.sh
+++ b/veil/scripts/veil-bankr-prompt.sh
@@ -44,9 +44,23 @@ fi
 # Poll
 ATTEMPT=0
 MAX_ATTEMPTS=150
+LAST_STATUS=""
 while [[ $ATTEMPT -lt $MAX_ATTEMPTS ]]; do
   sleep 2
-  STATUS=$(curl -sf -X GET "$API_URL/agent/job/$JOB_ID" -H "X-API-Key: $API_KEY")
+  STATUS=$(curl -sf -X GET "$API_URL/agent/job/$JOB_ID" -H "X-API-Key: $API_KEY") || {
+    echo "Failed to poll Bankr job status (attempt $((ATTEMPT+1))/$MAX_ATTEMPTS)" >&2
+    ATTEMPT=$((ATTEMPT+1))
+    continue
+  }
+  LAST_STATUS="$STATUS"
+
+  # Validate response is JSON
+  if ! echo "$STATUS" | jq empty 2>/dev/null; then
+    echo "Bankr returned non-JSON response: $STATUS" >&2
+    ATTEMPT=$((ATTEMPT+1))
+    continue
+  fi
+
   STATE=$(echo "$STATUS" | jq -r '.status')
   case "$STATE" in
     completed)
@@ -54,19 +68,27 @@ while [[ $ATTEMPT -lt $MAX_ATTEMPTS ]]; do
       exit 0
       ;;
     failed|cancelled)
-      echo "$STATUS" | jq . >&2
+      ERROR_DETAIL=$(echo "$STATUS" | jq -r '.error // .message // .reason // empty')
       echo "Bankr job $STATE: $JOB_ID" >&2
+      [[ -n "$ERROR_DETAIL" ]] && echo "Detail: $ERROR_DETAIL" >&2
+      echo "$STATUS" | jq . >&2
       exit 1
       ;;
     pending|processing)
       :
       ;;
     *)
+      echo "Unexpected Bankr job status '$STATE' for job $JOB_ID" >&2
       echo "$STATUS" | jq . >&2
       ;;
   esac
   ATTEMPT=$((ATTEMPT+1))
 done
 
-echo "Timed out waiting for Bankr job: $JOB_ID" >&2
+echo "Timed out waiting for Bankr job: $JOB_ID (after $MAX_ATTEMPTS attempts)" >&2
+if [[ -n "$LAST_STATUS" ]]; then
+  LAST_STATE=$(echo "$LAST_STATUS" | jq -r '.status // "unknown"')
+  echo "Last known status: $LAST_STATE" >&2
+  echo "$LAST_STATUS" | jq . >&2
+fi
 exit 1

--- a/veil/scripts/veil-deposit-unsigned.sh
+++ b/veil/scripts/veil-deposit-unsigned.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 # Build a Bankr-compatible unsigned deposit tx JSON (no signing).
 # Usage: veil-deposit-unsigned.sh <asset> <amount> [extra flags...]
-#   asset: ETH, USDC, or CBBTC (default: ETH)
+#   asset: ETH or USDC
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/_common.sh"
 
-ASSET="${1:?asset required (ETH, USDC, CBBTC)}"
+ASSET="${1:?asset required (ETH, USDC)}"
 AMOUNT="${2:?amount required}"
 shift 2 || true
 

--- a/veil/scripts/veil-deposit-via-bankr.sh
+++ b/veil/scripts/veil-deposit-via-bankr.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Build unsigned deposit tx JSON and submit via Bankr.
-# For ETH: single tx. For USDC/cbBTC: approve tx first, then deposit tx.
+# For ETH: single tx. For USDC: approve tx first, then deposit tx.
 # Usage: veil-deposit-via-bankr.sh <asset> <amount> [extra flags...]
-#   asset: ETH, USDC, or CBBTC (default: ETH)
+#   asset: ETH or USDC
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -10,17 +10,30 @@ source "$SCRIPT_DIR/_common.sh"
 
 need_bin jq
 
-ASSET="${1:?asset required (ETH, USDC, CBBTC)}"
+ASSET="${1:?asset required (ETH, USDC)}"
 AMOUNT="${2:?amount required}"
 shift 2 || true
 
 PAYLOAD=$(veil_cli deposit "$ASSET" "$AMOUNT" --unsigned --quiet "$@")
 
+# Validate CLI output is valid JSON
+if ! echo "$PAYLOAD" | jq empty 2>/dev/null; then
+  echo "CLI did not return valid JSON:" >&2
+  echo "$PAYLOAD" >&2
+  exit 1
+fi
+
 # Check if payload is an array (ERC20: approve + deposit) or single object (ETH)
 IS_ARRAY=$(echo "$PAYLOAD" | jq -r 'if type == "array" then "true" else "false" end')
 
 if [[ "$IS_ARRAY" == "true" ]]; then
-  # ERC20 deposit: submit approve tx first, then deposit tx
+  ARRAY_LEN=$(echo "$PAYLOAD" | jq 'length')
+  if [[ "$ARRAY_LEN" -ne 2 ]]; then
+    echo "Expected 2 transactions (approve + deposit), got $ARRAY_LEN" >&2
+    echo "$PAYLOAD" >&2
+    exit 1
+  fi
+
   APPROVE_TX=$(echo "$PAYLOAD" | jq -c '.[0]')
   DEPOSIT_TX=$(echo "$PAYLOAD" | jq -c '.[1]')
 
@@ -31,9 +44,18 @@ if [[ "$IS_ARRAY" == "true" ]]; then
     exit 1
   }
 
+  # Validate approval result is JSON
+  if ! echo "$APPROVE_RESULT" | jq empty 2>/dev/null; then
+    echo "Approval result is not valid JSON:" >&2
+    echo "$APPROVE_RESULT" >&2
+    exit 1
+  fi
+
   APPROVE_STATUS=$(echo "$APPROVE_RESULT" | jq -r '.status // empty')
   if [[ "$APPROVE_STATUS" != "completed" ]]; then
     echo "Approval transaction not completed (status: ${APPROVE_STATUS:-unknown})" >&2
+    ERROR_MSG=$(echo "$APPROVE_RESULT" | jq -r '.error // .message // .reason // empty')
+    [[ -n "$ERROR_MSG" ]] && echo "Error: $ERROR_MSG" >&2
     echo "$APPROVE_RESULT" >&2
     exit 1
   fi

--- a/veil/scripts/veil-merge.sh
+++ b/veil/scripts/veil-merge.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 # Merge/consolidate UTXOs by self-transfer.
 # Usage: veil-merge.sh <asset> <amount>
-#   asset: ETH, USDC, or CBBTC
+#   asset: ETH or USDC
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/_common.sh"
 
-ASSET="${1:?asset required (ETH, USDC, CBBTC)}"
+ASSET="${1:?asset required (ETH, USDC)}"
 AMOUNT="${2:?amount required}"
 
 veil_cli merge "$ASSET" "$AMOUNT" --quiet

--- a/veil/scripts/veil-private-balance.sh
+++ b/veil/scripts/veil-private-balance.sh
@@ -4,4 +4,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/_common.sh"
 
-veil_cli private-balance --quiet "$@"
+need_bin jq
+# Extract private balance from unified veil balance output
+veil_cli balance --quiet "$@" | jq '.private'

--- a/veil/scripts/veil-queue-balance.sh
+++ b/veil/scripts/veil-queue-balance.sh
@@ -4,4 +4,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/_common.sh"
 
-veil_cli queue-balance --quiet "$@"
+need_bin jq
+# Extract queue balance from unified veil balance output
+veil_cli balance --quiet "$@" | jq '.queue'

--- a/veil/scripts/veil-transfer.sh
+++ b/veil/scripts/veil-transfer.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 # Private transfer within the pool to another registered address.
 # Usage: veil-transfer.sh <asset> <amount> <recipient>
-#   asset: ETH, USDC, or CBBTC
+#   asset: ETH or USDC
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/_common.sh"
 
-ASSET="${1:?asset required (ETH, USDC, CBBTC)}"
+ASSET="${1:?asset required (ETH, USDC)}"
 AMOUNT="${2:?amount required}"
 RECIPIENT="${3:?recipient address required}"
 

--- a/veil/scripts/veil-withdraw.sh
+++ b/veil/scripts/veil-withdraw.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 # Withdraw from private pool to a public address (executes locally using VEIL_KEY).
 # Usage: veil-withdraw.sh <asset> <amount> <recipient>
-#   asset: ETH, USDC, or CBBTC
+#   asset: ETH or USDC
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/_common.sh"
 
-ASSET="${1:?asset required (ETH, USDC, CBBTC)}"
+ASSET="${1:?asset required (ETH, USDC)}"
 AMOUNT="${2:?amount required}"
 RECIPIENT="${3:?recipient address required}"
 


### PR DESCRIPTION
We've updated the veil SDK to support USDC pools and cbBTC

Also improved the veil keypair creation. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction-building/submission scripts and introduces a two-step ERC20 approve+deposit flow, so mistakes could cause failed deposits or incorrect on-chain submissions. Changes are localized to the Veil skill scripts/docs with no broader system refactors.
> 
> **Overview**
> Updates the Veil skill to target `@veil-cash/sdk` v3 and expand beyond ETH to **USDC and cbBTC** pools, including updated docs for `--pool` balance checks and asset-first CLI/script usage.
> 
> Enhances Bankr-assisted deposits by handling the SDK’s ERC20 `--unsigned` output (approve + deposit array) and submitting the approval tx before the deposit tx, while also tightening error handling/reporting in `veil-bankr-prompt.sh` and improving `veil-init.sh` to support `--force` and write `.env.veil` from JSON keypair output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d80d09cb7a4bc292e7385d714d8b34d793d5188. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->