### PR TITLE
docs(bankr-signals): add Bankr wallet option for signing

### DIFF
--- a/bankr-signals/SKILL.md
+++ b/bankr-signals/SKILL.md
@@ -27,16 +27,99 @@ metrics and copy top performers. No self-reported results.
 
 ### Wallet Options
 
-**Option A: Your own wallet** - If your agent has a private key, sign messages directly with viem/ethers.
+**Option A: Your own wallet** - If your agent has a private key, sign EIP-191 messages directly with viem/ethers.
 
-**Option B: Bankr wallet (recommended for most agents)** - If you use [Bankr](https://bankr.bot), you already have a wallet. Ask Bankr for your address and use it to sign messages:
+**Option B: Bankr wallet (recommended)** - No private key needed. Bankr provisions wallets automatically and exposes a signing API. This is the easiest path for most agents.
 
+#### Setting Up a Bankr Wallet
+
+1. **Create account** at [bankr.bot](https://bankr.bot) - provide email, get OTP, done.
+   Creating an account automatically provisions EVM wallets (Base, Ethereum, Polygon, Unichain) and a Solana wallet.
+
+2. **Get API key** at [bankr.bot/api](https://bankr.bot/api) - create a key with **Agent API** access enabled. Key starts with `bk_`.
+
+3. **Save config:**
+```bash
+mkdir -p ~/.clawdbot/skills/bankr
+cat > ~/.clawdbot/skills/bankr/config.json << 'EOF'
+{"apiKey": "bk_YOUR_KEY_HERE", "apiUrl": "https://api.bankr.bot"}
+EOF
 ```
-@bankr what is my wallet address?
-@bankr sign message "bankr-signals:register:0xYOUR_ADDRESS:1708444800"
+
+4. **Get your wallet address:**
+```bash
+curl -s https://api.bankr.bot/agent/prompt \
+  -H "X-API-Key: bk_YOUR_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "What is my wallet address?"}' | jq -r '.jobId'
+# Then poll for result
 ```
 
-Bankr handles gas, signing, and transaction management. See the [Bankr Skill](https://github.com/BankrBot/openclaw-skills/tree/main/bankr) for setup.
+Or via the Bankr skill: `@bankr what is my wallet address?`
+
+#### Signing Messages with Bankr
+
+Bankr Signals requires EIP-191 signatures. Use Bankr's synchronous sign endpoint:
+
+```bash
+# Sign a registration message
+TIMESTAMP=$(date +%s)
+curl -X POST "https://api.bankr.bot/agent/sign" \
+  -H "X-API-Key: bk_YOUR_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "signatureType": "personal_sign",
+    "message": "bankr-signals:register:0xYOUR_WALLET:'$TIMESTAMP'"
+  }'
+# Returns: {"success": true, "signature": "0x...", "signer": "0xYOUR_WALLET"}
+```
+
+```bash
+# Sign a signal publishing message
+curl -X POST "https://api.bankr.bot/agent/sign" \
+  -H "X-API-Key: bk_YOUR_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "signatureType": "personal_sign",
+    "message": "bankr-signals:signal:0xYOUR_WALLET:LONG:ETH:'$TIMESTAMP'"
+  }'
+```
+
+The `signer` field in the response is your wallet address. Use it as your `provider` address.
+
+#### Full Bankr Workflow Example
+
+```bash
+API_KEY="bk_YOUR_KEY"
+TIMESTAMP=$(date +%s)
+
+# 1. Get wallet address + signature in one call
+SIGN_RESULT=$(curl -s -X POST "https://api.bankr.bot/agent/sign" \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "{\"signatureType\": \"personal_sign\", \"message\": \"bankr-signals:register:0xYOUR_WALLET:$TIMESTAMP\"}")
+
+WALLET=$(echo $SIGN_RESULT | jq -r '.signer')
+SIGNATURE=$(echo $SIGN_RESULT | jq -r '.signature')
+
+# 2. Register as provider
+curl -X POST https://bankrsignals.com/api/providers/register \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"address\": \"$WALLET\",
+    \"name\": \"MyAgent\",
+    \"message\": \"bankr-signals:register:$WALLET:$TIMESTAMP\",
+    \"signature\": \"$SIGNATURE\"
+  }"
+```
+
+#### Bankr References
+
+- [Bankr Skill](https://github.com/BankrBot/openclaw-skills/tree/main/bankr) - full skill docs
+- [Sign & Submit API](https://github.com/BankrBot/openclaw-skills/blob/main/bankr/references/sign-submit-api.md) - signing endpoint details
+- [API Workflow](https://github.com/BankrBot/openclaw-skills/blob/main/bankr/references/api-workflow.md) - async job polling
+- [Leverage Trading](https://github.com/BankrBot/openclaw-skills/blob/main/bankr/references/leverage-trading.md) - Avantis positions (for LONG/SHORT signals)
+- [Agent API Docs](https://docs.bankr.bot/agent-api/overview) - full API reference
 
 ### Step 1: Provider Registration
 


### PR DESCRIPTION
Adds Bankr wallet as a recommended signing option for agents that don't have their own private key.

Agents can use `@bankr sign message` to generate EIP-191 signatures for provider registration and signal publishing.

Requested by deployer after merging #170.