### PR TITLE
Add DumbMoney skill — Solana reflection token launchpad

### DIFF
--- a/dumbmoney/SKILL.md
+++ b/dumbmoney/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: dumbmoney
+description: "Trade reflection tokens on DumbMoney — Solana's token launchpad where holders earn passive SOL income from every sell. Browse tokens, check earnings, find high-yield reflection tokens."
+metadata: {"clawdbot": {"emoji": "💸", "homepage": "https://dumbmoney.win", "requires": {"bins": ["curl", "jq"]}}}
+---
+
+# DumbMoney — Solana Reflection Token Launchpad
+
+DumbMoney is a token launchpad on Solana where every token has **built-in reflection mechanics**. When someone sells a token, a percentage of the sale is automatically distributed to all holders as SOL. The more you hold, the more you earn — passively.
+
+## How It Works
+
+1. **Bonding Curve**: Each token launches on a bonding curve. Early buyers get lower prices. The curve graduates to Raydium at ~$69k market cap.
+2. **Reflection Fee**: Every sell triggers a reflection fee (typically 1-10%) that gets distributed proportionally to all holders.
+3. **Burn Fee**: A portion of each sell is also burned, reducing supply over time.
+4. **Passive Income**: Holders earn SOL just by holding. No staking, no claiming needed — reflections accumulate automatically.
+
+## Key Concepts
+
+- **Reflection Rate**: The percentage of each sell distributed to holders (e.g., 5% = 500 bps)
+- **Reflection Pool**: Total SOL that has been distributed to holders for a token
+- **Your Share**: Your percentage of the total holder pool — determines how much of each reflection you receive
+- **Bonding Curve Progress**: How close a token is to graduating to Raydium (100% = graduated)
+
+## What You Can Do
+
+### Browse All Tokens
+To see what tokens are available on DumbMoney, run:
+```bash
+{baseDir}/scripts/list-tokens.sh
+```
+This returns all tokens with their reflection rates, reserves, and earnings data.
+
+### Get Token Details
+To get detailed info about a specific token (by its mint address):
+```bash
+{baseDir}/scripts/token-info.sh <MINT_ADDRESS>
+```
+Returns price, market cap, reflection pool, bonding curve progress, and more.
+
+### Find Top Earning Tokens
+To see which tokens have paid out the most in reflections:
+```bash
+{baseDir}/scripts/top-earners.sh
+```
+Returns the top 10 tokens ranked by total reflections paid to holders.
+
+### Check Your Earnings
+To see how much a specific wallet has earned from a token:
+```bash
+{baseDir}/scripts/check-earnings.sh <MINT_ADDRESS> <WALLET_ADDRESS>
+```
+Returns pending SOL earnings, your share percentage, and USD value.
+
+### Buy a DumbMoney Token
+To buy a DumbMoney token, use Bankr's built-in Solana swap:
+> "Swap [AMOUNT] SOL for [MINT_ADDRESS] on Solana"
+
+The mint address can be found using the list-tokens or token-info scripts.
+
+### Sell a DumbMoney Token
+To sell, use Bankr's built-in swap:
+> "Swap [AMOUNT] [MINT_ADDRESS] for SOL on Solana"
+
+Note: Selling triggers the reflection fee, which pays other holders.
+
+### Launch Your Own Token (for AI Agents)
+AI agents can register on DumbMoney and launch their own reflection tokens via API. No approval needed — self-service registration.
+
+**Step 1: Register to get an API key**
+```bash
+curl -X POST https://dumbmoney.win/api/agents/register \
+  -H 'Content-Type: application/json' \
+  -d '{"name": "my-agent", "description": "My trading bot", "fee_wallet": "OPTIONAL_SOLANA_ADDRESS"}'
+```
+Save the returned `api_key` — it's shown only once.
+
+**Step 2: Create a token**
+```bash
+curl -X POST https://dumbmoney.win/api/tokens/create \
+  -H 'Content-Type: application/json' \
+  -H 'X-API-Key: YOUR_API_KEY' \
+  -d '{"name": "MyToken", "symbol": "MTK", "description": "A reflection token", "reflection_bps": 500, "burn_bps": 100}'
+```
+The platform handles gas fees, image upload, metadata, and on-chain creation. Your agent earns creator fees on every trade.
+
+- Agent docs: https://dumbmoney.win/llms.txt
+- OpenAPI spec: https://dumbmoney.win/openapi.json
+
+## Trading Strategies
+
+- **High Reflection Rate**: Look for tokens with 5%+ reflection rates — more of each sell goes to holders
+- **Growing Reflection Pool**: Tokens with large and growing reflection pools indicate active trading and real earnings
+- **Early Bonding Curve**: Tokens earlier on the bonding curve have more upside potential before graduation
+- **Low Market Cap + High Reflection**: Best risk/reward for passive income plays
+
+## Example Prompts
+
+- "Show me all DumbMoney tokens"
+- "What are the top earning reflection tokens on DumbMoney?"
+- "Get details on DumbMoney token [mint address]"
+- "How much has wallet [address] earned from token [mint]?"
+- "Buy 0.5 SOL of the top earning DumbMoney token"
+- "Find DumbMoney tokens with reflection rates above 5%"
+
+## Links
+
+- Website: https://dumbmoney.win
+- Launch a token: https://dumbmoney.win/launch
+- API docs: See `references/api-docs.md`

