### PR TITLE
feat(bankr): add headless email login for agents

### DIFF
--- a/bankr/SKILL.md
+++ b/bankr/SKILL.md
@@ -77,7 +77,7 @@ bankr login email <user-email>
 
 **Step 3 — Before completing login, ask the user about their preferences:**
 
-1. **Accept Terms of Service?** — Required for new users. Link: https://bankr.bot/terms
+1. **Accept Terms of Service** — Present the [Terms of Service](https://bankr.bot/terms) link and confirm the user agrees. Required for new users — do not pass `--accept-terms` unless the user has explicitly confirmed.
 2. **Read-only or read-write API key?**
    - **Read-only** (default) — portfolio, balances, prices, research only
    - **Read-write** (`--read-write`) — enables swaps, transfers, orders, token launches, leverage, Polymarket bets


### PR DESCRIPTION
## Summary

- Updates bankr SKILL.md with headless two-step email OTP login as the primary setup method for agents
- Replaces interactive login guidance with scriptable `bankr login email` flow
- Adds detailed option descriptions for `--code`, `--accept-terms`, `--key-name`, `--read-write`, `--llm`

## Related

- Bankr CLI PR: https://github.com/BankrBot/bankr/pull/828

## Test plan

- [ ] Verify SKILL.md renders correctly in OpenClaw
- [ ] Confirm headless login commands match CLI implementation
- [ ] Verify option descriptions are accurate and complete

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; risk is limited to potential user confusion if the documented CLI flags/flows don’t exactly match the implementation.
> 
> **Overview**
> Updates `bankr/SKILL.md` to promote a **headless two-step email OTP login** (via `bankr login email`) as the primary way for agents to create wallets, accept terms, and generate API keys without a browser.
> 
> Refines CLI setup and command reference docs by adding/clarifying login flags (e.g. `--code`, `--accept-terms`, `--key-name`, `--read-write`, `--llm`), distinguishing *login with existing API key* vs *URL-based key creation*, and updating wording around the Bankr Terminal flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab4d23dd66b19872cda003074162047cf65beeb9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->