### PR TITLE
Add Shulam compliance screening and trust scoring skills

### DIFF
--- a/shulam/compliance-screening/SKILL.md
+++ b/shulam/compliance-screening/SKILL.md
@@ -1,0 +1,45 @@
+# Compliance Screening
+
+OFAC/SDN wallet screening for autonomous agents via the Shulam CaaS API.
+
+## Capabilities
+
+- Screen Ethereum wallet addresses against OFAC SDN (Specially Designated Nationals) and other sanctions lists
+- Batch screening — screen up to 50 addresses in a single call
+- Real-time status: `clear` (no match), `held` (partial match, under review), `blocked` (confirmed match)
+- Automatic exponential backoff on rate limits (429)
+- Zero external dependencies — uses raw `fetch` only
+
+## Usage Examples
+
+```typescript
+import { screenWallet, screenWallets } from './scripts/index.js';
+
+// Single address screening
+const result = await screenWallet('0x1234...');
+console.log(result.status); // 'clear' | 'held' | 'blocked'
+console.log(result.matchScore); // 0.0 - 1.0
+
+// Batch screening (up to 50)
+const results = await screenWallets(['0x1234...', '0x5678...']);
+results.forEach(r => console.log(`${r.status}: score=${r.matchScore}`));
+```
+
+**Response shape:**
+```json
+{
+  "status": "clear",
+  "matchScore": 0.0,
+  "screenedAt": "2026-02-19T12:00:00.000Z",
+  "listsChecked": ["OFAC_SDN"],
+  "holdId": null
+}
+```
+
+## Requirements
+
+- **`SHULAM_API_KEY`** (required) — Get a free key (100 screens/day) at [api.shulam.xyz/register](https://api.shulam.xyz/register)
+- **`SHULAM_API_URL`** (optional) — API base URL, defaults to `https://api.shulam.xyz`
+- Node.js 18+ (for native `fetch`)
+
+Powered by [Shulam](https://shulam.xyz) — enterprise-grade x402 payment facilitation with built-in compliance.

--- a/shulam/compliance-screening/scripts/index.ts
+++ b/shulam/compliance-screening/scripts/index.ts
@@ -1,0 +1,160 @@
+/**
+ * Compliance Screening Skill — OFAC/SDN wallet screening via Shulam CaaS API.
+ *
+ * Zero external dependencies. Uses raw `fetch` only.
+ * Status mapping follows ADR-23: clear | held | blocked (NEVER "flagged").
+ */
+
+// ── Types ──────────────────────────────────────────────────────
+
+export type ComplianceStatus = 'clear' | 'held' | 'blocked';
+
+export interface ScreeningResult {
+  status: ComplianceStatus;
+  matchScore: number;
+  screenedAt: string;
+  listsChecked: string[];
+  holdId: string | null;
+}
+
+// ── Config ─────────────────────────────────────────────────────
+
+function getApiKey(): string {
+  const key = process.env.SHULAM_API_KEY;
+  if (!key) {
+    throw new Error(
+      'SHULAM_API_KEY not set. Get a free key at https://api.shulam.xyz/register',
+    );
+  }
+  return key;
+}
+
+function getApiUrl(): string {
+  return process.env.SHULAM_API_URL ?? 'https://api.shulam.xyz';
+}
+
+// ── Status mapping ─────────────────────────────────────────────
+
+const STATUS_MAP: Record<string, ComplianceStatus> = {
+  clear: 'clear',
+  held: 'held',
+  blocked: 'blocked',
+  pending: 'held',
+  error: 'held',
+};
+
+function mapStatus(raw: string): ComplianceStatus {
+  return STATUS_MAP[raw] ?? 'held';
+}
+
+// ── Backoff ────────────────────────────────────────────────────
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchWithBackoff(
+  url: string,
+  init: RequestInit,
+  maxRetries = 3,
+): Promise<Response> {
+  let lastError: Error | undefined;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const response = await fetch(url, init);
+
+      if (response.status === 429) {
+        const retryAfter = response.headers.get('Retry-After');
+        const delayMs = retryAfter
+          ? parseInt(retryAfter, 10) * 1000
+          : Math.min(1000 * 2 ** attempt, 30_000);
+        await sleep(delayMs);
+        continue;
+      }
+
+      return response;
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+      if (attempt < maxRetries) {
+        await sleep(Math.min(1000 * 2 ** attempt, 30_000));
+      }
+    }
+  }
+
+  throw lastError ?? new Error('Request failed after retries');
+}
+
+// ── Public API ─────────────────────────────────────────────────
+
+/**
+ * Screen a single wallet address against OFAC SDN and sanctions lists.
+ */
+export async function screenWallet(address: string): Promise<ScreeningResult> {
+  const apiKey = getApiKey();
+  const baseUrl = getApiUrl();
+
+  const response = await fetchWithBackoff(
+    `${baseUrl}/v1/compliance/screen`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': apiKey,
+      },
+      body: JSON.stringify({ address }),
+    },
+  );
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Screening failed (${response.status}): ${body}`);
+  }
+
+  const data = await response.json() as Record<string, unknown>;
+
+  return {
+    status: mapStatus(data.status as string),
+    matchScore: (data.matchScore as number) ?? 0,
+    screenedAt: (data.screenedAt as string) ?? new Date().toISOString(),
+    listsChecked: (data.listsChecked as string[]) ?? ['OFAC_SDN'],
+    holdId: (data.holdId as string) ?? null,
+  };
+}
+
+/**
+ * Screen multiple wallet addresses in a single batch.
+ */
+export async function screenWallets(
+  addresses: string[],
+): Promise<ScreeningResult[]> {
+  const apiKey = getApiKey();
+  const baseUrl = getApiUrl();
+
+  const response = await fetchWithBackoff(
+    `${baseUrl}/v1/compliance/screen/batch`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': apiKey,
+      },
+      body: JSON.stringify({ addresses }),
+    },
+  );
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Batch screening failed (${response.status}): ${body}`);
+  }
+
+  const data = await response.json() as { results: Array<Record<string, unknown>> };
+
+  return data.results.map((r) => ({
+    status: mapStatus(r.status as string),
+    matchScore: (r.matchScore as number) ?? 0,
+    screenedAt: (r.screenedAt as string) ?? new Date().toISOString(),
+    listsChecked: (r.listsChecked as string[]) ?? ['OFAC_SDN'],
+    holdId: (r.holdId as string) ?? null,
+  }));
+}