--- a/dumbmoney/references/api-docs.md
+++ b/dumbmoney/references/api-docs.md
@@ -1,0 +1,157 @@
+# DumbMoney API Reference
+
+Base URL: `https://dumbmoney.win/api`
+
+## Endpoints
+
+### GET /api/tokens
+
+List all DumbMoney reflection tokens.
+
+**Response:**
+```json
+[
+  {
+    "mint": "ABC123...",
+    "name": "PepeCoin",
+    "symbol": "PEPE",
+    "reflectionBps": 500,
+    "burnBps": 200,
+    "creatorFeeBps": 100,
+    "status": "bonding_curve",
+    "solReserves": 45.2,
+    "marketCapSol": 89.5,
+    "circulatingSupply": "450000000000000000",
+    "reflectionPoolSol": 2.34,
+    "reflectionPoolUsd": 468.0,
+    "totalBurned": 12345678.0,
+    "bondingCurveProgress": 53.2,
+    "price": {
+      "solPerToken": 0.0000001,
+      "usdPerToken": 0.00002
+    },
+    "createdAt": 1707400000
+  }
+]
+```
+
+### GET /api/tokens/:mint
+
+Get detailed info about a specific token by its mint address.
+
+**Parameters:**
+- `mint` (path) - The token's Solana mint address
+
+**Response:** Same fields as above, plus `tokenId` and `totalShares`.
+
+### GET /api/tokens/:mint/earnings?wallet=WALLET
+
+Check a wallet's pending reflection earnings for a specific token.
+
+**Parameters:**
+- `mint` (path) - The token's Solana mint address
+- `wallet` (query) - The holder's Solana wallet address
+
+**Response:**
+```json
+{
+  "wallet": "XYZ789...",
+  "token": "ABC123...",
+  "pendingSol": 0.042,
+  "pendingUsd": 8.40,
+  "sharePercent": 2.3,
+  "holderShares": 15000000,
+  "totalShares": 650000000
+}
+```
+
+### GET /api/top-earners
+
+Get top 10 tokens ranked by total reflections paid to holders.
+
+**Response:**
+```json
+[
+  {
+    "mint": "ABC123...",
+    "name": "PepeCoin",
+    "symbol": "PEPE",
+    "reflectionPoolSol": 5.67,
+    "reflectionPoolUsd": 1134.0,
+    "reflectionBps": 500,
+    "solReserves": 45.2,
+    "totalBurned": 12345678.0,
+    "creator": "DEF456..."
+  }
+]
+```
+
+### POST /api/agents/register
+
+Register as an AI agent to get an API key for creating tokens. No authentication required. Rate limited to 3 per hour per IP.
+
+**Request:**
+```json
+{
+  "name": "my-agent",
+  "description": "optional description",
+  "fee_wallet": "optional Solana address to receive creator fees"
+}
+```
+
+**Response:**
+```json
+{
+  "agent_id": "uuid",
+  "api_key": "dm_live_...",
+  "name": "my-agent",
+  "message": "Save your API key — it will not be shown again."
+}
+```
+
+### GET /api/agents/me
+
+Get your agent profile, tokens created count, and rate limits. Requires `X-API-Key` header.
+
+### POST /api/tokens/create
+
+Launch a new reflection token on-chain. Requires `X-API-Key` header. Platform pays gas.
+
+**Request:**
+```json
+{
+  "name": "MyToken",
+  "symbol": "MTK",
+  "description": "A reflection token",
+  "reflection_bps": 500,
+  "burn_bps": 100,
+  "creator_fee_bps": 100,
+  "image_url": "https://gateway.pinata.cloud/...",
+  "fee_wallet": "optional Solana address"
+}
+```
+
+**Image options** (provide one):
+- `image_url` — HTTPS URL from IPFS/Arweave/Pinata
+- `image_base64` — Base64-encoded image (max 5MB)
+- `dalle_prompt` — AI-generated image from prompt
+
+**Response:**
+```json
+{
+  "mint": "NEW_TOKEN_MINT_ADDRESS",
+  "name": "MyToken",
+  "symbol": "MTK",
+  "tx": "transaction_signature",
+  "creator": "PLATFORM_WALLET"
+}
+```
+
+## Notes
+
+- All SOL amounts are in SOL (not lamports)
+- `reflectionBps` is in basis points (500 = 5%)
+- `status` is one of: `bonding_curve`, `graduated`, `paused`
+- `bondingCurveProgress` is 0-100 (percentage of tokens sold from curve)
+- Responses are cached for 10 seconds with 30-second stale-while-revalidate
+- Token-2022 standard on Solana

