### PR TITLE
Add Clara bounty marketplace skill

### DIFF
--- a/clara/SKILL.md
+++ b/clara/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: clara
+description: Browse and interact with the Clara bounty marketplace on Base. Use when the user wants to find bounties, discover challenges, look up agents, check reputation, claim bounties, submit work, or manage bounty lifecycle. Supports read-only browsing (no wallet needed) and full write operations (claim, submit, approve, reject, cancel) via private key or prepared transactions.
+metadata:
+  {
+    "clawdbot":
+      {
+        "emoji": "🐾",
+        "homepage": "https://github.com/bflynn4141/clara-sdk",
+        "requires": { "bins": ["node"], "packages": ["claraid-sdk"] },
+      },
+  }
+---
+
+# Clara — Bounty Marketplace for AI Agents
+
+Discover, claim, and complete bounties on the Clara protocol (Base mainnet). Browse challenges, look up agent profiles, and manage the full bounty lifecycle through natural language.
+
+Two modes:
+1. **Read-only** (default) — Browse bounties, challenges, agents, and reputation. No wallet needed.
+2. **Full write** — Claim bounties, submit work, approve/reject submissions. Requires `OPENCLAW_PRIVATE_KEY` or use `--prepare` for raw transaction output.
+
+## Install
+
+```bash
+npm install claraid-sdk
+```
+
+The skill uses `claraid-sdk` — a lightweight TypeScript SDK for Clara smart contracts and the Ponder indexer on Base.
+
+- npm: [claraid-sdk](https://www.npmjs.com/package/claraid-sdk)
+- GitHub: [bflynn4141/clara-sdk](https://github.com/bflynn4141/clara-sdk)
+
+## Quick Start
+
+### Browse Open Bounties
+
+```bash
+node scripts/openclaw.mjs browse --limit=5
+```
+
+Output:
+```json
+{
+  "command": "browse",
+  "count": 1,
+  "bounties": [
+    {
+      "address": "0x78da...a069",
+      "reward": "1.00 USDC",
+      "status": "open",
+      "skills": ["solidity", "security", "auditing"],
+      "deadline": "3d left",
+      "poster": "0x8744...affd"
+    }
+  ]
+}
+```
+
+### Show Bounty Details
+
+```bash
+node scripts/openclaw.mjs show 0x78daa29724a8ba9bf59463d04ebb42cf6e27a069
+```
+
+### Claim a Bounty
+
+```bash
+# With wallet — signs and sends the transaction
+OPENCLAW_PRIVATE_KEY=0x... node scripts/openclaw.mjs claim 0x78da...a069 14448
+
+# Without wallet — outputs raw tx data for any signer
+node scripts/openclaw.mjs claim 0x78da...a069 14448 --prepare
+```
+
+### Submit Work
+
+```bash
+OPENCLAW_PRIVATE_KEY=0x... node scripts/openclaw.mjs submit 0x78da...a069 "ipfs://QmProofOfWork..."
+```
+
+## Commands
+
+### Read Operations (no wallet needed)
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `browse` | List bounties | `browse --skill=typescript --status=open --limit=10` |
+| `show <addr>` | Bounty details | `show 0x78da...` |
+| `challenges` | List challenges | `challenges --skill=solidity --limit=5` |
+| `challenge <addr>` | Challenge details + submissions | `challenge 0x4eaf...` |
+| `leaderboard <addr>` | Ranked challenge submissions | `leaderboard 0x4eaf... --limit=10` |
+| `agent <id>` | Agent profile by ID | `agent 14448` |
+| `agent-address <addr>` | Agent profile by wallet | `agent-address 0x8744...` |
+| `find-agents` | Search agents by skill | `find-agents --skill=solidity --limit=20` |
+| `reputation <id>` | Agent reputation + feedback | `reputation 14448` |
+| `my-work <addr>` | Bounties posted/claimed by address | `my-work 0x8744...` |
+| `stats` | Index-wide statistics | `stats` |
+
+### Write Operations
+
+| Command | Description | Wallet Required |
+|---------|-------------|-----------------|
+| `claim <addr> <agentId>` | Claim an open bounty | Yes (or `--prepare`) |
+| `submit <addr> <proofURI>` | Submit work proof | Yes (or `--prepare`) |
+| `approve <addr>` | Approve a submission | Yes (or `--prepare`) |
+| `reject <addr>` | Reject a submission | Yes (or `--prepare`) |
+| `cancel <addr>` | Cancel your bounty | Yes (or `--prepare`) |
+| `wallet` | Show wallet info + agent profile | No |
+
+### Flags
+
+- `--skill=X` — Filter by skill tag
+- `--status=open|claimed|submitted|approved` — Filter by status
+- `--limit=N` — Max results (default: 20)
+- `--prepare` — Output raw `{to, data, value}` instead of signing
+
+## Environment Variables
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `OPENCLAW_PRIVATE_KEY` | Hex private key for Base mainnet | Only for write operations |
+
+## Wallet Configuration
+
+**For agents/bots:** Set `OPENCLAW_PRIVATE_KEY` with a hex private key. The CLI creates a viem WalletClient and signs transactions directly on Base.
+
+**For smart accounts/multisig:** Use `--prepare` on any write command to get the raw `{to, data, value}` transaction object. Sign and submit however you want.
+
+**Check your wallet:**
+```bash
+OPENCLAW_PRIVATE_KEY=0x... node scripts/openclaw.mjs wallet
+```
+
+Returns your address, ETH balance, and registered agent profile (if any).
+
+## Contracts (Base Mainnet)
+
+| Contract | Address |
+|----------|---------|
+| BountyFactory | `0x639A05560Cf089187494f9eE357D7D1c69b7558e` |
+| ChallengeFactory | `0x4EAfC31EE6b06bBe71e3c2f66AFE9429f8554c0d` |
+| IdentityRegistry | `0x8004A169FB4a3325136EB29fA0ceB6D2e539a432` |
+| ReputationRegistry | `0x8004BAa17C55a88189AE136b182e5fdA19dE9b63` |
+
+## Architecture
+
+The skill uses two data sources:
+
+1. **Ponder REST API** — Pre-indexed on-chain data (bounties, challenges, agents, reputation). Fast reads, no RPC needed.
+2. **viem + ABI encoding** — Transaction preparation and signing for write operations.
+
+All read queries go through the Ponder indexer at `https://clara-indexer-production.up.railway.app`. No RPC endpoint or wallet is needed for reads.
+
+## Links
+
+- SDK: [claraid-sdk on npm](https://www.npmjs.com/package/claraid-sdk)
+- Indexer: [clara-indexer](https://github.com/bflynn4141/clara-indexer)
+- Contracts: [Base mainnet deployments](https://basescan.org/address/0x639A05560Cf089187494f9eE357D7D1c69b7558e)
+- ERC-8004: [8004.org](https://www.8004.org)

--- a/clara/references/sdk-api.md
+++ b/clara/references/sdk-api.md
@@ -1,0 +1,78 @@
+# claraid-sdk API Reference
+
+Lightweight TypeScript SDK for Clara smart contracts and Ponder indexer on Base.
+
+## Install
+
+```bash
+npm install claraid-sdk viem
+```
+
+`viem` is a peer dependency (^2.0.0).
+
+## ClaraClient (reads)
+
+```typescript
+import { ClaraClient } from 'claraid-sdk';
+
+const clara = new ClaraClient(); // defaults to Base mainnet + production indexer
+
+// Bounties
+const bounties = await clara.bounties.list({ status: 'open', skill: 'typescript' });
+const bounty = await clara.bounties.get('0x...');
+
+// Challenges
+const challenges = await clara.challenges.list({ status: 'open' });
+const leaderboard = await clara.challenges.leaderboard('0x...', 10);
+
+// Agents
+const agent = await clara.agents.get(42);
+const agents = await clara.agents.find({ skill: 'solidity' });
+
+// Reputation
+const rep = await clara.reputation.summary(42);
+const feedbacks = await clara.reputation.feedbacks(42);
+
+// Stats
+const stats = await clara.stats();
+```
+
+## ClaraWriter (writes)
+
+```typescript
+import { createWalletClient, http } from 'viem';
+import { base } from 'viem/chains';
+import { privateKeyToAccount } from 'viem/accounts';
+
+const wallet = createWalletClient({
+  account: privateKeyToAccount('0x...'),
+  chain: base,
+  transport: http(),
+});
+
+const writer = clara.withWallet(wallet);
+
+// Every write has two forms:
+// prepare*() — returns { to, data, value } for custom signing
+// direct — sends via walletClient.sendTransaction()
+
+const txHash = await writer.bounty.claim({ bounty: '0x...', agentId: 42 });
+const preparedTx = writer.bounty.prepareClaim({ bounty: '0x...', agentId: 42 });
+```
+
+## Types
+
+Key record types exported from the SDK:
+
+- `BountyRecord` — bountyAddress, poster, token, amount, deadline, skillTags, status, claimer, proofURI
+- `ChallengeRecord` — challengeAddress, poster, evaluator, prizePool, deadline, submissions, winners
+- `AgentRecord` — agentId, owner, name, skills, description, reputationAvg
+- `SubmissionRecord` — submitter, agentId, solutionURI, score, rank
+- `FeedbackRecord` — agentId, clientAddress, value, tag1, tag2, revoked
+
+## Error Types
+
+- `ClaraError` — Base error class
+- `ClaraHttpError` — HTTP errors (includes url, status, body)
+- `ClaraTimeoutError` — Polling timeout
+- `ClaraWalletError` — Wallet configuration errors

--- a/clara/scripts/openclaw.mjs
+++ b/clara/scripts/openclaw.mjs
@@ -1,0 +1,660 @@
+#!/usr/bin/env node
+/**
+ * OpenClaw CLI — Clara marketplace explorer for Claude Code.
+ * Uses claraid-sdk for all Ponder REST queries.
+ *
+ * Usage: node openclaw.mjs <command> [args] [--flags]
+ *
+ * Commands:
+ *   browse [--skill=X] [--status=open] [--limit=N]
+ *   show <address>
+ *   challenges [--skill=X] [--status=open] [--limit=N]
+ *   challenge <address>
+ *   leaderboard <challengeAddress> [--limit=N]
+ *   agent <id>
+ *   agent-address <address>
+ *   reputation <agentId>
+ *   find-agents [--skill=X] [--limit=N]
+ *   my-work <address>
+ *   stats
+ */
+
+import { ClaraClient, formatAddress, formatRawAmount, BOUNTY_ABI } from 'claraid-sdk';
+import { createWalletClient, createPublicClient, http, encodeFunctionData } from 'viem';
+import { base } from 'viem/chains';
+import { privateKeyToAccount } from 'viem/accounts';
+
+const client = new ClaraClient();
+
+// ── Wallet setup (optional — enables write operations) ──────────────────
+
+let writer = null;
+let walletAddress = null;
+
+const pk = process.env.OPENCLAW_PRIVATE_KEY;
+if (pk) {
+  const account = privateKeyToAccount(pk.startsWith('0x') ? pk : `0x${pk}`);
+  walletAddress = account.address;
+  const walletClient = createWalletClient({
+    account,
+    chain: base,
+    transport: http(),
+  });
+  writer = client.withWallet(walletClient);
+}
+
+function requireWriter(command) {
+  if (!writer) {
+    out({
+      error: `Write operation "${command}" requires OPENCLAW_PRIVATE_KEY to be set.`,
+      hint: 'Set OPENCLAW_PRIVATE_KEY env var with a hex private key for Base mainnet.',
+      alternative: 'Use --prepare to get raw transaction data without signing.',
+    });
+    process.exit(1);
+  }
+  return writer;
+}
+
+// ── Arg parsing ──────────────────────────────────────────────────────────
+
+const [, , command, ...rest] = process.argv;
+const prepareOnly = rest.includes('--prepare');
+
+function getFlag(name) {
+  const prefix = `--${name}=`;
+  const match = rest.find((a) => a.startsWith(prefix));
+  return match ? match.slice(prefix.length) : undefined;
+}
+
+function getPositional(index = 0) {
+  return rest.filter((a) => !a.startsWith('--'))[index];
+}
+
+// ── Token helpers ────────────────────────────────────────────────────────
+
+function tokenLabel(address, rawAmount) {
+  const formatted = formatRawAmount(String(rawAmount), address);
+  // formatRawAmount returns the formatted string with symbol, or raw amount if unknown token
+  return formatted;
+}
+
+function deadlineLabel(ts) {
+  if (!ts) return 'none';
+  const d = new Date(ts * 1000);
+  const now = Date.now();
+  const diff = ts * 1000 - now;
+  if (diff < 0) return `expired ${d.toLocaleDateString()}`;
+  const days = Math.floor(diff / 86400000);
+  if (days > 1) return `${days}d left (${d.toLocaleDateString()})`;
+  const hours = Math.floor(diff / 3600000);
+  return `${hours}h left`;
+}
+
+// ── Output helper ────────────────────────────────────────────────────────
+
+function out(data) {
+  console.log(JSON.stringify(data, null, 2));
+}
+
+// ── Commands ─────────────────────────────────────────────────────────────
+
+async function browse() {
+  const filters = {};
+  const skill = getFlag('skill');
+  const status = getFlag('status') || 'open';
+  const limit = parseInt(getFlag('limit') || '20', 10);
+  if (skill) filters.skill = skill;
+  if (status) filters.status = status;
+  if (limit) filters.limit = limit;
+
+  const bounties = await client.bounties.list(filters);
+
+  if (bounties.length === 0) {
+    out({ command: 'browse', filters, count: 0, bounties: [], message: 'No bounties found matching filters.' });
+    return;
+  }
+
+  const rows = bounties.map((b) => ({
+    address: b.bountyAddress,
+    reward: tokenLabel(b.token, b.amount),
+    status: b.status,
+    skills: b.skillTags,
+    deadline: deadlineLabel(b.deadline),
+    poster: formatAddress(b.poster),
+    hasClaimer: !!b.claimer,
+  }));
+
+  out({ command: 'browse', filters, count: rows.length, bounties: rows });
+}
+
+async function show() {
+  const addr = getPositional();
+  if (!addr) {
+    out({ error: 'Missing bounty address. Usage: show <address>' });
+    process.exit(1);
+  }
+
+  const b = await client.bounties.get(addr);
+  if (!b) {
+    out({ error: `Bounty not found: ${addr}` });
+    process.exit(1);
+  }
+
+  // Parse task metadata from URI if it's a data URI
+  let task = null;
+  if (b.taskURI?.startsWith('data:')) {
+    try {
+      const json = b.taskURI.split(',')[1];
+      task = JSON.parse(decodeURIComponent(json));
+    } catch {}
+  }
+
+  out({
+    command: 'show',
+    bounty: {
+      address: b.bountyAddress,
+      status: b.status,
+      reward: tokenLabel(b.token, b.amount),
+      token: b.token,
+      poster: b.poster,
+      deadline: deadlineLabel(b.deadline),
+      deadlineTs: b.deadline,
+      skills: b.skillTags,
+      claimer: b.claimer || null,
+      claimerAgentId: b.claimerAgentId || null,
+      proofURI: b.proofURI || null,
+      workerBond: b.workerBond || null,
+      posterBond: b.posterBond || null,
+      taskDescription: task?.description || task?.summary || null,
+      taskRaw: task,
+      createdTxHash: b.createdTxHash,
+    },
+  });
+}
+
+async function listChallenges() {
+  const filters = {};
+  const skill = getFlag('skill');
+  const status = getFlag('status') || 'open';
+  const limit = parseInt(getFlag('limit') || '20', 10);
+  if (skill) filters.skill = skill;
+  if (status) filters.status = status;
+  if (limit) filters.limit = limit;
+
+  const challenges = await client.challenges.list(filters);
+
+  if (challenges.length === 0) {
+    out({ command: 'challenges', filters, count: 0, challenges: [], message: 'No challenges found.' });
+    return;
+  }
+
+  const rows = challenges.map((c) => ({
+    address: c.challengeAddress,
+    prizePool: tokenLabel(c.token, c.prizePool),
+    status: c.status,
+    skills: c.skillTags,
+    deadline: deadlineLabel(c.deadline),
+    submissions: c.submissionCount,
+    winnerCount: c.winnerCount,
+    maxParticipants: c.maxParticipants,
+  }));
+
+  out({ command: 'challenges', filters, count: rows.length, challenges: rows });
+}
+
+async function showChallenge() {
+  const addr = getPositional();
+  if (!addr) {
+    out({ error: 'Missing challenge address. Usage: challenge <address>' });
+    process.exit(1);
+  }
+
+  const c = await client.challenges.get(addr);
+  if (!c) {
+    out({ error: `Challenge not found: ${addr}` });
+    process.exit(1);
+  }
+
+  // Parse challenge metadata
+  let meta = null;
+  if (c.challengeURI?.startsWith('data:')) {
+    try {
+      const json = c.challengeURI.split(',')[1];
+      meta = JSON.parse(decodeURIComponent(json));
+    } catch {}
+  }
+
+  const submissionList = Object.values(c.submissions || {}).map((s) => ({
+    submitter: formatAddress(s.submitter),
+    agentId: s.agentId,
+    score: s.score,
+    rank: s.rank,
+    submittedAt: s.submittedAt ? new Date(s.submittedAt * 1000).toISOString() : null,
+  }));
+
+  out({
+    command: 'challenge',
+    challenge: {
+      address: c.challengeAddress,
+      status: c.status,
+      prizePool: tokenLabel(c.token, c.prizePool),
+      token: c.token,
+      poster: c.poster,
+      evaluator: c.evaluator,
+      deadline: deadlineLabel(c.deadline),
+      scoringDeadline: deadlineLabel(c.scoringDeadline),
+      skills: c.skillTags,
+      submissionCount: c.submissionCount,
+      winnerCount: c.winnerCount,
+      maxParticipants: c.maxParticipants,
+      payoutBps: c.payoutBps,
+      winners: c.winners,
+      submissions: submissionList,
+      description: meta?.description || meta?.summary || null,
+      metaRaw: meta,
+      createdTxHash: c.createdTxHash,
+    },
+  });
+}
+
+async function leaderboard() {
+  const addr = getPositional();
+  if (!addr) {
+    out({ error: 'Missing challenge address. Usage: leaderboard <address>' });
+    process.exit(1);
+  }
+  const limit = parseInt(getFlag('limit') || '25', 10);
+
+  const entries = await client.challenges.leaderboard(addr, limit);
+  const rows = entries.map((s, i) => ({
+    rank: s.rank ?? i + 1,
+    submitter: formatAddress(s.submitter),
+    agentId: s.agentId,
+    score: s.score,
+  }));
+
+  out({ command: 'leaderboard', challenge: addr, count: rows.length, entries: rows });
+}
+
+async function showAgent() {
+  const id = getPositional();
+  if (!id) {
+    out({ error: 'Missing agent ID. Usage: agent <id>' });
+    process.exit(1);
+  }
+
+  const agent = await client.agents.get(parseInt(id, 10));
+  if (!agent) {
+    out({ error: `Agent not found: #${id}` });
+    process.exit(1);
+  }
+
+  out({
+    command: 'agent',
+    agent: {
+      id: agent.agentId,
+      name: agent.name,
+      owner: agent.owner,
+      skills: agent.skills,
+      description: agent.description || null,
+      reputation: {
+        count: agent.reputationCount ?? 0,
+        average: agent.reputationAvg ?? null,
+        sum: agent.reputationSum ?? 0,
+      },
+    },
+  });
+}
+
+async function showAgentByAddress() {
+  const addr = getPositional();
+  if (!addr) {
+    out({ error: 'Missing address. Usage: agent-address <address>' });
+    process.exit(1);
+  }
+
+  const agent = await client.agents.getByAddress(addr);
+  if (!agent) {
+    out({ error: `No agent registered at ${addr}` });
+    process.exit(1);
+  }
+
+  out({
+    command: 'agent',
+    agent: {
+      id: agent.agentId,
+      name: agent.name,
+      owner: agent.owner,
+      skills: agent.skills,
+      description: agent.description || null,
+      reputation: {
+        count: agent.reputationCount ?? 0,
+        average: agent.reputationAvg ?? null,
+        sum: agent.reputationSum ?? 0,
+      },
+    },
+  });
+}
+
+async function findAgents() {
+  const filters = {};
+  const skill = getFlag('skill');
+  const limit = parseInt(getFlag('limit') || '20', 10);
+  if (skill) filters.skill = skill;
+  if (limit) filters.limit = limit;
+
+  const agents = await client.agents.find(filters);
+  const rows = agents.map((a) => ({
+    id: a.agentId,
+    name: a.name,
+    skills: a.skills,
+    reputation: a.reputationAvg ?? null,
+    reputationCount: a.reputationCount ?? 0,
+  }));
+
+  out({ command: 'find-agents', filters, count: rows.length, agents: rows });
+}
+
+async function showReputation() {
+  const id = getPositional();
+  if (!id) {
+    out({ error: 'Missing agent ID. Usage: reputation <agentId>' });
+    process.exit(1);
+  }
+
+  const agentId = parseInt(id, 10);
+  const [summary, feedbacks] = await Promise.all([
+    client.reputation.summary(agentId),
+    client.reputation.feedbacks(agentId),
+  ]);
+
+  const feedbackRows = feedbacks.map((f) => ({
+    from: formatAddress(f.clientAddress),
+    value: f.value,
+    tags: [f.tag1, f.tag2].filter(Boolean),
+    revoked: f.revoked,
+  }));
+
+  out({
+    command: 'reputation',
+    agentId,
+    summary: summary
+      ? {
+          count: summary.count,
+          average: summary.averageRating,
+          total: summary.totalValue,
+        }
+      : null,
+    feedbacks: feedbackRows,
+  });
+}
+
+async function myWork() {
+  const addr = getPositional();
+  if (!addr) {
+    out({ error: 'Missing address. Usage: my-work <address>' });
+    process.exit(1);
+  }
+
+  // Fetch bounties where user is poster AND where user is claimer, in parallel
+  const [asPosted, asClaimed] = await Promise.all([
+    client.bounties.list({ poster: addr }),
+    client.bounties.list({ claimer: addr }),
+  ]);
+
+  const posted = asPosted.map((b) => ({
+    address: b.bountyAddress,
+    reward: tokenLabel(b.token, b.amount),
+    status: b.status,
+    skills: b.skillTags,
+    claimer: b.claimer ? formatAddress(b.claimer) : null,
+  }));
+
+  const claimed = asClaimed.map((b) => ({
+    address: b.bountyAddress,
+    reward: tokenLabel(b.token, b.amount),
+    status: b.status,
+    skills: b.skillTags,
+    poster: formatAddress(b.poster),
+  }));
+
+  out({
+    command: 'my-work',
+    address: addr,
+    posted: { count: posted.length, bounties: posted },
+    claimed: { count: claimed.length, bounties: claimed },
+  });
+}
+
+async function stats() {
+  const s = await client.stats();
+  out({ command: 'stats', ...s });
+}
+
+// ── Write Commands ───────────────────────────────────────────────────────
+
+async function claim() {
+  const bounty = getPositional(0);
+  const agentIdStr = getPositional(1) || getFlag('agent');
+  if (!bounty || !agentIdStr) {
+    out({ error: 'Usage: claim <bountyAddress> <agentId>' });
+    process.exit(1);
+  }
+  const agentId = parseInt(agentIdStr, 10);
+
+  if (prepareOnly) {
+    out({
+      command: 'claim',
+      mode: 'prepare',
+      transaction: {
+        to: bounty,
+        data: encodeFunctionData({ abi: BOUNTY_ABI, functionName: 'claim', args: [BigInt(agentId)] }),
+        value: '0',
+      },
+    });
+    return;
+  }
+
+  const w = requireWriter('claim');
+  const txHash = await w.bounty.claim({ bounty, agentId });
+  out({ command: 'claim', txHash, bounty, agentId });
+}
+
+async function submitWork() {
+  const bounty = getPositional(0);
+  const proofURI = getPositional(1) || getFlag('proof');
+  if (!bounty || !proofURI) {
+    out({ error: 'Usage: submit <bountyAddress> <proofURI>' });
+    process.exit(1);
+  }
+
+  if (prepareOnly) {
+    out({
+      command: 'submit',
+      mode: 'prepare',
+      transaction: {
+        to: bounty,
+        data: encodeFunctionData({ abi: BOUNTY_ABI, functionName: 'submitWork', args: [proofURI] }),
+        value: '0',
+      },
+    });
+    return;
+  }
+
+  const w = requireWriter('submit');
+  const txHash = await w.bounty.submit({ bounty, proofURI });
+  out({ command: 'submit', txHash, bounty });
+}
+
+async function approveBounty() {
+  const bounty = getPositional(0);
+  if (!bounty) {
+    out({ error: 'Usage: approve <bountyAddress>' });
+    process.exit(1);
+  }
+
+  if (prepareOnly) {
+    out({
+      command: 'approve',
+      mode: 'prepare',
+      transaction: {
+        to: bounty,
+        data: encodeFunctionData({ abi: BOUNTY_ABI, functionName: 'approve' }),
+        value: '0',
+      },
+    });
+    return;
+  }
+
+  const w = requireWriter('approve');
+  const txHash = await w.bounty.approve({ bounty });
+  out({ command: 'approve', txHash, bounty });
+}
+
+async function rejectBounty() {
+  const bounty = getPositional(0);
+  if (!bounty) {
+    out({ error: 'Usage: reject <bountyAddress>' });
+    process.exit(1);
+  }
+
+  if (prepareOnly) {
+    out({
+      command: 'reject',
+      mode: 'prepare',
+      transaction: {
+        to: bounty,
+        data: encodeFunctionData({ abi: BOUNTY_ABI, functionName: 'reject' }),
+        value: '0',
+      },
+    });
+    return;
+  }
+
+  const w = requireWriter('reject');
+  const txHash = await w.bounty.reject({ bounty });
+  out({ command: 'reject', txHash, bounty });
+}
+
+async function cancelBounty() {
+  const bounty = getPositional(0);
+  if (!bounty) {
+    out({ error: 'Usage: cancel <bountyAddress>' });
+    process.exit(1);
+  }
+
+  if (prepareOnly) {
+    out({
+      command: 'cancel',
+      mode: 'prepare',
+      transaction: {
+        to: bounty,
+        data: encodeFunctionData({ abi: BOUNTY_ABI, functionName: 'cancel' }),
+        value: '0',
+      },
+    });
+    return;
+  }
+
+  const w = requireWriter('cancel');
+  const txHash = await w.bounty.cancel({ bounty });
+  out({ command: 'cancel', txHash, bounty });
+}
+
+async function walletInfo() {
+  if (!walletAddress) {
+    out({
+      command: 'wallet',
+      configured: false,
+      message: 'No wallet configured. Set OPENCLAW_PRIVATE_KEY to enable write operations.',
+    });
+    return;
+  }
+
+  const publicClient = createPublicClient({ chain: base, transport: http() });
+  const balance = await publicClient.getBalance({ address: walletAddress });
+  const ethBalance = Number(balance) / 1e18;
+
+  // Check if this address has a registered agent
+  const agent = await client.agents.getByAddress(walletAddress);
+
+  out({
+    command: 'wallet',
+    configured: true,
+    address: walletAddress,
+    ethBalance: `${ethBalance.toFixed(6)} ETH`,
+    agent: agent
+      ? { id: agent.agentId, name: agent.name, skills: agent.skills }
+      : null,
+  });
+}
+
+// ── Router ───────────────────────────────────────────────────────────────
+
+const commands = {
+  // Reads
+  browse,
+  show,
+  challenges: listChallenges,
+  challenge: showChallenge,
+  leaderboard,
+  agent: showAgent,
+  'agent-address': showAgentByAddress,
+  'find-agents': findAgents,
+  reputation: showReputation,
+  'my-work': myWork,
+  stats,
+  // Writes
+  claim,
+  submit: submitWork,
+  approve: approveBounty,
+  reject: rejectBounty,
+  cancel: cancelBounty,
+  wallet: walletInfo,
+};
+
+async function main() {
+  if (!command || command === 'help') {
+    out({
+      commands: Object.keys(commands),
+      usage: 'node openclaw.mjs <command> [args] [--flags]',
+      examples: [
+        'browse --skill=typescript --limit=5',
+        'show 0x...',
+        'challenges --status=open',
+        'challenge 0x...',
+        'leaderboard 0x... --limit=10',
+        'agent 42',
+        'agent-address 0x...',
+        'find-agents --skill=solidity',
+        'reputation 42',
+        'my-work 0x...',
+        'stats',
+        'wallet',
+        'claim 0x<bounty> 14448',
+        'submit 0x<bounty> ipfs://proof',
+        'approve 0x<bounty>',
+        'reject 0x<bounty>',
+        'cancel 0x<bounty>',
+        'claim 0x<bounty> 42 --prepare  (output raw tx, no signing)',
+      ],
+    });
+    return;
+  }
+
+  const handler = commands[command];
+  if (!handler) {
+    console.error(`Unknown command: ${command}`);
+    console.error(`Available: ${Object.keys(commands).join(', ')}`);
+    process.exit(1);
+  }
+
+  try {
+    await handler();
+  } catch (err) {
+    out({ error: err.message, type: err.constructor.name });
+    process.exit(1);
+  }
+}
+
+main();

--- a/clara/scripts/package.json
+++ b/clara/scripts/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "openclaw-skill",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "claraid-sdk": "^0.1.0",
+    "viem": "^2.45.3"
+  }
+}

--- a/clara/scripts/setup.sh
+++ b/clara/scripts/setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Install dependencies for the Clara OpenClaw skill
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "Installing claraid-sdk..."
+npm install
+echo "Done. Run: node $SCRIPT_DIR/openclaw.mjs help"


### PR DESCRIPTION
## Summary

- Adds **Clara** — a skill for browsing and interacting with the Clara bounty marketplace on Base mainnet
- Powered by [`claraid-sdk`](https://www.npmjs.com/package/claraid-sdk), a lightweight TypeScript SDK for Clara smart contracts and the Ponder indexer
- **11 read commands** (browse bounties, challenges, agents, reputation, leaderboard, stats) — no wallet needed
- **5 write commands** (claim, submit, approve, reject, cancel) — via `OPENCLAW_PRIVATE_KEY` or `--prepare` for raw tx output
- All reads go through the public Ponder indexer REST API (no RPC needed)
- All writes use viem ABI encoding for full type safety

## Files

| File | Purpose |
|------|---------|
| `clara/SKILL.md` | Skill definition with triggers, commands, and docs |
| `clara/scripts/openclaw.mjs` | Node.js CLI backend (660 lines) |
| `clara/scripts/package.json` | Dependencies: `claraid-sdk`, `viem` |
| `clara/scripts/setup.sh` | Install helper |
| `clara/references/sdk-api.md` | SDK API reference for LLM context |

## Test plan

- [x] All 11 read commands tested against live Ponder indexer
- [x] Write commands verified with `--prepare` flag (outputs raw tx data)
- [x] `wallet` command shows address + ETH balance + agent profile
- [x] Error handling for missing args, unknown commands, wallet not configured
- [ ] End-to-end write test with funded wallet on Base

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new CLI code that can sign and submit onchain transactions when `OPENCLAW_PRIVATE_KEY` is configured; mistakes could lead to unintended transactions. Otherwise changes are additive and isolated to a new `clara/` skill directory.
> 
> **Overview**
> Adds a new `clara` skill for browsing and interacting with the Clara bounty marketplace on Base, including end-user docs in `SKILL.md` and an SDK API reference.
> 
> Introduces the `scripts/openclaw.mjs` Node CLI that supports read-only marketplace queries via `claraid-sdk` and optional write operations (`claim`, `submit`, `approve`, `reject`, `cancel`) via `OPENCLAW_PRIVATE_KEY` or `--prepare` to output raw `{to,data,value}` transactions, plus a `wallet` info command.
> 
> Adds a minimal `scripts/package.json` (deps: `claraid-sdk`, `viem`) and `scripts/setup.sh` installer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d6c4d60743174efc1d5c2d43b408af80e84cc88b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->