--- a/shulam/trust-scoring/SKILL.md
+++ b/shulam/trust-scoring/SKILL.md
@@ -1,0 +1,49 @@
+# Trust Scoring
+
+Agent trust scores and wallet reputation via the Shulam Agent Passport API.
+
+## Capabilities
+
+- Retrieve trust scores (0-100) and tier classification for any wallet address
+- 6-dimension breakdown: volume, reliability, compliance, diversity, longevity, stability
+- Configurable minimum trust threshold via `MIN_TRUST_SCORE`
+- Combined compliance + trust check in a single call (`combinedCheck`)
+- 60-second in-memory cache to reduce API calls
+- Zero external dependencies — uses raw `fetch` only
+
+## Usage Examples
+
+```typescript
+import { getTrustScore, combinedCheck } from './scripts/index.js';
+
+// Trust score lookup
+const score = await getTrustScore('0x1234...');
+console.log(score.score);     // 72
+console.log(score.tier);      // 'trusted'
+console.log(score.breakdown); // { volume: 80, reliability: 75, ... }
+
+// Combined: compliance screen + trust score (parallel)
+const check = await combinedCheck('0x1234...');
+console.log(check.compliance.status); // 'clear'
+console.log(check.trust.score);       // 72
+console.log(check.trust.meetsThreshold); // true
+```
+
+**Tier classification:**
+
+| Tier | Score Range | Meaning |
+|------|------------|---------|
+| `unknown` | — | No transaction history |
+| `new` | 0-25 | Recently active |
+| `established` | 26-50 | Consistent history |
+| `trusted` | 51-75 | Strong track record |
+| `exemplary` | 76-100 | Top-tier reputation |
+
+## Requirements
+
+- **`SHULAM_API_KEY`** (required) — Get a free key (100 lookups/day) at [api.shulam.xyz/register](https://api.shulam.xyz/register)
+- **`SHULAM_API_URL`** (optional) — API base URL, defaults to `https://api.shulam.xyz`
+- **`MIN_TRUST_SCORE`** (optional) — Minimum trust score threshold (0-100, default: 0)
+- Node.js 18+ (for native `fetch`)
+
+Powered by [Shulam](https://shulam.xyz) — enterprise-grade x402 payment facilitation with built-in compliance.

--- a/shulam/trust-scoring/scripts/index.ts
+++ b/shulam/trust-scoring/scripts/index.ts
@@ -1,0 +1,227 @@
+/**
+ * Trust Scoring Skill — Wallet trust scores via Shulam Agent Passport API.
+ *
+ * Zero external dependencies. Uses raw `fetch` only.
+ * Field mapping mirrors packages/agent-skills/src/handlers/trust-score.ts.
+ */
+
+// ── Types ──────────────────────────────────────────────────────
+
+export type TrustTier = 'unknown' | 'new' | 'established' | 'trusted' | 'exemplary';
+
+export interface TrustBreakdown {
+  volume: number;
+  reliability: number;
+  compliance: number;
+  diversity: number;
+  longevity: number;
+  stability: number;
+}
+
+export interface TrustScoreResult {
+  wallet: string;
+  score: number;
+  tier: TrustTier;
+  breakdown: TrustBreakdown;
+  calculatedAt: string;
+  meetsThreshold: boolean;
+}
+
+export type ComplianceStatus = 'clear' | 'held' | 'blocked';
+
+export interface ScreeningResult {
+  status: ComplianceStatus;
+  matchScore: number;
+  screenedAt: string;
+}
+
+export interface CombinedCheckResult {
+  compliance: ScreeningResult;
+  trust: TrustScoreResult;
+}
+
+// ── Config ─────────────────────────────────────────────────────
+
+function getApiKey(): string {
+  const key = process.env.SHULAM_API_KEY;
+  if (!key) {
+    throw new Error(
+      'SHULAM_API_KEY not set. Get a free key at https://api.shulam.xyz/register',
+    );
+  }
+  return key;
+}
+
+function getApiUrl(): string {
+  return process.env.SHULAM_API_URL ?? 'https://api.shulam.xyz';
+}
+
+function getMinTrustScore(): number {
+  const val = process.env.MIN_TRUST_SCORE;
+  if (!val) return 0;
+  const parsed = parseInt(val, 10);
+  return Number.isNaN(parsed) ? 0 : Math.max(0, Math.min(100, parsed));
+}
+
+// ── Cache ──────────────────────────────────────────────────────
+
+interface CacheEntry {
+  result: TrustScoreResult;
+  cachedAt: number;
+}
+
+const CACHE_TTL_MS = 60_000; // 60 seconds
+const cache = new Map<string, CacheEntry>();
+
+function getCached(address: string): TrustScoreResult | null {
+  const entry = cache.get(address.toLowerCase());
+  if (!entry) return null;
+  if (Date.now() - entry.cachedAt > CACHE_TTL_MS) {
+    cache.delete(address.toLowerCase());
+    return null;
+  }
+  return entry.result;
+}
+
+function setCache(address: string, result: TrustScoreResult): void {
+  cache.set(address.toLowerCase(), { result, cachedAt: Date.now() });
+}
+
+/** Clear the cache (for testing). */
+export function clearCache(): void {
+  cache.clear();
+}
+
+// ── Backoff ────────────────────────────────────────────────────
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function fetchWithBackoff(
+  url: string,
+  init: RequestInit,
+  maxRetries = 3,
+): Promise<Response> {
+  let lastError: Error | undefined;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const response = await fetch(url, init);
+
+      if (response.status === 429) {
+        const retryAfter = response.headers.get('Retry-After');
+        const delayMs = retryAfter
+          ? parseInt(retryAfter, 10) * 1000
+          : Math.min(1000 * 2 ** attempt, 30_000);
+        await sleep(delayMs);
+        continue;
+      }
+
+      return response;
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err));
+      if (attempt < maxRetries) {
+        await sleep(Math.min(1000 * 2 ** attempt, 30_000));
+      }
+    }
+  }
+
+  throw lastError ?? new Error('Request failed after retries');
+}
+
+// ── Status mapping (for combinedCheck) ─────────────────────────
+
+const STATUS_MAP: Record<string, ComplianceStatus> = {
+  clear: 'clear',
+  held: 'held',
+  blocked: 'blocked',
+  pending: 'held',
+  error: 'held',
+};
+
+// ── Public API ─────────────────────────────────────────────────
+
+/**
+ * Get the trust score for a wallet address.
+ * Results are cached for 60 seconds.
+ */
+export async function getTrustScore(address: string): Promise<TrustScoreResult> {
+  const cached = getCached(address);
+  if (cached) return cached;
+
+  const apiKey = getApiKey();
+  const baseUrl = getApiUrl();
+  const minScore = getMinTrustScore();
+
+  const response = await fetchWithBackoff(
+    `${baseUrl}/v1/trust/score/${encodeURIComponent(address)}`,
+    {
+      method: 'GET',
+      headers: {
+        'X-API-Key': apiKey,
+      },
+    },
+  );
+
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Trust score lookup failed (${response.status}): ${body}`);
+  }
+
+  const data = await response.json() as Record<string, unknown>;
+  const passport = (data.passport ?? data) as Record<string, unknown>;
+  const breakdownRaw = (passport.breakdown ?? {}) as Record<string, number>;
+
+  const result: TrustScoreResult = {
+    wallet: address,
+    score: (passport.trustScore as number) ?? 0,
+    tier: ((passport.trustTier as string) ?? 'unknown') as TrustTier,
+    breakdown: {
+      volume: breakdownRaw.volume ?? 0,
+      reliability: breakdownRaw.reliability ?? 0,
+      compliance: breakdownRaw.compliance ?? 0,
+      diversity: breakdownRaw.diversity ?? 0,
+      longevity: breakdownRaw.longevity ?? 0,
+      stability: breakdownRaw.stability ?? 0,
+    },
+    calculatedAt: (passport.lastSeen as string) ?? new Date().toISOString(),
+    meetsThreshold: ((passport.trustScore as number) ?? 0) >= minScore,
+  };
+
+  setCache(address, result);
+  return result;
+}
+
+/**
+ * Combined check: run compliance screening and trust scoring in parallel.
+ */
+export async function combinedCheck(address: string): Promise<CombinedCheckResult> {
+  const apiKey = getApiKey();
+  const baseUrl = getApiUrl();
+
+  const [screenResponse, trustResult] = await Promise.all([
+    fetchWithBackoff(`${baseUrl}/v1/compliance/screen`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-API-Key': apiKey },
+      body: JSON.stringify({ address }),
+    }),
+    getTrustScore(address),
+  ]);
+
+  if (!screenResponse.ok) {
+    const body = await screenResponse.text();
+    throw new Error(`Screening failed (${screenResponse.status}): ${body}`);
+  }
+
+  const screenData = await screenResponse.json() as Record<string, unknown>;
+
+  return {
+    compliance: {
+      status: STATUS_MAP[screenData.status as string] ?? 'held',
+      matchScore: (screenData.matchScore as number) ?? 0,
+      screenedAt: (screenData.screenedAt as string) ?? new Date().toISOString(),
+    },
+    trust: trustResult,
+  };
+}


### PR DESCRIPTION
## Summary

- **Compliance Screening** — OFAC/SDN wallet screening via Shulam CaaS API. Returns `clear`, `held`, or `blocked` status with match scores.
- **Trust Scoring** — Wallet trust scores (0-100) with 6-dimension breakdown and tier classification via Shulam Agent Passport API.

Both skills use zero dependencies (raw `fetch`), include exponential backoff on rate limits, and are free for 100 requests/day.

## Test plan

- [x] Verified SKILL.md follows contributing guide format (Capabilities, Usage Examples, Requirements)
- [x] Scripts tested against Shulam API (clear/held/blocked mapping confirmed)
- [x] 20 unit tests passing in source repo
- [ ] Manual review of SKILL.md content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new network-facing skills that depend on external API behavior and environment configuration; failures or schema changes could impact agent flows, but changes are additive and isolated to new modules.
> 
> **Overview**
> Adds a new `shulam` provider with two installable skills: **Compliance Screening** (single + batch wallet screening via Shulam CaaS, returning `clear`/`held`/`blocked` with match metadata) and **Trust Scoring** (wallet trust score lookup with tier + breakdown, plus a `combinedCheck` that runs trust + compliance in parallel).
> 
> Both skills are implemented as dependency-free TypeScript modules using raw `fetch`, include exponential backoff handling for `429` responses, and document required env vars (`SHULAM_API_KEY`, optional `SHULAM_API_URL`, plus `MIN_TRUST_SCORE`); trust scoring also adds a 60s in-memory cache with a `clearCache` helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fb9ac3c814befe0549ba145db123a20f9ed392ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->