--- a/dumbmoney/scripts/check-earnings.sh
+++ b/dumbmoney/scripts/check-earnings.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Check a wallet's pending reflection earnings for a DumbMoney token
+# Usage: check-earnings.sh <MINT_ADDRESS> <WALLET_ADDRESS>
+MINT="$1"
+WALLET="$2"
+if [ -z "$MINT" ] || [ -z "$WALLET" ]; then
+  echo "Usage: check-earnings.sh <MINT_ADDRESS> <WALLET_ADDRESS>"
+  exit 1
+fi
+# Validate base58 format (Solana addresses are 32-44 chars of alphanumeric, no 0/O/I/l)
+if ! echo "$MINT" | grep -qE '^[1-9A-HJ-NP-Za-km-z]{32,44}$'; then
+  echo "Error: Invalid mint address format"
+  exit 1
+fi
+if ! echo "$WALLET" | grep -qE '^[1-9A-HJ-NP-Za-km-z]{32,44}$'; then
+  echo "Error: Invalid wallet address format"
+  exit 1
+fi
+curl -s "https://dumbmoney.win/api/tokens/${MINT}/earnings?wallet=${WALLET}" | jq '{
+  wallet, token,
+  pendingEarnings: "\(.pendingSol) SOL ($\(.pendingUsd | tostring | .[0:10]))",
+  sharePercent: "\(.sharePercent | tostring | .[0:5])%",
+  holderShares, totalShares
+}'

--- a/dumbmoney/scripts/list-tokens.sh
+++ b/dumbmoney/scripts/list-tokens.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# List all DumbMoney reflection tokens on Solana
+# Returns: name, symbol, mint address, reflection rate, reserves, earnings data
+curl -s "https://dumbmoney.win/api/tokens" | jq '.[] | {name, symbol, mint, reflectionRate: "\(.reflectionBps / 100)%", status, solReserves: "\(.solReserves) SOL", reflectionPoolSol: "\(.reflectionPoolSol) SOL", reflectionPoolUsd: "\(.reflectionPoolUsd | tostring | .[0:10]) USD"}'

--- a/dumbmoney/scripts/token-info.sh
+++ b/dumbmoney/scripts/token-info.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Get detailed info about a specific DumbMoney token
+# Usage: token-info.sh <MINT_ADDRESS>
+MINT="$1"
+if [ -z "$MINT" ]; then
+  echo "Usage: token-info.sh <MINT_ADDRESS>"
+  exit 1
+fi
+# Validate base58 format (Solana addresses are 32-44 chars of alphanumeric, no 0/O/I/l)
+if ! echo "$MINT" | grep -qE '^[1-9A-HJ-NP-Za-km-z]{32,44}$'; then
+  echo "Error: Invalid Solana address format"
+  exit 1
+fi
+curl -s "https://dumbmoney.win/api/tokens/${MINT}" | jq '{
+  name, symbol, mint,
+  status,
+  reflectionRate: "\(.reflectionBps / 100)%",
+  burnRate: "\(.burnBps / 100)%",
+  solReserves: "\(.solReserves) SOL",
+  marketCapSol: "\(.marketCapSol) SOL",
+  reflectionPool: "\(.reflectionPoolSol) SOL ($\(.reflectionPoolUsd | tostring | .[0:10]))",
+  totalBurned: "\(.totalBurned) tokens",
+  bondingCurveProgress: "\(.bondingCurveProgress | tostring | .[0:5])%",
+  price: .price
+}'

--- a/dumbmoney/scripts/top-earners.sh
+++ b/dumbmoney/scripts/top-earners.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Find top earning DumbMoney tokens ranked by total reflections paid
+# Returns: top 10 tokens by reflection pool size
+curl -s "https://dumbmoney.win/api/top-earners" | jq '.[] | {name, symbol, mint, reflectionRate: "\(.reflectionBps / 100)%", totalPaid: "\(.reflectionPoolSol) SOL ($\(.reflectionPoolUsd | tostring | .[0:10]))"}'


### PR DESCRIPTION
## Summary

- Adds the **DumbMoney** skill — a Solana token launchpad where every token has built-in reflection mechanics (Token-2022 transfer fees that distribute SOL to all holders on every trade)
- Includes 4 shell scripts for querying tokens, checking earnings, and finding top earners
- Supports AI agent self-registration for programmatic token creation via API
- Full API reference docs included

## Skill Contents

| File | Description |
|------|-------------|
| `SKILL.md` | Skill definition with usage instructions and example prompts |
| `scripts/list-tokens.sh` | List all reflection tokens |
| `scripts/token-info.sh` | Get details for a specific token |
| `scripts/top-earners.sh` | Top 10 tokens by reflections paid |
| `scripts/check-earnings.sh` | Check wallet earnings for a token |
| `references/api-docs.md` | Full REST API reference |

## Links

- Website: https://dumbmoney.win
- API docs: https://dumbmoney.win/llms.txt
- OpenAPI spec: https://dumbmoney.win/openapi.json

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive docs and shell scripts that only perform read-only HTTP calls (plus documented token-creation endpoints) with no changes to existing runtime logic.
> 
> **Overview**
> Introduces a new `dumbmoney` skill that documents DumbMoney’s Solana reflection-token launchpad and how to browse tokens, inspect token stats, and check holder earnings.
> 
> Adds four `curl`/`jq` shell scripts (`list-tokens.sh`, `token-info.sh`, `top-earners.sh`, `check-earnings.sh`) that call `https://dumbmoney.win/api` to list tokens, fetch per-mint details, rank top earners, and query wallet earnings (with basic base58 address validation where applicable).
> 
> Includes a new `references/api-docs.md` describing the public REST API surface, including agent self-registration and token creation endpoints.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e26e5d95d9478876c37c2b2b2e013dd3f0211c7b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->