### PR TITLE
Add ENS agent identity skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Dependencies
+node_modules/
+
 # Skill user config (contains API keys)
 config.json
 

--- a/ens-agent-identity/SKILL.md
+++ b/ens-agent-identity/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: ens-agent-identity
+description: Give Bankr agents ENS-based identity with human-readable names, structured metadata, and on-chain verification. Use when the user wants to register an agent name, set agent text records, verify agent identity via ENSIP-25, resolve agent metadata, or make their agent discoverable via ENS.
+---
+
+# ENS Agent Identity
+
+Give Bankr agents a full identity layer using ENS subnames, structured metadata via text records, and on-chain verification via ENSIP-25 + ERC-8004.
+
+An ENS agent identity provides:
+- **Human-readable name**: `alpha-go.bankr.eth` instead of `0x579b...9105`
+- **Structured metadata**: Capabilities, chains, type, version — all discoverable via ENS resolution
+- **On-chain verification**: ENSIP-25 links the ENS name to an ERC-8004 registry entry
+- **Cross-platform portability**: Any ENS client can resolve and verify the agent
+
+## Requirements
+
+### Required: Bankr CLI
+
+This skill requires the **Bankr CLI** for transaction signing:
+
+```bash
+bun install -g @bankr/cli
+bankr login
+```
+
+### Required: NameStone API Key
+
+Agent subnames are managed via NameStone (offchain ENS subname service). Obtain a free API key via SIWE at [namestone.com](https://namestone.com).
+
+```bash
+export NAMESTONE_API_KEY="your-api-key"
+```
+
+### Required: Node.js + viem
+
+Scripts use Node.js with `viem` for ENS resolution and ABI encoding. Install in a local project directory:
+
+```bash
+npm init -y && npm install viem
+```
+
+## Quick Start
+
+```bash
+# Register an agent and set metadata
+./scripts/set-agent-records.sh alpha-go trading-bot "swap,bridge,limit-order"
+
+# Resolve an agent's ENS name and metadata
+./scripts/resolve-agent.sh alpha-go.bankr.eth
+
+# Verify ENSIP-25 link between ENS name and ERC-8004 identity
+./scripts/verify-agent-registration.sh alpha-go.bankr.eth 42
+```
+
+## Agent Text Record Schema
+
+Every Bankr agent stores structured metadata as ENS text records under the `agent:*` namespace:
+
+| Text Record | Purpose | Example |
+|---|---|---|
+| `agent:type` | Agent classification | `trading-bot`, `portfolio-manager`, `token-launcher` |
+| `agent:capabilities` | Comma-separated capabilities | `swap,bridge,limit-order,dca` |
+| `agent:chains` | Supported chains | `base,ethereum,polygon` |
+| `agent:a2a` | Agent-to-Agent API endpoint | `https://api.bankr.bot/agent/xyz` |
+| `agent:version` | Agent version | `2.1.0` |
+| `agent:creator` | Creator's ENS name | `estmcmxci.eth` |
+| `agent:token` | Deployed token address | `0x842cfeb...` |
+| `agent:delegation` | Parent agent delegation | `treasury.bankr.eth` |
+| `agent:policy` | Access policy | `read-only`, `full-access`, `scoped` |
+| `agent:mode` | Operating mode | `autonomous`, `supervised` |
+| `agent:chainId` | Primary chain ID | `8453` |
+
+See `references/agent-text-record-schema.md` for the full schema specification.
+
+## ENSIP-25 Verification
+
+ENSIP-25 links an ENS name to an ERC-8004 registry entry via a parameterized text record:
+
+```
+agent-registration[<registry>][<agentId>] = "1"
+```
+
+This allows any client to verify that the ENS name owner endorses the association with a specific on-chain agent identity. See `references/ensip-25-verification.md` for details.
+
+## Architecture
+
+```
+                    resolve name
+User / Agent  ──────────────────>  ENS Name
+                                   (agent.bankr.eth)
+                                        |
+              +--------------+----------+-----------+--------------+
+              v              v          v           v              v
+        Wallet Address  Text Records  ENSIP-25   ERC-8004 NFT  Reputation
+        (addr record)   (agent:*)     Verification (Identity)  (ERC-8004)
+```
+
+## Namespace
+
+**Parent domain**: Configurable via `BANKR_ENS_DOMAIN` env var (default: `bankr.eth`)
+
+- Any `.eth` domain onboarded to NameStone can be used as the parent namespace
+- Subnames registered via NameStone API (gasless, offchain)
+- Universal resolution from any ENS client on any chain
+- Resolver: NameStone Hybrid Resolver (`0xA87361C4E58B619c390f469B9E6F27d759715125`)
+
+## Lifecycle
+
+1. **Agent created** -> register `name.bankr.eth` via NameStone -> set `agent:*` text records
+2. **ERC-8004 registered** -> set ENSIP-25 verification record
+3. **Agent deactivated** -> clear ENSIP-25 record -> release subname
+4. **Name transferred** -> verification automatically invalidated
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| "NameStone API key not set" | Export `NAMESTONE_API_KEY` or get one at namestone.com |
+| "Name already taken" | Choose a different subname under `bankr.eth` |
+| "Resolution failed" | Check that NameStone resolver is set on `bankr.eth` |
+| "ENSIP-25 verification failed" | Ensure the text record matches the registry address and agent ID |
+| "Bankr CLI not found" | Install with `bun install -g @bankr/cli && bankr login` |
+
+## Links
+
+- ENS Docs: https://docs.ens.domains
+- NameStone: https://namestone.com
+- ENSIP-25 Spec: https://docs.ens.domains/ensip/25/
+- ERC-8004: https://eips.ethereum.org/EIPS/eip-8004
+- Oikonomos: https://github.com/estmcmxci/oikonomos

--- a/ens-agent-identity/SKILL.md
+++ b/ens-agent-identity/SKILL.md
@@ -51,6 +51,11 @@ npm init -y && npm install viem
 
 # Verify ENSIP-25 link between ENS name and ERC-8004 identity
 ./scripts/verify-agent-registration.sh alpha-go.bankr.eth 42
+
+# Phase A (AuthResolver pilot, scaffold): publish auth.* records, then read-only verify
+BANKR_ENS_DOMAIN=bankrtest.eth AUTH_SIGNER_ADDRESS=0x… AUTH_SCOPE="swap,bridge" \
+  ./scripts/publish-auth-records.sh authtest primary
+NODE_NO_WARNINGS=1 node ./scripts/verify-action.ts authtest.bankrtest.eth primary
 ```
 
 ## Agent Text Record Schema
@@ -82,6 +87,55 @@ agent-registration[<registry>][<agentId>] = "1"
 ```
 
 This allows any client to verify that the ENS name owner endorses the association with a specific on-chain agent identity. See `references/ensip-25-verification.md` for details.
+
+## Phase A: AuthResolver Read-Only Pilot
+
+> **Forward-declaring scaffold — not contract work.** This is **layer 3 (Authentication)** on
+> top of the existing layer-1 (ENSIP-25 identity) and layer-2 (`agent:*` attribution) records.
+> It publishes `auth.*` records and runs a **read-only** verification mirror. The contracts
+> that consume these records — the **Verifier** + **AuthResolverImpl** — are the **unfunded M1
+> deliverable** (target 2026-08-31, `github.com/steg-eth`) and are **not deployed**. Nothing
+> here performs end-to-end signature verification; it proves the **record plumbing**.
+>
+> The `auth.*` key naming and record shapes come from the AuthResolver spec; **how they map to a
+> specific platform's real auth model is a design conversation with that platform's engineers**,
+> not fixed here.
+
+**What Phase A proves:** an agent can publish credential / capability / revocation records on
+its ENS name without clobbering its existing identity/attribution records, and a counterparty
+can resolve + read + structurally pre-check them along the spec's `verifyAction` ordering. It
+**does not alter any production execution path** — it is a counterparty-side, read-only observer.
+
+**Records** (full schema in `references/auth-record-schema.md`):
+
+| Key | Purpose | Consumed by `verifyAction`? |
+|---|---|---|
+| `auth.credential[<id>]` | signing key + scheme + validity window | yes (M1) |
+| `auth.capability[<id>]` | scope declaration | no — reserved for v1.1 |
+| `auth.revocation[<id>]` | revocation flag (any bytes ⇒ revoked) | yes (M1) |
+
+Phase-A records are **JSON-in-text-record** — a deliberate simplification that migrates to
+`setData` + CBOR once the M1 `AuthResolverImpl` is deployed.
+
+**Prerequisites:** `NAMESTONE_API_KEY` (publish half) + Node 24 with `viem` (already installed
+in `ens-agent-identity/`). The on-chain verify step additionally needs the **deployed M1
+AuthResolver** and `AUTH_RESOLVER_ADDRESS` — **pending M1**; until then the verifier runs in
+demo mode.
+
+```bash
+# 1. Publish auth.* WITHOUT clobbering existing agent:*/ENSIP-25 records (read-merge-write)
+BANKR_ENS_DOMAIN=bankrtest.eth AUTH_SIGNER_ADDRESS=0x… AUTH_SCOPE="swap,bridge,limit-order" \
+  ./scripts/publish-auth-records.sh authtest primary
+
+# 2. (Real signature) produce a secp256k1 signature via Bankr's /agent/sign — unchanged endpoint
+
+# 3. Verify (read-only; on-chain verifyAction STUBBED pending M1)
+NODE_NO_WARNINGS=1 node ./scripts/verify-action.ts authtest.bankrtest.eth primary
+#   => "contract not deployed yet; record plumbing verified"  (verified: null)
+```
+
+The verifier's `verifyAction` ABI is a **design sketch** (spec §5.1), marked `// TODO(M1)`. See
+`references/phase-a-demo.md` for the full 5-minute demo incl. deny-path and fail-path examples.
 
 ## Architecture
 

--- a/ens-agent-identity/references/agent-text-record-schema.md
+++ b/ens-agent-identity/references/agent-text-record-schema.md
@@ -1,0 +1,114 @@
+# Agent Text Record Schema
+
+Standardized ENS text records for Bankr agent metadata, using the `agent:*` namespace established in the [oikonomos framework](https://github.com/estmcmxci/oikonomos).
+
+## Core Records
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `agent:type` | string | Yes | Agent classification. One of: `trading-bot`, `portfolio-manager`, `token-launcher`, `treasury`, `defi`, `nft`, `prediction-market` |
+| `agent:capabilities` | string | Yes | Comma-separated list of capabilities the agent supports |
+| `agent:chains` | string | Yes | Comma-separated list of chains the agent operates on |
+| `agent:version` | semver | No | Agent software version (e.g. `2.1.0`) |
+| `agent:creator` | string | No | ENS name or address of the agent's creator |
+
+## Network & API Records
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `agent:a2a` | URL | No | Agent-to-Agent (A2A) protocol endpoint |
+| `agent:chainId` | number | No | Primary chain ID (e.g. `8453` for Base) |
+| `agent:mode` | string | No | Operating mode: `autonomous` or `supervised` |
+| `agent:policy` | string | No | Access policy: `read-only`, `full-access`, or `scoped` |
+
+## Token & Delegation Records
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `agent:token` | address | No | Address of the agent's deployed token contract |
+| `agent:token:symbol` | string | No | Token ticker symbol |
+| `agent:token:address` | address | No | Explicit token contract address (alias for `agent:token`) |
+| `agent:delegation` | string | No | ENS name of the parent agent this agent delegates to |
+
+## Verification Records (ENSIP-25)
+
+| Key | Type | Required | Description |
+|-----|------|----------|-------------|
+| `agent-registration[<registry>][<agentId>]` | string | No | ENSIP-25 attestation linking ENS name to ERC-8004 registry entry. Value is `"1"` (non-empty = endorsement) |
+
+The `<registry>` parameter is an [ERC-7930](https://eips.ethereum.org/EIPS/eip-7930) interoperable address encoding chain + contract address.
+
+## Capabilities Vocabulary
+
+Standard capability values for the `agent:capabilities` field:
+
+| Capability | Description |
+|------------|-------------|
+| `swap` | Token swaps (same-chain) |
+| `bridge` | Cross-chain token bridges |
+| `limit-order` | Limit order placement |
+| `dca` | Dollar-cost averaging |
+| `twap` | Time-weighted average price execution |
+| `polymarket` | Prediction market operations |
+| `nft` | NFT buying/selling |
+| `deploy-token` | ERC-20 token deployment |
+| `transfer` | Token/ETH transfers |
+| `leverage` | Leveraged/perpetual trading |
+| `portfolio` | Portfolio tracking and management |
+
+## Chain Identifiers
+
+Standard chain values for the `agent:chains` field:
+
+| Value | Chain ID | Chain |
+|-------|----------|-------|
+| `base` | 8453 | Base |
+| `ethereum` | 1 | Ethereum Mainnet |
+| `polygon` | 137 | Polygon |
+| `arbitrum` | 42161 | Arbitrum One |
+| `optimism` | 10 | Optimism |
+| `unichain` | 130 | Unichain |
+| `solana` | — | Solana |
+
+## Example: Full Agent Record Set
+
+For `alpha-go.bankr.eth`:
+
+```
+agent:type          = "trading-bot"
+agent:capabilities  = "swap,bridge,limit-order,dca"
+agent:chains        = "base,ethereum,polygon"
+agent:a2a           = "https://api.bankr.bot/agent/alpha-go"
+agent:version       = "2.1.0"
+agent:creator       = "estmcmxci.eth"
+agent:chainId       = "8453"
+agent:mode          = "autonomous"
+agent:policy        = "full-access"
+agent:token         = "0x842cfeb..."
+agent:token:symbol  = "ALPH"
+agent:delegation    = "treasury.bankr.eth"
+
+# ENSIP-25 verification
+agent-registration[0x0001000002210514BA001234...][42] = "1"
+```
+
+## Setting Records via NameStone
+
+```typescript
+import NameStone from "@namestone/namestone-sdk";
+const ns = new NameStone(process.env.NAMESTONE_API_KEY);
+
+await ns.setName({
+  name: "alpha-go",
+  domain: "bankr.eth",
+  address: "0x703ae03fB120eC91e9Ed6d08Ce8044E498CC789B",
+  text_records: {
+    "agent:type": "trading-bot",
+    "agent:capabilities": "swap,bridge,limit-order,dca",
+    "agent:chains": "base,ethereum,polygon",
+    "agent:a2a": "https://api.bankr.bot/agent/alpha-go",
+    "agent:version": "2.1.0",
+    "agent:creator": "estmcmxci.eth"
+  }
+});
+```

--- a/ens-agent-identity/references/auth-record-schema.md
+++ b/ens-agent-identity/references/auth-record-schema.md
@@ -1,0 +1,188 @@
+# AuthResolver `auth.*` Record Schema (Phase A)
+
+> **Status: forward-declaring scaffold.** This documents the `auth.*` records that the
+> AuthResolver pilot publishes on an ENS name. The contracts that *consume* these records
+> — the **Verifier** and **AuthResolverImpl** — are the unfunded **M1 deliverable** (target
+> 2026-08-31, `github.com/steg-eth`) and are **not deployed**. Nothing here performs
+> end-to-end signature verification today. Phase A proves the **record plumbing**:
+> publish → resolve → read → parse → local structural pre-checks.
+>
+> The normative source of truth is the AuthResolver prototype spec (v1.0-draft.02). Where
+> this Phase-A schema deviates from it, the deviation is **called out loudly** below and is
+> deliberate.
+
+> **What's settled vs. open.** The `auth.*` key names and the credential / capability /
+> revocation record shapes are taken from the AuthResolver prototype spec — they define *the
+> resolver's* data model and are stable in that sense. **How they map onto a specific platform's
+> real authorization model is not settled here.** For a managed agent platform like Bankr, the
+> exact contents — what a credential's signing key and scope should be, how `capability` scopes
+> mirror the platform's API-key permission flags (read-only vs. read-write, IP allowlist,
+> rate-limit tier), how `revocation` tracks a real key-revocation event — require a design
+> conversation with that platform's engineers. This document and the read-only pilot demonstrate
+> the *mechanics and the proposed shape* on a throwaway name; they are **not** a claim about any
+> platform's internal auth layer.
+
+## Where this sits: the three-layer agent-identity model
+
+An ENS name carrying a full agent identity has three composable layers (spec §2):
+
+| Layer | Question it answers | Where it lives | Status on `alpha-go.bankrtest.eth` |
+|---|---|---|---|
+| **1. Identity** (ENSIP-25) | Is this name bound to this agent's ERC-8004 record? | `agent-registration[...]` text record | ✅ verified live |
+| **2. Attribution** (ENSIP-26 / `agent:*`) | What is this agent? Capabilities, type, chains? | `agent:*` text records | ✅ live (`agent:type`, `agent:capabilities`, `agent:chains`) |
+| **3. Authentication** (AuthResolver) | Is *this signed action* verifiable under the agent's published credentials? | **`auth.*` records** | ⬅ **this document** |
+
+`auth.*` is **layer 3**. The on-chain `verifyAction` (M1) enforces **layer 3 only**; composing
+layers 1 and 2 is the relying party's job (spec §5.3). A serious counterparty reads all three.
+
+> **Mapping to the MAIP taxonomy (Display / Discovery / Authority).** This three-layer identity
+> *lens* (Identity / Attribution / Authentication, from spec §2) is **orthogonal** to the MAIP
+> infrastructure *tiers* (Display / Discovery / Authority, defined in the MAIP taxonomy) — they
+> cross-cut rather than rename each other. Identity (ENSIP-25) and Attribution (ENSIP-26 /
+> `agent:*`) span the **Display** tier (profile records — `agent:type`, `agent:chains`) and the
+> **Discovery** tier (capability / endpoint records — `agent:capabilities`, ENSIP-26
+> `services[*]`); Authentication (AuthResolver `auth.*`) is the **Authority** tier. The
+> submission application compresses the Display+Discovery span to "ENSIP-26 (discovery)"; the
+> `agent:*` profile records used in this pilot are therefore mostly Display, with
+> `agent:capabilities` leaning Discovery.
+
+## Key naming (spec §4.5, verbatim)
+
+```
+auth.credential[<id>]   — the registered signing key + scheme + validity window
+auth.capability[<id>]   — scope declaration (publishable, NOT enforced by verifyAction in v1)
+auth.revocation[<id>]   — revocation flag (presence of any bytes => revoked)
+```
+
+`<id>` is a free-string identifier chosen by the name owner. This pilot uses `primary`.
+
+## ⚠️ Three deliberate deviations from the normative spec
+
+These are **Phase-A simplifications**, not the target design. Each migrates at M1.
+
+1. **JSON-in-text-record, not CBOR-in-`data`.** The spec (§4.5, conformance items A14/A15)
+   requires records under the `IDataResolver.data(node, key) → bytes` profile, **CBOR-encoded**,
+   and **MUST NOT** use text records. Phase A uses **JSON strings in NameStone text records**
+   because (a) NameStone's surface is text records, and (b) the `data`+CBOR profile needs the
+   M1-deployed `AuthResolverImpl`. **Migrates to `setData` + CBOR at M1.**
+2. **`scheme` as a string, not `bytes32`.** Stored as `"ECDSA-secp256k1"`. The on-chain
+   canonical form is `keccak256("ECDSA-secp256k1")` (spec §3.2). The verifier computes the
+   hash; the text record carries the human-readable string.
+3. **`schemaVersion` wrapper field.** Not part of any spec struct. Added so M1 migration
+   tooling can distinguish Phase-A JSON payloads from real CBOR. Value: `"phase-a/0.1"`.
+
+A fourth, credential-specific deviation is the `pubKey`/`address` substitution — see the
+note in the credential table.
+
+## `auth.credential[<id>]` — spec §6.1 `CredentialRecord`
+
+| Spec struct field | Phase-A JSON key | Example value | Note |
+|---|---|---|---|
+| `schemeId` bytes32 | `scheme` | `"ECDSA-secp256k1"` | string form (deviation 2). One of: `WebAuthn-ES256`, `ECDSA-secp256k1`, `EIP-1271` (spec §3.2) |
+| `pubKey` bytes | `address` | *(signer wallet, passed via env)* | **DECISION A1:** Phase A stores the **20-byte address** we have, not the **64-byte uncompressed key** the spec's secp256k1 path requires (§3.2). `// TODO(M1): 64-byte uncompressed key.` |
+| `notBefore` uint64 | `notBefore` | `1747000000` | unix seconds; issue time |
+| `notAfter` uint64 (0=∞) | `notAfter` | `0` | `0` = no expiry |
+| `capabilityRef` bytes32 (0=none) | `capabilityRef` | `"primary"` | structural only in v1 — `verifyAction` does NOT enforce capability scope (spec §6.1) |
+| — | `schemaVersion` | `"phase-a/0.1"` | wrapper (deviation 3) |
+
+```json
+{
+  "scheme": "ECDSA-secp256k1",
+  "address": "0x<signer-address>",
+  "notBefore": 1747000000,
+  "notAfter": 0,
+  "capabilityRef": "primary",
+  "schemaVersion": "phase-a/0.1"
+}
+```
+
+## `auth.capability[<id>]` — spec §6.2 `CapabilityRecord`
+
+Publishable in v1, **not consumed by `verifyAction`** (reserved for the v1.1 policy layer, spec §6.2).
+
+| Spec field | Phase-A JSON key | Example value | Note |
+|---|---|---|---|
+| `scope` string | `scope` | `"swap,bridge,limit-order"` | mirrors the agent's `agent:capabilities` |
+| `expiry` uint64 (0=∞) | `expiry` | `0` | `0` = no expiry |
+| `revocationKey` bytes32 (0=use cred id) | *(omitted)* | — | omitted ⇒ verifier uses the credential id as the revocation key |
+| — | `schemaVersion` | `"phase-a/0.1"` | wrapper |
+
+```json
+{ "scope": "swap,bridge,limit-order", "expiry": 0, "schemaVersion": "phase-a/0.1" }
+```
+
+## `auth.revocation[<id>]` — spec §6.3 `RevocationRecord`
+
+Per spec §5.2 step 4, **the presence of any bytes ⇒ revoked**, regardless of decoded content.
+Decoding `revokedAt`/`reason` is optional for the deny decision but recommended for diagnostics.
+
+| Spec field | Phase-A JSON key | Example value |
+|---|---|---|
+| `revokedAt` uint64 (0=not revoked) | `revokedAt` | `1747100000` |
+| `reason` string (optional) | `reason` | `"key rotation"` |
+| — | `schemaVersion` | `"phase-a/0.1"` |
+
+```json
+{ "revokedAt": 1747100000, "reason": "key rotation", "schemaVersion": "phase-a/0.1" }
+```
+
+> The pilot publishes **credential + capability** on the happy path. **Revocation is shown
+> as a deny-path example only** — never set on the live happy-path record.
+
+## How `verifyAction` will consume these (spec §5.2, M1)
+
+The on-chain `verifyAction(node, credentialId, message, signature)` runs this ordering and
+returns on the first failure with a `DenyReason`:
+
+1. **Credential lookup** — empty ⇒ `Unverified`
+2. **Decode** — decode failure ⇒ `Unverified`
+3. **Validity window** — outside `notBefore`/`notAfter` ⇒ `Stale`
+4. **Revocation** — any bytes at `auth.revocation[<id>]` ⇒ `Revoked`
+5. **Scheme support** — scheme not registered in the Verifier ⇒ `Mismatch`
+6. **Signature verification** — Verifier `verify(...)` returns false ⇒ `Unverified`
+7. **Success** — `{allowed: true, reason: None, ...}`
+
+`scripts/verify-action.ts` runs steps 1–5 **locally and read-only** as structural pre-checks.
+**Steps 6–7 are the on-chain step and are STUBBED** (the Verifier is not deployed). The script
+prints `verified: null` — it never claims a signature was cryptographically verified pre-M1.
+
+## Illustrative record set (NON-NORMATIVE; not necessarily published live)
+
+For reference only, the shape a live agent like `alpha-go.bankrtest.eth` would carry once the
+`auth.*` namespace is populated. Per spec §1.3, **reference-deployment addresses MUST NOT be
+hard-coded** — the scripts take the address via args/env. Live validation for this pilot runs
+on the throwaway `authtest.bankrtest.eth`, not on `alpha-go`.
+
+```
+# Layer 2 — attribution (already live)
+agent:type          = "trading-bot"
+agent:capabilities  = "swap,bridge,limit-order"
+agent:chains        = "base"
+
+# Layer 1 — identity / ENSIP-25 (already live)
+agent-registration[0x0001...e539a432][19327] = "1"
+
+# Layer 3 — authentication / AuthResolver (this schema; Phase A)
+auth.credential[primary]  = {"scheme":"ECDSA-secp256k1","address":"0x<signer>","notBefore":...,"notAfter":0,"capabilityRef":"primary","schemaVersion":"phase-a/0.1"}
+auth.capability[primary]  = {"scope":"swap,bridge,limit-order","expiry":0,"schemaVersion":"phase-a/0.1"}
+# auth.revocation[primary] — absent on the happy path
+```
+
+## Migration to M1 (what changes)
+
+| Phase A (today) | M1 (target 2026-08-31) |
+|---|---|
+| JSON string in NameStone **text** record | CBOR bytes in `IDataResolver.data` slot via `setData` |
+| `scheme` as string | `schemeId` = `keccak256(scheme)` bytes32 |
+| `address` (20 bytes) | `pubKey` (64-byte uncompressed secp256k1) |
+| `schemaVersion: "phase-a/0.1"` wrapper | dropped — CBOR struct layout is the version |
+| local read-only pre-checks (`verify-action.ts`) | on-chain `verifyAction` via deployed AuthResolver + Verifier |
+
+## References
+
+- AuthResolver prototype spec v1.0-draft.02 (normative): §2 (three-layer framing), §3.2
+  (schemes), §4.5 (key naming + record profile), §5.1–§5.2 (`DenyReason`, ordering), §6.1–§6.3
+  (record structs).
+- `references/ensip-25-verification.md` — layer 1 (identity binding).
+- `references/agent-text-record-schema.md` — layer 2 (`agent:*` attribution).
+- `references/namestone-integration.md` — the text-record surface this pilot writes to.

--- a/ens-agent-identity/references/ensip-25-verification.md
+++ b/ens-agent-identity/references/ensip-25-verification.md
@@ -1,0 +1,94 @@
+# ENSIP-25: Agent Registry ENS Name Verification
+
+ENSIP-25 establishes a standardized method for verifying the association between an ENS name and an agent identity in any on-chain registry (e.g. ERC-8004).
+
+Spec: https://docs.ens.domains/ensip/25/
+
+## The Problem
+
+Without ENSIP-25, an agent's ENS name and its ERC-8004 identity are two disconnected claims. Anyone could register an ERC-8004 entry claiming to be `alpha-go.bankr.eth` with no way to confirm the ENS name owner endorses that claim.
+
+## How It Works
+
+The ENS name owner sets a parameterized text record:
+
+```
+agent-registration[<registry>][<agentId>] = "1"
+```
+
+Where:
+- `<registry>` is the [ERC-7930](https://eips.ethereum.org/EIPS/eip-7930) interoperable address of the agent registry contract
+- `<agentId>` is the agent's identifier in that registry
+- A non-empty value is an attestation: "this agent registration is legitimately associated with this name"
+
+## ERC-7930 Address Encoding
+
+The registry parameter uses ERC-7930 binary encoding of chain + contract address:
+
+```
+0x 0001 0000 02 2105 14 [20-byte registry address]
+   ---- ---- -- ---- --
+   |    |    |  |    +-- Address is 20 bytes (0x14)
+   |    |    |  +-- Chain ID 8453 (Base) = 0x2105
+   |    |    +-- ChainReference is 2 bytes long
+   |    +-- ChainType 0x0000 (EVM)
+   +-- Version 1
+```
+
+### Common Chain Encodings
+
+| Chain | Chain ID | Hex Chain ID | ERC-7930 Prefix |
+|-------|----------|-------------|-----------------|
+| Ethereum | 1 | 0x01 | `0x00010000010114` |
+| Base | 8453 | 0x2105 | `0x0001000002210514` |
+| Arbitrum | 42161 | 0xA4B1 | `0x0001000002A4B114` |
+| Optimism | 10 | 0x0A | `0x00010000010A14` |
+| Sepolia | 11155111 | 0xAA36A7 | `0x0001000003AA36A714` |
+
+## Concrete Example: Bankr on Base
+
+For agent `alpha-go.bankr.eth` registered as ID `42` in an ERC-8004 registry at `0xBA001234...` on Base:
+
+```
+Key:   agent-registration[0x0001000002210514BA001234...][42]
+Value: "1"
+```
+
+## Verification Flow
+
+```
+1. Agent claims: "I'm alpha-go.bankr.eth, agent #42 on Base"
+2. Verifier resolves alpha-go.bankr.eth
+3. Decodes the ERC-7930 registry address -> Base (chain 8453), contract 0xBA00...
+4. Reads text record: agent-registration[0x0001000002210514BA00...][42]
+5. Record is non-empty -> ENS name owner endorses this association
+6. Queries ERC-8004 registry at 0xBA00... on Base for agent #42 -> identity confirmed
+```
+
+## Lifecycle Management
+
+ENSIP-25 records must be managed alongside the agent lifecycle:
+
+| Event | Action |
+|-------|--------|
+| Agent created + ERC-8004 minted | Set ENSIP-25 text record |
+| Agent deactivated | Clear ENSIP-25 text record |
+| ENS name transferred | Verification automatically invalidated (new owner has no record) |
+| ERC-8004 NFT transferred | Old ENSIP-25 record becomes stale; new owner must re-attest |
+
+## Relationship to agent:* Records
+
+ENSIP-25 handles **verification** (proving the ENS name and registry entry belong together). The `agent:*` text records handle **metadata** (what the agent does, its capabilities, etc.). They are complementary:
+
+```
+agent:type = "trading-bot"                              <- metadata
+agent:capabilities = "swap,bridge"                       <- metadata
+agent-registration[<registry>][<agentId>] = "1"          <- verification
+```
+
+## Security Considerations
+
+- Only the ENS name owner can set the verification record
+- Name ownership transfers invalidate all existing records
+- Verifiers should always check both directions: ENS -> registry AND registry -> ENS
+- Stale records (where the ERC-8004 NFT has been transferred) should be detected by checking current NFT ownership

--- a/ens-agent-identity/references/namestone-integration.md
+++ b/ens-agent-identity/references/namestone-integration.md
@@ -1,0 +1,150 @@
+# NameStone Integration
+
+[NameStone](https://namestone.com) is a managed offchain ENS subname service powering 9M+ subnames across 250+ domains. It provides gasless subname registration and text record management for `bankr.eth` agent names.
+
+## Setup
+
+### 1. Set Resolver (one-time, on-chain)
+
+Set `bankr.eth`'s resolver to NameStone's Hybrid Resolver:
+
+```
+Resolver: 0xA87361C4E58B619c390f469B9E6F27d759715125
+```
+
+This is a single on-chain transaction on Ethereum mainnet.
+
+### 2. Get API Key
+
+Obtain a free API key via Sign-In with Ethereum (SIWE) at [namestone.com](https://namestone.com).
+
+```bash
+export NAMESTONE_API_KEY="your-api-key"
+```
+
+### 3. Install SDK (optional)
+
+```bash
+npm install @namestone/namestone-sdk
+```
+
+## API Reference
+
+### Register a Subname
+
+```bash
+curl -X POST "https://namestone.com/api/public_v1/set-name" \
+  -H "Authorization: $NAMESTONE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "alpha-go",
+    "domain": "bankr.eth",
+    "address": "0x703ae03fB120eC91e9Ed6d08Ce8044E498CC789B",
+    "text_records": {
+      "agent:type": "trading-bot",
+      "agent:capabilities": "swap,bridge,limit-order",
+      "agent:chains": "base,ethereum"
+    }
+  }'
+```
+
+### TypeScript SDK
+
+```typescript
+import NameStone from "@namestone/namestone-sdk";
+const ns = new NameStone(process.env.NAMESTONE_API_KEY);
+
+// Register agent with metadata
+await ns.setName({
+  name: "alpha-go",
+  domain: "bankr.eth",
+  address: "0x703ae03fB120eC91e9Ed6d08Ce8044E498CC789B",
+  text_records: {
+    "agent:type": "trading-bot",
+    "agent:capabilities": "swap,bridge,limit-order,dca",
+    "agent:chains": "base,ethereum,polygon",
+    "agent:a2a": "https://api.bankr.bot/agent/alpha-go",
+    "agent:version": "2.1.0",
+    "agent:creator": "estmcmxci.eth"
+  }
+});
+```
+
+### Get a Name
+
+```bash
+curl "https://namestone.com/api/public_v1/get-names?domain=bankr.eth&name=alpha-go" \
+  -H "Authorization: $NAMESTONE_API_KEY"
+```
+
+### Search Names
+
+```bash
+# Find all agents under bankr.eth
+curl "https://namestone.com/api/public_v1/search-names?domain=bankr.eth" \
+  -H "Authorization: $NAMESTONE_API_KEY"
+```
+
+### Delete a Name
+
+```bash
+curl -X POST "https://namestone.com/api/public_v1/delete-name" \
+  -H "Authorization: $NAMESTONE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "alpha-go",
+    "domain": "bankr.eth"
+  }'
+```
+
+## How CCIP-Read Works
+
+NameStone uses [EIP-3668 (CCIP-Read)](https://eips.ethereum.org/EIPS/eip-3668) for gasless resolution:
+
+```
+1. Client calls resolve() on the NameStone Hybrid Resolver
+2. Resolver reverts with OffchainLookup(url, calldata)
+3. Client fetches the signed response from NameStone's gateway
+4. Client calls resolver again with the signed proof
+5. Resolver verifies the signature and returns the data
+```
+
+This means:
+- **Registration is free** (no on-chain transaction per subname)
+- **Resolution is trustless** (cryptographically signed responses)
+- **Standard ENS clients work** (any client supporting CCIP-Read)
+
+## Text Record Management
+
+NameStone supports arbitrary text records as `Record<string, string>`. This means the full `agent:*` schema and ENSIP-25 verification records can be written at registration time or updated later.
+
+### Updating Records
+
+To update text records on an existing subname, call `setName` again with the same name and domain. **NameStone overwrites the entire record** — you must include all text records in each call, not just the ones you want to change. Records omitted from the update will be removed.
+
+### ENSIP-25 Records
+
+ENSIP-25 verification records can be set as text records:
+
+```typescript
+await ns.setName({
+  name: "alpha-go",
+  domain: "bankr.eth",
+  address: "0x703ae03fB120eC91e9Ed6d08Ce8044E498CC789B",
+  text_records: {
+    "agent-registration[0x0001000002210514BA001234...][42]": "1"
+  }
+});
+```
+
+## Migration Path
+
+If custom resolution logic or data sovereignty is needed in the future, the `bankr.eth` resolver can be swapped with a single on-chain transaction. NameStone has no lock-in — the resolver is the only integration point.
+
+## Limits & Pricing
+
+- **Free**: NameStone is funded by ENS DAO grants. No documented usage limits or paid tiers.
+- **Batch size**: Max 50 subnames per `set-names` call
+- **Text records**: Arbitrary key-value pairs (`Record<string, string>`), no limit on number per name
+- **Resolution latency**: ~0.9s (CCIP-Read roundtrip), supported by all major ENS clients
+- **Overwrite semantics**: `set-name` replaces the entire record — always include all text records in each call

--- a/ens-agent-identity/references/phase-a-demo.md
+++ b/ens-agent-identity/references/phase-a-demo.md
@@ -1,0 +1,149 @@
+# Phase A Demo — AuthResolver Read-Only Pilot (5 minutes)
+
+> **Forward-declaring scaffold.** The publish half runs end-to-end today against a real ENS
+> subname via NameStone. The verify half is **read-only** and the on-chain
+> `AuthResolver.verifyAction` step is **STUBBED** — the Verifier + AuthResolverImpl contracts
+> are the unfunded M1 deliverable (target 2026-08-31, `github.com/steg-eth`), not deployed.
+> Nothing here performs end-to-end signature verification. It proves the **record plumbing**.
+
+## What this demo proves
+
+1. You can publish `auth.credential` / `auth.capability` records on an ENS name **without
+   clobbering** the name's existing `agent:*` (attribution) and ENSIP-25 (identity) records.
+2. A counterparty can resolve the name, read the `auth.*` records, and run the spec's §5.2
+   verification ordering as local structural pre-checks.
+3. The exact seam where the M1 on-chain `verifyAction` call slots in is marked and honest —
+   the verifier prints `verified: null` and `"contract not deployed yet; record plumbing verified"`.
+
+## Prerequisites
+
+```bash
+export NAMESTONE_API_KEY="…"        # required for the publish half; never printed by the scripts
+cd ens-agent-identity/scripts        # viem is installed in ens-agent-identity/; Node 24+
+```
+
+- **Read half needs nothing but an RPC** (default `https://eth.drpc.org`).
+- **Publish half needs `NAMESTONE_API_KEY`.** No Bankr API spend in this demo (we pass the
+  signer address explicitly rather than querying the Bankr CLI).
+- Validation target is the throwaway **`authtest.bankrtest.eth`** — we do NOT touch
+  `alpha-go.bankrtest.eth` (its records are cited live elsewhere).
+
+---
+
+## Step 1 — Seed the subname with layer-1/2 records (so the clobber proof has something to preserve)
+
+Register `authtest.bankrtest.eth` with `agent:*` attribution records and an address. (Uses the
+existing `set-agent-records.sh`; `BANKR_ENS_DOMAIN` overrides the default `bankr.eth`.)
+
+```bash
+BANKR_ENS_DOMAIN=bankrtest.eth \
+  ./set-agent-records.sh authtest trading-bot "swap,bridge,limit-order" \
+  0x579bc9f36e339bbc8f2580a792e4db4bcff39105
+```
+
+This sets `agent:type`, `agent:capabilities`, `agent:chains` and the addr record. These are the
+keys the next step must preserve.
+
+## Step 2 — Publish `auth.*` (layer 3) WITHOUT clobbering layers 1/2
+
+```bash
+BANKR_ENS_DOMAIN=bankrtest.eth \
+AUTH_SIGNER_ADDRESS=0x579bc9f36e339bbc8f2580a792e4db4bcff39105 \
+AUTH_SCOPE="swap,bridge,limit-order" \
+  ./publish-auth-records.sh authtest primary
+```
+
+What it does (read → merge → write):
+1. **GET** the current records (finds the `agent:*` keys from step 1).
+2. **MERGE** `auth.credential[primary]` + `auth.capability[primary]` into the existing map.
+3. **POST** the full merged map back (NameStone `set-name` replaces the whole map, so the merge
+   is what keeps the `agent:*` keys alive).
+4. **Re-GET** and print a before/after **clobber check**:
+   ```
+   CLOBBER CHECK PASSED: no prior keys lost; all auth.* keys present.
+   ```
+
+## Step 3 — Verify (read-only; on-chain step stubbed)
+
+```bash
+NODE_NO_WARNINGS=1 node verify-action.ts authtest.bankrtest.eth primary
+```
+
+Expected: resolves the name, reads the `auth.*` records, runs local pre-checks (credential
+present → validity window → revocation → scheme recognized), then:
+
+```
+Step 4: On-chain AuthResolver.verifyAction (signature verify + scheme dispatch)...
+  AUTH_RESOLVER_ADDRESS unset => contract not deployed yet; record plumbing verified
+```
+
+and prints JSON with `"verified": null` and `"reason": "ContractNotDeployed"`.
+
+---
+
+## Deny-path example (revocation)
+
+Publish a revocation record for the same id, then re-run the verifier. The local pre-check now
+short-circuits at the revocation step (spec §5.2 step 4 — presence of any bytes ⇒ revoked):
+
+```bash
+BANKR_ENS_DOMAIN=bankrtest.eth \
+AUTH_SIGNER_ADDRESS=0x579bc9f36e339bbc8f2580a792e4db4bcff39105 \
+AUTH_SCOPE="swap,bridge,limit-order" \
+AUTH_REVOKED_AT=$(date +%s) AUTH_REVOKE_REASON="key rotation" \
+  ./publish-auth-records.sh authtest primary
+
+NODE_NO_WARNINGS=1 node verify-action.ts authtest.bankrtest.eth primary
+# local pre-check: ... revoked=true ... would DENY ... : Revoked
+```
+
+> **CCIP-Read propagation lag (observed ~30–40s).** NameStone's CCIP-Read gateway
+> negative-caches a key that was *absent* at first read. After you add
+> `auth.revocation[primary]`, the publish script's own re-GET (NameStone REST) sees it
+> immediately, but `verify-action.ts` (viem CCIP-Read) may still read it as empty for
+> ~30–40s until the negative cache expires. Re-run the verifier after a short wait, or read
+> the authoritative published state directly via the NameStone REST `get-names` endpoint.
+
+> To return `authtest` to a clean happy-path state afterward, re-run step 2 without the
+> `AUTH_REVOKED_AT`/`AUTH_REVOKE_REASON` vars. (NameStone `set-name` replaces the map; the merge
+> only re-writes the `auth.*` keys you pass, so the revocation key persists until you clear it
+> with NameStone's `delete-name`/`set-name` — note this when resetting.)
+
+## Fail-path examples (input validation)
+
+```bash
+# Missing credential source -> clean error, no write attempted:
+BANKR_ENS_DOMAIN=bankrtest.eth ./publish-auth-records.sh authtest primary
+# Error: no credential supplied. Set AUTH_CREDENTIAL_JSON=<json> or AUTH_SIGNER_ADDRESS=<0x...>
+
+# Missing API key -> clean error:
+unset NAMESTONE_API_KEY; ./publish-auth-records.sh authtest primary
+# Error: NAMESTONE_API_KEY environment variable not set
+
+# Verifier against a name with no auth.* records -> Unverified (read-only, no error):
+NODE_NO_WARNINGS=1 node verify-action.ts somename.bankrtest.eth primary
+```
+
+---
+
+## Toward Phase B
+
+Phase A is the read-only counterparty observer. Phase B (post-M1, contingent on Bankr
+engagement) integrates `verifyAction` at a real action boundary — e.g., a Bankr Skill that
+gates an external action on AuthResolver verification. That requires the deployed M1 contracts
+plus Bankr-side dev. See `bankr-compatibility-test.md` §"Day-zero integration design" for the
+Phase A → B → C → D sequencing.
+
+## Known limitations / TODOs
+
+- `verify-action.ts`'s `verifyAction` ABI is a **design sketch** (spec §5.1), not a deployed
+  ABI — `// TODO(M1)` markers flag the swap-in points.
+- Records are **JSON-in-text**, not CBOR-in-`data` — migrates to `setData`+CBOR at M1 (see
+  `references/auth-record-schema.md`).
+- The credential stores the signer **address**, not the 64-byte uncompressed secp256k1 key the
+  spec's verifier path requires — `// TODO(M1)`.
+- No on-chain write infrastructure for auth records; no core Bankr product code is touched.
+- **NameStone `get-names` ignores the `name` query param** — it returns *all* names under
+  the domain as an array. `publish-auth-records.sh` filters client-side by exact label; do the
+  same in any tooling, or you will read/merge the wrong subname's records.
+- **CCIP-Read negative-cache lag** (~30–40s) on newly-added keys — see the deny-path note above.

--- a/ens-agent-identity/scripts/publish-auth-records.sh
+++ b/ens-agent-identity/scripts/publish-auth-records.sh
@@ -1,0 +1,340 @@
+#!/bin/bash
+# ENS Agent Identity - Phase A: publish AuthResolver auth.* records via NameStone
+#
+# Forward-declaring scaffold for the AuthResolver + Verifier pilot (Phase A,
+# read-only verification demo). This script is REAL and runs end-to-end today:
+# it publishes auth.credential / auth.capability / auth.revocation records on an
+# ENS subname via NameStone. The contracts that *consume* these records (the
+# AuthResolverImpl + Verifier) are the unfunded M1 deliverable (target 2026-08-31)
+# and are NOT exercised here. See references/auth-record-schema.md.
+#
+# CLOBBER PREVENTION (critical): NameStone set-name REPLACES the full text_records
+# map. This script GETs the existing records, MERGES the new auth.* keys in, and
+# POSTs the full merged map — so existing agent:* and ENSIP-25 keys survive.
+#
+# Phase-A value format is JSON-in-text-record, a deliberate simplification. The
+# spec's normative profile is CBOR in the IDataResolver.data slot; that needs the
+# M1-deployed AuthResolverImpl. Phase A migrates to setData+CBOR at M1.
+#
+# Usage:
+#   ./publish-auth-records.sh <agent-name> [credential-id]
+#
+# Example (build credential from fields):
+#   AUTH_SIGNER_ADDRESS=0x579bc9... AUTH_SCOPE="swap,bridge,limit-order" \
+#     ./publish-auth-records.sh authtest primary
+#
+# Example (supply raw JSON verbatim):
+#   AUTH_CREDENTIAL_JSON='{"scheme":"ECDSA-secp256k1","address":"0x..","notBefore":1747000000,"notAfter":0,"capabilityRef":"primary","schemaVersion":"phase-a/0.1"}' \
+#     ./publish-auth-records.sh authtest primary
+#
+# Environment:
+#   NAMESTONE_API_KEY    (required) NameStone API key. NEVER printed by this script.
+#   BANKR_ENS_DOMAIN     (default bankrtest.eth) parent domain.
+#   AUTH_SUBNAME_ADDRESS (optional) addr record to set IF the subname does not exist
+#                        yet. If the subname already exists, its current address is
+#                        preserved automatically.
+#
+#   Credential (auth.credential[<id>]) — REQUIRED. Either:
+#     AUTH_CREDENTIAL_JSON   raw JSON, used verbatim (must parse as an object), OR
+#     built from fields:
+#       AUTH_SIGNER_ADDRESS  (required if no JSON) signer wallet whose signatures
+#                            the verifier checks. NOT hard-coded; you pass it.
+#       AUTH_SCHEME          (default ECDSA-secp256k1)
+#       AUTH_NOT_BEFORE      (default: now, unix seconds)
+#       AUTH_NOT_AFTER       (default 0 = no expiry)
+#       AUTH_CAPABILITY_REF  (default: <credential-id>)
+#
+#   Capability (auth.capability[<id>]) — OPTIONAL. Either:
+#     AUTH_CAPABILITY_JSON   raw JSON verbatim, OR
+#     built from fields (only if AUTH_SCOPE is set):
+#       AUTH_SCOPE           comma-separated scope, e.g. "swap,bridge,limit-order"
+#       AUTH_EXPIRY          (default 0 = no expiry)
+#
+#   Revocation (auth.revocation[<id>]) — OPTIONAL (deny-path demo only). Either:
+#     AUTH_REVOCATION_JSON   raw JSON verbatim, OR
+#     built from fields (only if AUTH_REVOKED_AT is set):
+#       AUTH_REVOKED_AT      unix seconds when revoked
+#       AUTH_REVOKE_REASON   (default "")
+#
+# Output: human-readable progress -> stderr; machine-readable JSON result -> stdout.
+
+set -euo pipefail
+
+AGENT_NAME="${1:?Usage: publish-auth-records.sh <agent-name> [credential-id]}"
+CRED_ID="${2:-primary}"
+DOMAIN="${BANKR_ENS_DOMAIN:-bankrtest.eth}"
+NS_BASE="https://namestone.com/api/public_v1"
+
+if [ -z "${NAMESTONE_API_KEY:-}" ]; then
+  echo "Error: NAMESTONE_API_KEY environment variable not set" >&2
+  echo "Get your API key at https://namestone.com" >&2
+  exit 1
+fi
+
+# A credential is mandatory: either raw JSON or a signer address to build from.
+if [ -z "${AUTH_CREDENTIAL_JSON:-}" ] && [ -z "${AUTH_SIGNER_ADDRESS:-}" ]; then
+  echo "Error: no credential supplied." >&2
+  echo "Set AUTH_CREDENTIAL_JSON=<json> or AUTH_SIGNER_ADDRESS=<0x...>" >&2
+  exit 1
+fi
+
+echo "=== Phase A: Publish AuthResolver auth.* records ===" >&2
+echo "Subname:       ${AGENT_NAME}.${DOMAIN}" >&2
+echo "Credential id: ${CRED_ID}" >&2
+echo "Format:        JSON-in-text-record (Phase-A only; migrates to setData+CBOR at M1)" >&2
+echo "" >&2
+
+# ---------------------------------------------------------------------------
+# Step 1: Build the new auth.* record map.
+# All user input is passed via environment variables to prevent shell/Node
+# injection (matches the hardening in set-agent-records.sh).
+# Emits a JSON object: { "auth.credential[id]": "<json-string>", ... }
+# ---------------------------------------------------------------------------
+echo "Step 1: Building auth.* records..." >&2
+
+AUTH_RECORDS_JSON=$(
+  CRED_ID="$CRED_ID" \
+  AUTH_CREDENTIAL_JSON="${AUTH_CREDENTIAL_JSON:-}" \
+  AUTH_CAPABILITY_JSON="${AUTH_CAPABILITY_JSON:-}" \
+  AUTH_REVOCATION_JSON="${AUTH_REVOCATION_JSON:-}" \
+  AUTH_SIGNER_ADDRESS="${AUTH_SIGNER_ADDRESS:-}" \
+  AUTH_SCHEME="${AUTH_SCHEME:-ECDSA-secp256k1}" \
+  AUTH_NOT_BEFORE="${AUTH_NOT_BEFORE:-}" \
+  AUTH_NOT_AFTER="${AUTH_NOT_AFTER:-0}" \
+  AUTH_CAPABILITY_REF="${AUTH_CAPABILITY_REF:-}" \
+  AUTH_SCOPE="${AUTH_SCOPE:-}" \
+  AUTH_EXPIRY="${AUTH_EXPIRY:-0}" \
+  AUTH_REVOKED_AT="${AUTH_REVOKED_AT:-}" \
+  AUTH_REVOKE_REASON="${AUTH_REVOKE_REASON:-}" \
+  node -e '
+const SCHEMA_VERSION = "phase-a/0.1";
+const id = process.env.CRED_ID;
+const out = {};
+
+function parseOrFail(raw, label) {
+  let v;
+  try { v = JSON.parse(raw); }
+  catch (e) { console.error("Error: " + label + " is not valid JSON: " + e.message); process.exit(1); }
+  if (typeof v !== "object" || v === null || Array.isArray(v)) {
+    console.error("Error: " + label + " must be a JSON object"); process.exit(1);
+  }
+  return v;
+}
+
+// --- Credential (required) ---
+let credential;
+if (process.env.AUTH_CREDENTIAL_JSON) {
+  credential = parseOrFail(process.env.AUTH_CREDENTIAL_JSON, "AUTH_CREDENTIAL_JSON");
+} else {
+  const addr = process.env.AUTH_SIGNER_ADDRESS;
+  if (!/^0x[a-fA-F0-9]{40}$/.test(addr)) {
+    console.error("Error: AUTH_SIGNER_ADDRESS must be a 20-byte 0x address, got: " + addr);
+    process.exit(1);
+  }
+  const notBefore = process.env.AUTH_NOT_BEFORE
+    ? parseInt(process.env.AUTH_NOT_BEFORE, 10)
+    : Math.floor(Date.now() / 1000);
+  credential = {
+    scheme: process.env.AUTH_SCHEME,                  // string form; on-chain canonical is keccak256(scheme)
+    address: addr,                                    // DECISION A1: address, not 64-byte uncompressed pubKey
+    notBefore,
+    notAfter: parseInt(process.env.AUTH_NOT_AFTER, 10),
+    capabilityRef: process.env.AUTH_CAPABILITY_REF || id,
+    schemaVersion: SCHEMA_VERSION,
+    // TODO(M1): spec §3.2 requires pubKey = 64-byte uncompressed secp256k1 key.
+    // Phase A stores the address (what NameStone + Bankr expose); the M1 verifier
+    // path needs the full key.
+  };
+}
+out["auth.credential[" + id + "]"] = JSON.stringify(credential);
+
+// --- Capability (optional) ---
+if (process.env.AUTH_CAPABILITY_JSON) {
+  const cap = parseOrFail(process.env.AUTH_CAPABILITY_JSON, "AUTH_CAPABILITY_JSON");
+  out["auth.capability[" + id + "]"] = JSON.stringify(cap);
+} else if (process.env.AUTH_SCOPE) {
+  out["auth.capability[" + id + "]"] = JSON.stringify({
+    scope: process.env.AUTH_SCOPE,
+    expiry: parseInt(process.env.AUTH_EXPIRY, 10),
+    schemaVersion: SCHEMA_VERSION,
+    // revocationKey omitted => verifyAction uses the credential id as revocation key.
+    // NOTE: capability records are publishable in v1 but NOT consumed by verifyAction (spec §6.2).
+  });
+}
+
+// --- Revocation (optional; deny-path demo only) ---
+if (process.env.AUTH_REVOCATION_JSON) {
+  const rev = parseOrFail(process.env.AUTH_REVOCATION_JSON, "AUTH_REVOCATION_JSON");
+  out["auth.revocation[" + id + "]"] = JSON.stringify(rev);
+} else if (process.env.AUTH_REVOKED_AT) {
+  out["auth.revocation[" + id + "]"] = JSON.stringify({
+    revokedAt: parseInt(process.env.AUTH_REVOKED_AT, 10),
+    reason: process.env.AUTH_REVOKE_REASON || "",
+    schemaVersion: SCHEMA_VERSION,
+  });
+}
+
+console.log(JSON.stringify(out));
+'
+)
+
+# Show which auth.* keys we're about to write (values are short JSON; safe to echo).
+AUTH_RECORDS_JSON="$AUTH_RECORDS_JSON" node -e '
+const r = JSON.parse(process.env.AUTH_RECORDS_JSON);
+for (const k of Object.keys(r)) console.error("  + " + k);
+' >&2
+echo "" >&2
+
+# ---------------------------------------------------------------------------
+# Step 2: GET existing records (the read half of read-merge-write).
+# ---------------------------------------------------------------------------
+echo "Step 2: Reading existing records (clobber prevention)..." >&2
+
+ENCODED=$(AGENT_NAME="$AGENT_NAME" DOMAIN="$DOMAIN" node -e '
+console.log(encodeURIComponent(process.env.AGENT_NAME));
+console.log(encodeURIComponent(process.env.DOMAIN));
+')
+ENCODED_NAME=$(echo "$ENCODED" | head -1)
+ENCODED_DOMAIN=$(echo "$ENCODED" | tail -1)
+
+GET_RESPONSE=$(curl -s "${NS_BASE}/get-names?domain=${ENCODED_DOMAIN}&name=${ENCODED_NAME}" \
+  -H "Authorization: $NAMESTONE_API_KEY")
+
+# Extract existing address + existing text_records map. Defaults: "" and {}.
+EXISTING=$(GET_RESPONSE="$GET_RESPONSE" AGENT_NAME="$AGENT_NAME" node -e '
+let data;
+try { data = JSON.parse(process.env.GET_RESPONSE); } catch { data = []; }
+// NameStone get-names returns ALL names under the domain as an array; the `name`
+// query param is NOT honored server-side. Filter client-side by exact label, or we
+// would read (and merge) the wrong subname'"'"'s records.
+const rec = Array.isArray(data) ? data.find(r => r && r.name === process.env.AGENT_NAME) : null;
+const addr = rec && rec.address ? rec.address : "";
+const tr = rec && rec.text_records && typeof rec.text_records === "object" ? rec.text_records : {};
+console.log(addr);
+console.log(JSON.stringify(tr));
+')
+EXISTING_ADDR=$(echo "$EXISTING" | head -1)
+EXISTING_RECORDS_JSON=$(echo "$EXISTING" | tail -1)
+
+EXISTING_COUNT=$(EXISTING_RECORDS_JSON="$EXISTING_RECORDS_JSON" node -e '
+console.log(Object.keys(JSON.parse(process.env.EXISTING_RECORDS_JSON)).length);
+')
+
+if [ -n "$EXISTING_ADDR" ]; then
+  echo "  Found existing subname. address=$EXISTING_ADDR, existing text_records=$EXISTING_COUNT" >&2
+  EXISTING_RECORDS_JSON="$EXISTING_RECORDS_JSON" node -e '
+const r = JSON.parse(process.env.EXISTING_RECORDS_JSON);
+for (const k of Object.keys(r)) console.error("    keep: " + k);
+' >&2
+  TARGET_ADDR="$EXISTING_ADDR"
+else
+  echo "  Subname does not exist yet (no records to preserve)." >&2
+  if [ -z "${AUTH_SUBNAME_ADDRESS:-}" ]; then
+    echo "Error: subname ${AGENT_NAME}.${DOMAIN} not found and AUTH_SUBNAME_ADDRESS not set." >&2
+    echo "Register it first (e.g. ./set-agent-records.sh ...) or pass AUTH_SUBNAME_ADDRESS=<0x...>." >&2
+    exit 1
+  fi
+  TARGET_ADDR="$AUTH_SUBNAME_ADDRESS"
+fi
+echo "" >&2
+
+# ---------------------------------------------------------------------------
+# Step 3: Merge (existing keys preserved; auth.* keys added/overwritten) and POST.
+# ---------------------------------------------------------------------------
+echo "Step 3: Merging and publishing (read-merge-write)..." >&2
+
+REQUEST_BODY=$(
+  AGENT_NAME="$AGENT_NAME" \
+  DOMAIN="$DOMAIN" \
+  TARGET_ADDR="$TARGET_ADDR" \
+  EXISTING_RECORDS_JSON="$EXISTING_RECORDS_JSON" \
+  AUTH_RECORDS_JSON="$AUTH_RECORDS_JSON" \
+  node -e '
+const existing = JSON.parse(process.env.EXISTING_RECORDS_JSON);
+const auth = JSON.parse(process.env.AUTH_RECORDS_JSON);
+// Existing first, then auth.* — preserves all prior keys, overwrites only the
+// auth.* keys being (re)published this run.
+const merged = { ...existing, ...auth };
+console.log(JSON.stringify({
+  name: process.env.AGENT_NAME,
+  domain: process.env.DOMAIN,
+  address: process.env.TARGET_ADDR,
+  text_records: merged,
+}));
+'
+)
+
+POST_RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "${NS_BASE}/set-name" \
+  -H "Authorization: $NAMESTONE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "$REQUEST_BODY")
+
+HTTP_CODE=$(echo "$POST_RESPONSE" | tail -1)
+POST_BODY=$(echo "$POST_RESPONSE" | sed '$d')
+
+if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+  echo "Error (HTTP $HTTP_CODE): $POST_BODY" >&2
+  exit 1
+fi
+echo "  set-name OK (HTTP $HTTP_CODE)" >&2
+echo "" >&2
+
+# ---------------------------------------------------------------------------
+# Step 4: Re-read and prove the merge (before/after clobber proof).
+# ---------------------------------------------------------------------------
+echo "Step 4: Verifying merge (auth.* present AND prior keys survived)..." >&2
+sleep 2
+
+VERIFY_RESPONSE=$(curl -s "${NS_BASE}/get-names?domain=${ENCODED_DOMAIN}&name=${ENCODED_NAME}" \
+  -H "Authorization: $NAMESTONE_API_KEY")
+
+RESULT=$(
+  VERIFY_RESPONSE="$VERIFY_RESPONSE" \
+  EXISTING_RECORDS_JSON="$EXISTING_RECORDS_JSON" \
+  AUTH_RECORDS_JSON="$AUTH_RECORDS_JSON" \
+  AGENT_NAME="$AGENT_NAME" \
+  DOMAIN="$DOMAIN" \
+  node -e '
+let data;
+try { data = JSON.parse(process.env.VERIFY_RESPONSE); } catch { data = []; }
+// Filter by exact label — get-names ignores the `name` query param (returns all names).
+const rec = (Array.isArray(data) ? data.find(r => r && r.name === process.env.AGENT_NAME) : null) || {};
+const now = rec.text_records && typeof rec.text_records === "object" ? rec.text_records : {};
+const before = JSON.parse(process.env.EXISTING_RECORDS_JSON);
+const auth = JSON.parse(process.env.AUTH_RECORDS_JSON);
+
+const nowKeys = Object.keys(now);
+const authKeys = Object.keys(auth);
+
+// Did every prior (non-auth) key survive?
+const preserved = Object.keys(before).filter(k => !(k in auth));
+const survived = preserved.filter(k => now[k] === before[k]);
+const lost = preserved.filter(k => now[k] !== before[k]);
+
+// Did every auth.* key land with the value we set?
+const authLanded = authKeys.filter(k => now[k] === auth[k]);
+const authMissing = authKeys.filter(k => now[k] !== auth[k]);
+
+console.error("  --- before/after ---");
+console.error("  preserved keys: " + preserved.length + " expected, " + survived.length + " survived" + (lost.length ? (", LOST: " + lost.join(", ")) : ""));
+console.error("  auth.* keys:    " + authKeys.length + " set, " + authLanded.length + " landed" + (authMissing.length ? (", MISSING: " + authMissing.join(", ")) : ""));
+console.error("  total keys now: " + nowKeys.length);
+
+const ok = lost.length === 0 && authMissing.length === 0;
+console.error("");
+console.error(ok ? "  CLOBBER CHECK PASSED: no prior keys lost; all auth.* keys present." : "  CLOBBER CHECK FAILED.");
+
+console.log(JSON.stringify({
+  success: ok,
+  name: process.env.AGENT_NAME + "." + process.env.DOMAIN,
+  authKeysWritten: authKeys,
+  preservedKeys: preserved,
+  lostKeys: lost,
+  totalKeys: nowKeys.length,
+  format: "json-in-text-record",
+  note: "Phase-A scaffold; records consumed by AuthResolverImpl + Verifier at M1 (not yet deployed).",
+}));
+'
+)
+
+echo "$RESULT"

--- a/ens-agent-identity/scripts/resolve-agent.sh
+++ b/ens-agent-identity/scripts/resolve-agent.sh
@@ -1,0 +1,119 @@
+#!/bin/bash
+# ENS Agent Identity - Resolve an agent's ENS name and all metadata
+# Usage: ./resolve-agent.sh <ens-name>
+# Example: ./resolve-agent.sh alpha-go.bankr.eth
+
+set -e
+
+ENS_NAME="${1:?Usage: resolve-agent.sh <ens-name>}"
+
+echo "=== Resolving Agent: $ENS_NAME ===" >&2
+echo "" >&2
+
+# Resolve address and all agent text records
+RESULT=$(node -e "
+const { createPublicClient, http } = require('viem');
+const { mainnet } = require('viem/chains');
+const { normalize } = require('viem/ens');
+
+const client = createPublicClient({
+  chain: mainnet,
+  transport: http('https://eth.drpc.org'),
+});
+
+const AGENT_KEYS = [
+  'agent:type',
+  'agent:capabilities',
+  'agent:chains',
+  'agent:a2a',
+  'agent:version',
+  'agent:creator',
+  'agent:token',
+  'agent:token:symbol',
+  'agent:token:address',
+  'agent:delegation',
+  'agent:mode',
+  'agent:policy',
+  'agent:chainId',
+];
+
+(async () => {
+  try {
+    const name = normalize('$ENS_NAME');
+
+    // Resolve address
+    const address = await client.getEnsAddress({ name });
+
+    // Resolve avatar
+    let avatar = null;
+    try {
+      avatar = await client.getEnsAvatar({ name });
+    } catch (e) {}
+
+    // Resolve text records
+    const records = {};
+    const results = await Promise.allSettled(
+      AGENT_KEYS.map(async (key) => {
+        const value = await client.getEnsText({ name, key });
+        return { key, value };
+      })
+    );
+
+    for (const result of results) {
+      if (result.status === 'fulfilled' && result.value.value) {
+        records[result.value.key] = result.value.value;
+      }
+    }
+
+    const output = {
+      name: '$ENS_NAME',
+      address: address || null,
+      avatar: avatar || null,
+      records,
+    };
+
+    console.log(JSON.stringify(output, null, 2));
+  } catch (e) {
+    console.error(JSON.stringify({ error: e.message }));
+    process.exit(1);
+  }
+})();
+" 2>/dev/null)
+
+if [ -z "$RESULT" ]; then
+  echo "Error: Could not resolve $ENS_NAME" >&2
+  exit 1
+fi
+
+# Parse and display
+ADDRESS=$(echo "$RESULT" | node -e "const d=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));console.log(d.address||'(none)')" 2>/dev/null)
+AVATAR=$(echo "$RESULT" | node -e "const d=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));console.log(d.avatar||'')" 2>/dev/null)
+
+echo "Name:    $ENS_NAME" >&2
+echo "Address: $ADDRESS" >&2
+if [ -n "$AVATAR" ]; then
+  echo "Avatar:  $AVATAR" >&2
+fi
+echo "" >&2
+
+# Display agent records
+echo "--- Agent Metadata ---" >&2
+echo "$RESULT" | node -e "
+const data = JSON.parse(require('fs').readFileSync('/dev/stdin', 'utf8'));
+const records = data.records || {};
+const keys = Object.keys(records);
+
+if (keys.length === 0) {
+  console.error('No agent text records found');
+} else {
+  const maxKeyLen = Math.max(...keys.map(k => k.length));
+  for (const [key, value] of Object.entries(records)) {
+    console.error(key.padEnd(maxKeyLen + 2) + value);
+  }
+}
+" 2>/dev/null
+
+echo "" >&2
+
+# Output JSON
+echo "$RESULT"

--- a/ens-agent-identity/scripts/resolve-agent.sh
+++ b/ens-agent-identity/scripts/resolve-agent.sh
@@ -10,11 +10,14 @@ ENS_NAME="${1:?Usage: resolve-agent.sh <ens-name>}"
 echo "=== Resolving Agent: $ENS_NAME ===" >&2
 echo "" >&2
 
-# Resolve address and all agent text records
-RESULT=$(node -e "
+# Resolve address, avatar, and all agent text records in a single Node.js call.
+# Display goes to stderr; machine-readable JSON goes to stdout.
+ENS_NAME="$ENS_NAME" node -e "
 const { createPublicClient, http } = require('viem');
 const { mainnet } = require('viem/chains');
 const { normalize } = require('viem/ens');
+
+const ensName = process.env.ENS_NAME;
 
 const client = createPublicClient({
   chain: mainnet,
@@ -39,81 +42,57 @@ const AGENT_KEYS = [
 
 (async () => {
   try {
-    const name = normalize('$ENS_NAME');
+    const name = normalize(ensName);
 
-    // Resolve address
     const address = await client.getEnsAddress({ name });
 
-    // Resolve avatar
     let avatar = null;
-    try {
-      avatar = await client.getEnsAvatar({ name });
-    } catch (e) {}
+    try { avatar = await client.getEnsAvatar({ name }); } catch {}
 
-    // Resolve text records
-    const records = {};
+    // Resolve all text records in parallel
     const results = await Promise.allSettled(
-      AGENT_KEYS.map(async (key) => {
-        const value = await client.getEnsText({ name, key });
-        return { key, value };
-      })
+      AGENT_KEYS.map(async (key) => ({
+        key,
+        value: await client.getEnsText({ name, key }),
+      }))
     );
 
+    const records = {};
     for (const result of results) {
       if (result.status === 'fulfilled' && result.value.value) {
         records[result.value.key] = result.value.value;
       }
     }
 
+    // Display summary to stderr
+    console.error('Name:    ' + ensName);
+    console.error('Address: ' + (address || '(none)'));
+    if (avatar) console.error('Avatar:  ' + avatar);
+    console.error('');
+    console.error('--- Agent Metadata ---');
+
+    const keys = Object.keys(records);
+    if (keys.length === 0) {
+      console.error('No agent text records found');
+    } else {
+      const pad = Math.max(...keys.map(k => k.length));
+      for (const [key, value] of Object.entries(records)) {
+        console.error(key.padEnd(pad + 2) + value);
+      }
+    }
+    console.error('');
+
+    // Machine-readable JSON to stdout
     const output = {
-      name: '$ENS_NAME',
+      name: ensName,
       address: address || null,
       avatar: avatar || null,
       records,
     };
-
     console.log(JSON.stringify(output, null, 2));
   } catch (e) {
     console.error(JSON.stringify({ error: e.message }));
     process.exit(1);
   }
 })();
-" 2>/dev/null)
-
-if [ -z "$RESULT" ]; then
-  echo "Error: Could not resolve $ENS_NAME" >&2
-  exit 1
-fi
-
-# Parse and display
-ADDRESS=$(echo "$RESULT" | node -e "const d=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));console.log(d.address||'(none)')" 2>/dev/null)
-AVATAR=$(echo "$RESULT" | node -e "const d=JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));console.log(d.avatar||'')" 2>/dev/null)
-
-echo "Name:    $ENS_NAME" >&2
-echo "Address: $ADDRESS" >&2
-if [ -n "$AVATAR" ]; then
-  echo "Avatar:  $AVATAR" >&2
-fi
-echo "" >&2
-
-# Display agent records
-echo "--- Agent Metadata ---" >&2
-echo "$RESULT" | node -e "
-const data = JSON.parse(require('fs').readFileSync('/dev/stdin', 'utf8'));
-const records = data.records || {};
-const keys = Object.keys(records);
-
-if (keys.length === 0) {
-  console.error('No agent text records found');
-} else {
-  const maxKeyLen = Math.max(...keys.map(k => k.length));
-  for (const [key, value] of Object.entries(records)) {
-    console.error(key.padEnd(maxKeyLen + 2) + value);
-  }
-}
-" 2>/dev/null
-
-echo "" >&2
-
-# Output JSON
-echo "$RESULT"
+"

--- a/ens-agent-identity/scripts/set-agent-records.sh
+++ b/ens-agent-identity/scripts/set-agent-records.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# ENS Agent Identity - Register a Bankr agent and set text records via NameStone
+# Usage: ./set-agent-records.sh <agent-name> <agent-type> <capabilities> [address]
+# Example: ./set-agent-records.sh alpha-go trading-bot "swap,bridge,limit-order"
+
+set -e
+
+AGENT_NAME="${1:?Usage: set-agent-records.sh <agent-name> <agent-type> <capabilities> [address]}"
+AGENT_TYPE="${2:?Usage: set-agent-records.sh <agent-name> <agent-type> <capabilities> [address]}"
+CAPABILITIES="${3:?Usage: set-agent-records.sh <agent-name> <agent-type> <capabilities> [address]}"
+ADDRESS="${4:-}"
+DOMAIN="${BANKR_ENS_DOMAIN:-bankr.eth}"
+
+# Require NameStone API key
+if [ -z "$NAMESTONE_API_KEY" ]; then
+  echo "Error: NAMESTONE_API_KEY environment variable not set" >&2
+  echo "Get your API key at https://namestone.com" >&2
+  exit 1
+fi
+
+# Require Bankr CLI for address resolution if no address provided
+if [ -z "$ADDRESS" ]; then
+  if ! command -v bankr >/dev/null 2>&1; then
+    echo "Bankr CLI not found. Provide an address or install with: bun install -g @bankr/cli" >&2
+    exit 1
+  fi
+  echo "Resolving wallet address from Bankr..." >&2
+  ADDRESS=$(bankr prompt "What is my wallet address?" 2>/dev/null | grep -oE '0x[a-fA-F0-9]{40}' | head -1)
+  if [ -z "$ADDRESS" ]; then
+    echo "Error: Could not resolve wallet address from Bankr" >&2
+    exit 1
+  fi
+fi
+
+echo "=== ENS Agent Identity Setup ===" >&2
+echo "Name: ${AGENT_NAME}.${DOMAIN}" >&2
+echo "Type: $AGENT_TYPE" >&2
+echo "Capabilities: $CAPABILITIES" >&2
+echo "Address: $ADDRESS" >&2
+echo "" >&2
+
+# Build text records JSON (using env vars passed to Node.js to avoid injection)
+TEXT_RECORDS=$(AGENT_TYPE="$AGENT_TYPE" \
+  CAPABILITIES="$CAPABILITIES" \
+  AGENT_CHAINS="${AGENT_CHAINS:-base}" \
+  AGENT_VERSION="${AGENT_VERSION}" \
+  AGENT_CREATOR="${AGENT_CREATOR}" \
+  AGENT_A2A="${AGENT_A2A}" \
+  AGENT_TOKEN="${AGENT_TOKEN}" \
+  AGENT_DELEGATION="${AGENT_DELEGATION}" \
+  AGENT_MODE="${AGENT_MODE}" \
+  AGENT_POLICY="${AGENT_POLICY}" \
+  AGENT_CHAIN_ID="${AGENT_CHAIN_ID}" \
+  node -e "
+const records = {
+  'agent:type': process.env.AGENT_TYPE,
+  'agent:capabilities': process.env.CAPABILITIES,
+  'agent:chains': process.env.AGENT_CHAINS,
+};
+
+const optional = {
+  'agent:version': process.env.AGENT_VERSION,
+  'agent:creator': process.env.AGENT_CREATOR,
+  'agent:a2a': process.env.AGENT_A2A,
+  'agent:token': process.env.AGENT_TOKEN,
+  'agent:delegation': process.env.AGENT_DELEGATION,
+  'agent:mode': process.env.AGENT_MODE,
+  'agent:policy': process.env.AGENT_POLICY,
+  'agent:chainId': process.env.AGENT_CHAIN_ID,
+};
+
+for (const [key, value] of Object.entries(optional)) {
+  if (value) records[key] = value;
+}
+
+console.log(JSON.stringify(records));
+")
+
+echo "Step 1: Registering subname via NameStone..." >&2
+
+REQUEST_BODY=$(AGENT_NAME="$AGENT_NAME" DOMAIN="$DOMAIN" ADDRESS="$ADDRESS" TEXT_RECORDS="$TEXT_RECORDS" \
+  node -e "
+    console.log(JSON.stringify({
+      name: process.env.AGENT_NAME,
+      domain: process.env.DOMAIN,
+      address: process.env.ADDRESS,
+      text_records: JSON.parse(process.env.TEXT_RECORDS)
+    }));
+  ")
+
+RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "https://namestone.com/api/public_v1/set-name" \
+  -H "Authorization: $NAMESTONE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "$REQUEST_BODY")
+
+HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+BODY=$(echo "$RESPONSE" | sed '$d')
+
+if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
+  echo "Subname registered successfully." >&2
+else
+  echo "Error (HTTP $HTTP_CODE): $BODY" >&2
+  exit 1
+fi
+
+# Step 2: Verify resolution
+echo "" >&2
+echo "Step 2: Verifying resolution..." >&2
+sleep 2
+
+VERIFY_RESPONSE=$(curl -s "https://namestone.com/api/public_v1/get-names?domain=${DOMAIN}&name=${AGENT_NAME}" \
+  -H "Authorization: $NAMESTONE_API_KEY")
+
+RESOLVED_ADDR=$(echo "$VERIFY_RESPONSE" | node -e "
+  const data = JSON.parse(require('fs').readFileSync('/dev/stdin', 'utf8'));
+  if (Array.isArray(data) && data.length > 0) {
+    console.log(data[0].address || '');
+  }
+" 2>/dev/null || echo "")
+
+if [ -n "$RESOLVED_ADDR" ]; then
+  echo "Resolved: ${AGENT_NAME}.${DOMAIN} -> $RESOLVED_ADDR" >&2
+  echo "" >&2
+  echo "======================================" >&2
+  echo "=== AGENT IDENTITY REGISTERED ===" >&2
+  echo "======================================" >&2
+  echo "" >&2
+  echo "ENS Name: ${AGENT_NAME}.${DOMAIN}" >&2
+  echo "Address:  $RESOLVED_ADDR" >&2
+  echo "Type:     $AGENT_TYPE" >&2
+  echo "" >&2
+  echo "Resolve with: viem getEnsText('${AGENT_NAME}.${DOMAIN}', 'agent:type')" >&2
+  echo "" >&2
+
+  echo "{\"success\":true,\"name\":\"${AGENT_NAME}.${DOMAIN}\",\"address\":\"$RESOLVED_ADDR\",\"type\":\"$AGENT_TYPE\",\"capabilities\":\"$CAPABILITIES\"}"
+else
+  echo "Warning: Could not verify resolution immediately. It may take a moment to propagate." >&2
+  echo "{\"success\":true,\"name\":\"${AGENT_NAME}.${DOMAIN}\",\"address\":\"$ADDRESS\",\"verified\":false}"
+fi

--- a/ens-agent-identity/scripts/set-agent-records.sh
+++ b/ens-agent-identity/scripts/set-agent-records.sh
@@ -18,7 +18,7 @@ if [ -z "$NAMESTONE_API_KEY" ]; then
   exit 1
 fi
 
-# Require Bankr CLI for address resolution if no address provided
+# Resolve address from Bankr CLI if none provided
 if [ -z "$ADDRESS" ]; then
   if ! command -v bankr >/dev/null 2>&1; then
     echo "Bankr CLI not found. Provide an address or install with: bun install -g @bankr/cli" >&2
@@ -39,8 +39,15 @@ echo "Capabilities: $CAPABILITIES" >&2
 echo "Address: $ADDRESS" >&2
 echo "" >&2
 
-# Build text records JSON (using env vars passed to Node.js to avoid injection)
-TEXT_RECORDS=$(AGENT_TYPE="$AGENT_TYPE" \
+# Build the full NameStone request body in a single Node.js call.
+# All user input is passed via environment variables to prevent injection.
+echo "Step 1: Registering subname via NameStone..." >&2
+
+REQUEST_BODY=$(\
+  AGENT_NAME="$AGENT_NAME" \
+  DOMAIN="$DOMAIN" \
+  ADDRESS="$ADDRESS" \
+  AGENT_TYPE="$AGENT_TYPE" \
   CAPABILITIES="$CAPABILITIES" \
   AGENT_CHAINS="${AGENT_CHAINS:-base}" \
   AGENT_VERSION="${AGENT_VERSION}" \
@@ -73,20 +80,13 @@ for (const [key, value] of Object.entries(optional)) {
   if (value) records[key] = value;
 }
 
-console.log(JSON.stringify(records));
+console.log(JSON.stringify({
+  name: process.env.AGENT_NAME,
+  domain: process.env.DOMAIN,
+  address: process.env.ADDRESS,
+  text_records: records,
+}));
 ")
-
-echo "Step 1: Registering subname via NameStone..." >&2
-
-REQUEST_BODY=$(AGENT_NAME="$AGENT_NAME" DOMAIN="$DOMAIN" ADDRESS="$ADDRESS" TEXT_RECORDS="$TEXT_RECORDS" \
-  node -e "
-    console.log(JSON.stringify({
-      name: process.env.AGENT_NAME,
-      domain: process.env.DOMAIN,
-      address: process.env.ADDRESS,
-      text_records: JSON.parse(process.env.TEXT_RECORDS)
-    }));
-  ")
 
 RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "https://namestone.com/api/public_v1/set-name" \
   -H "Authorization: $NAMESTONE_API_KEY" \
@@ -96,19 +96,27 @@ RESPONSE=$(curl -s -w "\n%{http_code}" -X POST "https://namestone.com/api/public
 HTTP_CODE=$(echo "$RESPONSE" | tail -1)
 BODY=$(echo "$RESPONSE" | sed '$d')
 
-if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
-  echo "Subname registered successfully." >&2
-else
+if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
   echo "Error (HTTP $HTTP_CODE): $BODY" >&2
   exit 1
 fi
+
+echo "Subname registered successfully." >&2
 
 # Step 2: Verify resolution
 echo "" >&2
 echo "Step 2: Verifying resolution..." >&2
 sleep 2
 
-VERIFY_RESPONSE=$(curl -s "https://namestone.com/api/public_v1/get-names?domain=${DOMAIN}&name=${AGENT_NAME}" \
+# URL-encode name and domain in a single Node.js call
+ENCODED=$(AGENT_NAME="$AGENT_NAME" DOMAIN="$DOMAIN" node -e "
+  console.log(encodeURIComponent(process.env.AGENT_NAME));
+  console.log(encodeURIComponent(process.env.DOMAIN));
+")
+ENCODED_NAME=$(echo "$ENCODED" | head -1)
+ENCODED_DOMAIN=$(echo "$ENCODED" | tail -1)
+
+VERIFY_RESPONSE=$(curl -s "https://namestone.com/api/public_v1/get-names?domain=${ENCODED_DOMAIN}&name=${ENCODED_NAME}" \
   -H "Authorization: $NAMESTONE_API_KEY")
 
 RESOLVED_ADDR=$(echo "$VERIFY_RESPONSE" | node -e "
@@ -117,6 +125,26 @@ RESOLVED_ADDR=$(echo "$VERIFY_RESPONSE" | node -e "
     console.log(data[0].address || '');
   }
 " 2>/dev/null || echo "")
+
+# Emit final result as JSON (all values passed via env vars)
+emit_result() {
+  AGENT_NAME="$AGENT_NAME" DOMAIN="$DOMAIN" ADDRESS="$1" \
+    AGENT_TYPE="$AGENT_TYPE" CAPABILITIES="$CAPABILITIES" VERIFIED="$2" \
+    node -e "
+      const o = {
+        success: true,
+        name: process.env.AGENT_NAME + '.' + process.env.DOMAIN,
+        address: process.env.ADDRESS,
+      };
+      if (process.env.VERIFIED === 'true') {
+        o.type = process.env.AGENT_TYPE;
+        o.capabilities = process.env.CAPABILITIES;
+      } else {
+        o.verified = false;
+      }
+      console.log(JSON.stringify(o));
+    "
+}
 
 if [ -n "$RESOLVED_ADDR" ]; then
   echo "Resolved: ${AGENT_NAME}.${DOMAIN} -> $RESOLVED_ADDR" >&2
@@ -131,9 +159,8 @@ if [ -n "$RESOLVED_ADDR" ]; then
   echo "" >&2
   echo "Resolve with: viem getEnsText('${AGENT_NAME}.${DOMAIN}', 'agent:type')" >&2
   echo "" >&2
-
-  echo "{\"success\":true,\"name\":\"${AGENT_NAME}.${DOMAIN}\",\"address\":\"$RESOLVED_ADDR\",\"type\":\"$AGENT_TYPE\",\"capabilities\":\"$CAPABILITIES\"}"
+  emit_result "$RESOLVED_ADDR" "true"
 else
   echo "Warning: Could not verify resolution immediately. It may take a moment to propagate." >&2
-  echo "{\"success\":true,\"name\":\"${AGENT_NAME}.${DOMAIN}\",\"address\":\"$ADDRESS\",\"verified\":false}"
+  emit_result "$ADDRESS" "false"
 fi

--- a/ens-agent-identity/scripts/verify-action.ts
+++ b/ens-agent-identity/scripts/verify-action.ts
@@ -1,0 +1,258 @@
+/**
+ * ENS Agent Identity — Phase A: AuthResolver read-only verification (FORWARD-DECLARING SCAFFOLD)
+ *
+ * What is REAL here:
+ *   - Resolve an ENS name on L1 mainnet (ENSIP-15 normalized).
+ *   - Read auth.credential / auth.capability / auth.revocation records via CCIP-Read.
+ *   - Parse the Phase-A JSON payloads and run the LOCAL, read-only structural pre-checks
+ *     that mirror the spec's verifyAction ordering (credential present -> validity window
+ *     -> revocation presence -> scheme recognized).
+ *
+ * What is STUBBED (pending M1):
+ *   - The actual on-chain AuthResolver.verifyAction(...) call, which performs signature
+ *     verification + scheme dispatch via the Verifier contract. The AuthResolverImpl +
+ *     Verifier contracts are the unfunded M1 deliverable (target 2026-08-31,
+ *     github.com/steg-eth). They are NOT deployed. This script NEVER claims a signature
+ *     was cryptographically verified — it verifies the RECORD PLUMBING only.
+ *
+ * The verifyAction signature below is a DESIGN SKETCH derived from the spec (§5.1) and the
+ * Bankr compatibility test, NOT a deployed ABI. See // TODO(M1) markers.
+ *
+ * Run (Node 24+, strips types and runs directly):
+ *   node verify-action.ts <ens-name> [credential-id]
+ *
+ * Env:
+ *   ETH_RPC_URL          (default https://eth.drpc.org) L1 mainnet RPC for ENS resolution.
+ *   AUTH_RESOLVER_ADDRESS (optional) per-name AuthResolver proxy on L1. UNSET => demo mode:
+ *                         prints "contract not deployed yet; record plumbing verified".
+ *   AUTH_MESSAGE         (optional) the signed message digest (hex) the agent produced.
+ *   AUTH_SIGNATURE       (optional) the secp256k1 signature (hex) over AUTH_MESSAGE.
+ *   BASE_RPC_URL         (optional, default https://base.drpc.org) ONLY for the ERC-8004
+ *                        cross-check; not used by the verification path.
+ *
+ * Output: human-readable progress -> stderr; machine-readable JSON -> stdout.
+ */
+
+const { createPublicClient, http } = require("viem");
+const { mainnet } = require("viem/chains");
+const { normalize, namehash } = require("viem/ens");
+
+// --- Phase-A record shapes (JSON-in-text-record; migrates to CBOR-in-data at M1) ---
+interface CredentialRecord {
+  scheme: string; // string form; on-chain canonical is keccak256(scheme) (spec §3.2)
+  address: string; // DECISION A1: address, not the 64-byte uncompressed pubKey spec §3.2 wants
+  notBefore: number; // unix seconds
+  notAfter: number; // unix seconds; 0 = no expiry
+  capabilityRef?: string; // structural only in v1 (spec §6.1)
+  schemaVersion?: string;
+}
+interface RevocationRecord {
+  revokedAt?: number;
+  reason?: string;
+  schemaVersion?: string;
+}
+
+// Schemes the v1 Verifier will register (spec §3.2). Used only for a LOCAL "recognized?"
+// pre-check — actual dispatch happens on-chain in the M1 Verifier.
+const KNOWN_SCHEMES = new Set(["WebAuthn-ES256", "ECDSA-secp256k1", "EIP-1271"]);
+
+// DenyReason mirror (spec §5.1). Local pre-checks can surface a SUBSET; the authoritative
+// decision is the on-chain verifyAction return, which is stubbed here.
+type LocalReason =
+  | "None"
+  | "Unverified" // credential record missing/empty (local) — signature check is on-chain
+  | "Stale"
+  | "Revoked"
+  | "Mismatch" // scheme not recognized locally
+  | "ContractNotDeployed"; // Phase-A sentinel: on-chain step not available
+
+/**
+ * verifyAction ABI — DESIGN SKETCH ONLY (spec §5.1). NOT a deployed contract.
+ * // TODO(M1): replace with the audited AuthResolverImpl ABI once the contract ships
+ * //           (github.com/steg-eth). Confirm struct field ordering + DenyReason enum.
+ */
+const VERIFY_ACTION_ABI = [
+  {
+    type: "function",
+    name: "verifyAction",
+    stateMutability: "view",
+    inputs: [
+      { name: "node", type: "bytes32" },
+      { name: "credentialId", type: "string" },
+      { name: "message", type: "bytes" },
+      { name: "signature", type: "bytes" },
+    ],
+    outputs: [
+      {
+        name: "",
+        type: "tuple",
+        components: [
+          { name: "allowed", type: "bool" },
+          { name: "reason", type: "uint8" },
+          { name: "resolvedAt", type: "uint64" },
+          { name: "stateHash", type: "bytes32" },
+        ],
+      },
+    ],
+  },
+] as const;
+
+/**
+ * STUB: the on-chain verifyAction call. The AuthResolver + Verifier are not deployed,
+ * so this never executes a real signature verification. It exists to mark exactly where
+ * the M1 contract call slots in, and to keep the call site honest.
+ *
+ * // TODO(M1): when AuthResolverImpl is deployed, replace the throw with:
+ * //   return client.readContract({ address, abi: VERIFY_ACTION_ABI,
+ * //     functionName: "verifyAction", args: [node, credentialId, message, signature] });
+ */
+function verifyActionOnChain(_args: {
+  node: `0x${string}`;
+  credentialId: string;
+  message: `0x${string}`;
+  signature: `0x${string}`;
+  resolver: string;
+}): never {
+  throw new Error(
+    "AuthResolver.verifyAction is not deployed (M1 deliverable). " +
+      "Phase A verifies record plumbing only; signature verification + scheme dispatch happen on-chain at M1.",
+  );
+}
+
+async function main() {
+  const ensName = process.argv[2];
+  const credentialId = process.argv[3] || "primary";
+  if (!ensName) {
+    console.error("Usage: node verify-action.ts <ens-name> [credential-id]");
+    process.exit(2);
+  }
+
+  const rpcUrl = process.env.ETH_RPC_URL || "https://eth.drpc.org";
+  const resolverAddr = process.env.AUTH_RESOLVER_ADDRESS || "";
+  const message = process.env.AUTH_MESSAGE || "";
+  const signature = process.env.AUTH_SIGNATURE || "";
+
+  console.error("=== Phase A: AuthResolver read-only verification (SCAFFOLD) ===");
+  console.error(`ENS name:      ${ensName}`);
+  console.error(`Credential id: ${credentialId}`);
+  console.error(`L1 RPC:        ${rpcUrl}`);
+  console.error("");
+
+  const client = createPublicClient({ chain: mainnet, transport: http(rpcUrl) });
+
+  // F8: normalize user-typed name via ENSIP-15 before namehash.
+  const name = normalize(ensName);
+  const node = namehash(name) as `0x${string}`;
+
+  console.error("Step 1: Resolving ENS name (L1)...");
+  const address = await client.getEnsAddress({ name }).catch(() => null);
+  console.error(`  address: ${address || "(none)"}`);
+
+  console.error("Step 2: Reading auth.* records (CCIP-Read)...");
+  const credKey = `auth.credential[${credentialId}]`;
+  const capKey = `auth.capability[${credentialId}]`;
+  const revKey = `auth.revocation[${credentialId}]`;
+
+  const [credRaw, capRaw, revRaw] = await Promise.all([
+    client.getEnsText({ name, key: credKey }).catch(() => null),
+    client.getEnsText({ name, key: capKey }).catch(() => null),
+    client.getEnsText({ name, key: revKey }).catch(() => null),
+  ]);
+  console.error(`  ${credKey}: ${credRaw ? "present" : "(empty)"}`);
+  console.error(`  ${capKey}: ${capRaw ? "present" : "(empty)"}`);
+  console.error(`  ${revKey}: ${revRaw ? "present" : "(empty)"}`);
+  console.error("");
+
+  // --- LOCAL read-only pre-checks (mirror spec §5.2 ordering; NOT the authoritative call) ---
+  console.error("Step 3: Local structural pre-checks (read-only mirror of §5.2)...");
+  const plumbing = {
+    resolved: !!address,
+    credentialFound: !!credRaw,
+    credentialParsed: false,
+    validityWindowOk: false,
+    revoked: !!revRaw,
+    schemeRecognized: false,
+  };
+  let localReason: LocalReason = "None";
+  let credential: CredentialRecord | null = null;
+
+  if (!credRaw) {
+    localReason = "Unverified"; // step 1: credential missing/empty
+  } else {
+    try {
+      credential = JSON.parse(credRaw) as CredentialRecord;
+      plumbing.credentialParsed = true;
+    } catch {
+      localReason = "Unverified"; // step 2: decode failure
+    }
+  }
+
+  if (credential) {
+    const now = Math.floor(Date.now() / 1000);
+    const okWindow =
+      now >= (credential.notBefore ?? 0) &&
+      (credential.notAfter === 0 || credential.notAfter === undefined || now <= credential.notAfter);
+    plumbing.validityWindowOk = okWindow;
+    plumbing.schemeRecognized = KNOWN_SCHEMES.has(credential.scheme);
+
+    if (!okWindow) localReason = "Stale"; // step 3
+    else if (plumbing.revoked) localReason = "Revoked"; // step 4 (presence of bytes => revoked)
+    else if (!plumbing.schemeRecognized) localReason = "Mismatch"; // step 5
+    // steps 6 (signature verify) + 7 (success) are on-chain — see below.
+  }
+
+  console.error(`  resolved=${plumbing.resolved} credentialFound=${plumbing.credentialFound} ` +
+    `parsed=${plumbing.credentialParsed} validityWindow=${plumbing.validityWindowOk} ` +
+    `revoked=${plumbing.revoked} schemeRecognized=${plumbing.schemeRecognized}`);
+  if (localReason !== "None") {
+    console.error(`  local pre-check would DENY before reaching on-chain verify: ${localReason}`);
+  }
+  console.error("");
+
+  // --- The on-chain step: STUBBED (pending M1) ---
+  console.error("Step 4: On-chain AuthResolver.verifyAction (signature verify + scheme dispatch)...");
+  let onChain: { attempted: boolean; note: string } = { attempted: false, note: "" };
+
+  if (!resolverAddr) {
+    // Demo mode: contract address not provided => not deployed yet. Exit cleanly (non-error).
+    onChain.note = "contract not deployed yet; record plumbing verified";
+    console.error(`  AUTH_RESOLVER_ADDRESS unset => ${onChain.note}`);
+  } else {
+    // Address provided, but the contract + ABI are a design sketch — do NOT pretend to verify.
+    onChain.attempted = true;
+    try {
+      verifyActionOnChain({
+        node,
+        credentialId,
+        message: (message || "0x") as `0x${string}`,
+        signature: (signature || "0x") as `0x${string}`,
+        resolver: resolverAddr,
+      });
+    } catch (e: any) {
+      onChain.note = e.message;
+      console.error(`  STUBBED: ${e.message}`);
+    }
+  }
+  console.error("");
+
+  // verified is INTENTIONALLY null: no end-to-end verification is possible pre-M1.
+  const result = {
+    phase: "A",
+    verified: null as null, // null => not determinable until M1 contract is deployed
+    reason: resolverAddr ? "ContractNotDeployed" : "ContractNotDeployed",
+    localPreCheckReason: localReason,
+    credentialId,
+    name,
+    address,
+    recordPlumbing: plumbing,
+    onChain,
+    note: "Phase-A scaffold: record plumbing verified; signature verification is the M1 on-chain step (not deployed).",
+  };
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+main().catch((e) => {
+  console.error(JSON.stringify({ error: e.message }));
+  process.exit(1);
+});

--- a/ens-agent-identity/scripts/verify-agent-registration.sh
+++ b/ens-agent-identity/scripts/verify-agent-registration.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+# ENS Agent Identity - Verify ENSIP-25 link between ENS name and ERC-8004 identity
+# Usage: ./verify-agent-registration.sh <ens-name> <agent-id> [chain]
+# Example: ./verify-agent-registration.sh alpha-go.bankr.eth 42 base
+
+set -e
+
+ENS_NAME="${1:?Usage: verify-agent-registration.sh <ens-name> <agent-id> [chain]}"
+AGENT_ID="${2:?Usage: verify-agent-registration.sh <ens-name> <agent-id> [chain]}"
+CHAIN="${3:-base}"
+
+# Chain configuration
+case "$CHAIN" in
+  base)
+    CHAIN_ID=8453
+    RPC_URL="https://mainnet.base.org"
+    EXPLORER="basescan.org"
+    # ERC-7930 prefix for Base: version 1, EVM (0x0000), 2-byte chain ref, chain ID 0x2105, 20-byte addr (0x14)
+    ERC7930_PREFIX="0x0001000002210514"
+    ;;
+  ethereum|mainnet)
+    CHAIN_ID=1
+    RPC_URL="https://eth.llamarpc.com"
+    EXPLORER="etherscan.io"
+    ERC7930_PREFIX="0x00010000010114"
+    ;;
+  sepolia)
+    CHAIN_ID=11155111
+    RPC_URL="https://rpc.sepolia.org"
+    EXPLORER="sepolia.etherscan.io"
+    ERC7930_PREFIX="0x0001000003AA36A714"
+    ;;
+  *)
+    echo "Unsupported chain: $CHAIN" >&2
+    echo "Supported: base, ethereum, sepolia" >&2
+    exit 1
+    ;;
+esac
+
+# Default registry addresses (ERC-8004)
+case "$CHAIN" in
+  ethereum|mainnet)
+    IDENTITY_REGISTRY="${ERC8004_REGISTRY:-0x8004A169FB4a3325136EB29fA0ceB6D2e539a432}"
+    ;;
+  base)
+    IDENTITY_REGISTRY="${ERC8004_REGISTRY:-0x8004A169FB4a3325136EB29fA0ceB6D2e539a432}"
+    ;;
+  sepolia)
+    IDENTITY_REGISTRY="${ERC8004_REGISTRY:-0x8004A818BFB912233c491871b3d84c89A494BD9e}"
+    ;;
+  *)
+    IDENTITY_REGISTRY="${ERC8004_REGISTRY:-}"
+    ;;
+esac
+
+echo "=== ENSIP-25 Verification ===" >&2
+echo "ENS Name: $ENS_NAME" >&2
+echo "Agent ID: $AGENT_ID" >&2
+echo "Chain: $CHAIN (ID: $CHAIN_ID)" >&2
+if [ -n "$IDENTITY_REGISTRY" ]; then
+  echo "Registry: $IDENTITY_REGISTRY" >&2
+fi
+echo "" >&2
+
+# Step 1: Resolve ENS name to address
+echo "Step 1: Resolving ENS name..." >&2
+
+RESOLVED_ADDR=$(node -e "
+const { createPublicClient, http } = require('viem');
+const { mainnet } = require('viem/chains');
+const { normalize } = require('viem/ens');
+
+const client = createPublicClient({
+  chain: mainnet,
+  transport: http('https://eth.drpc.org'),
+});
+
+(async () => {
+  try {
+    const address = await client.getEnsAddress({ name: normalize('$ENS_NAME') });
+    if (address) console.log(address);
+  } catch (e) {
+    console.error(e.message);
+  }
+})();
+" 2>/dev/null)
+
+if [ -z "$RESOLVED_ADDR" ]; then
+  echo "Could not resolve $ENS_NAME to an address" >&2
+  exit 1
+fi
+
+echo "Address: $RESOLVED_ADDR" >&2
+
+# Step 2: Check ENSIP-25 text record
+echo "" >&2
+echo "Step 2: Checking ENSIP-25 verification record..." >&2
+
+if [ -n "$IDENTITY_REGISTRY" ]; then
+  # Construct the ERC-7930 registry address
+  REGISTRY_LOWER=$(echo "$IDENTITY_REGISTRY" | tr '[:upper:]' '[:lower:]')
+  ERC7930_ADDR="${ERC7930_PREFIX}${REGISTRY_LOWER#0x}"
+  TEXT_RECORD_KEY="agent-registration[${ERC7930_ADDR}][${AGENT_ID}]"
+
+  echo "Text record key: $TEXT_RECORD_KEY" >&2
+
+  RECORD_VALUE=$(node -e "
+  const { createPublicClient, http } = require('viem');
+  const { mainnet } = require('viem/chains');
+  const { normalize } = require('viem/ens');
+
+  const client = createPublicClient({
+    chain: mainnet,
+    transport: http('https://eth.drpc.org'),
+  });
+
+  (async () => {
+    try {
+      const value = await client.getEnsText({
+        name: normalize('$ENS_NAME'),
+        key: '$TEXT_RECORD_KEY'
+      });
+      if (value) console.log(value);
+    } catch (e) {}
+  })();
+  " 2>/dev/null)
+
+  if [ -n "$RECORD_VALUE" ]; then
+    echo "ENSIP-25 record value: $RECORD_VALUE" >&2
+    ENSIP25_VERIFIED=true
+  else
+    echo "No ENSIP-25 record found" >&2
+    ENSIP25_VERIFIED=false
+  fi
+else
+  echo "No registry address configured for $CHAIN. Set ERC8004_REGISTRY env var." >&2
+  ENSIP25_VERIFIED=false
+fi
+
+# Step 3: Check ERC-8004 registry (if available)
+echo "" >&2
+echo "Step 3: Checking ERC-8004 registry..." >&2
+
+ERC8004_VERIFIED=false
+if [ -n "$IDENTITY_REGISTRY" ]; then
+  # Call tokenURI(uint256) on the Identity Registry (standard ERC-721)
+  # Selector: 0xc87b56dd (tokenURI)
+  AGENT_ID_HEX=$(printf '%064x' "$AGENT_ID")
+  CALLDATA="0xc87b56dd${AGENT_ID_HEX}"
+
+  REGISTRY_RESULT=$(curl -s --max-time 10 -X POST "$RPC_URL" \
+    -H "Content-Type: application/json" \
+    -d "{
+      \"jsonrpc\": \"2.0\",
+      \"id\": 1,
+      \"method\": \"eth_call\",
+      \"params\": [{
+        \"to\": \"$IDENTITY_REGISTRY\",
+        \"data\": \"$CALLDATA\"
+      }, \"latest\"]
+    }" | node -e "
+      const data = JSON.parse(require('fs').readFileSync('/dev/stdin', 'utf8'));
+      if (data.result && data.result !== '0x') {
+        // Decode ABI-encoded string
+        const hex = data.result;
+        try {
+          const length = parseInt(hex.slice(130, 194), 16);
+          if (length > 0) {
+            const str = Buffer.from(hex.slice(194, 194 + length * 2), 'hex').toString('utf8');
+            console.log(str);
+          }
+        } catch (e) {}
+      }
+    " 2>/dev/null)
+
+  if [ -n "$REGISTRY_RESULT" ]; then
+    echo "ERC-8004 agent URI: $REGISTRY_RESULT" >&2
+    ERC8004_VERIFIED=true
+  else
+    echo "Agent #$AGENT_ID not found in registry" >&2
+  fi
+else
+  echo "Skipped (no registry address)" >&2
+fi
+
+# Summary
+echo "" >&2
+echo "=== Verification Summary ===" >&2
+echo "" >&2
+
+if [ "$ENSIP25_VERIFIED" = "true" ] && [ "$ERC8004_VERIFIED" = "true" ]; then
+  echo "ENS Resolution:       $ENS_NAME -> $RESOLVED_ADDR" >&2
+  echo "ENSIP-25 Record:      $TEXT_RECORD_KEY = \"$RECORD_VALUE\"" >&2
+  echo "ERC-8004 Registry:    Agent #$AGENT_ID found" >&2
+  echo "" >&2
+  echo "FULLY VERIFIED: $ENS_NAME is agent #$AGENT_ID" >&2
+  echo "{\"verified\":true,\"name\":\"$ENS_NAME\",\"address\":\"$RESOLVED_ADDR\",\"agentId\":$AGENT_ID,\"ensip25\":true,\"erc8004\":true}"
+elif [ "$ENSIP25_VERIFIED" = "true" ]; then
+  echo "ENS Resolution:       $ENS_NAME -> $RESOLVED_ADDR" >&2
+  echo "ENSIP-25 Record:      Set" >&2
+  echo "ERC-8004 Registry:    Not verified" >&2
+  echo "" >&2
+  echo "PARTIAL: ENSIP-25 set but ERC-8004 not confirmed" >&2
+  echo "{\"verified\":\"partial\",\"name\":\"$ENS_NAME\",\"address\":\"$RESOLVED_ADDR\",\"agentId\":$AGENT_ID,\"ensip25\":true,\"erc8004\":false}"
+elif [ "$ERC8004_VERIFIED" = "true" ]; then
+  echo "ENS Resolution:       $ENS_NAME -> $RESOLVED_ADDR" >&2
+  echo "ENSIP-25 Record:      Not set" >&2
+  echo "ERC-8004 Registry:    Agent #$AGENT_ID found" >&2
+  echo "" >&2
+  echo "PARTIAL: ERC-8004 exists but ENSIP-25 not set" >&2
+  echo "{\"verified\":\"partial\",\"name\":\"$ENS_NAME\",\"address\":\"$RESOLVED_ADDR\",\"agentId\":$AGENT_ID,\"ensip25\":false,\"erc8004\":true}"
+else
+  echo "ENS Resolution:       $ENS_NAME -> $RESOLVED_ADDR" >&2
+  echo "ENSIP-25 Record:      Not set" >&2
+  echo "ERC-8004 Registry:    Not verified" >&2
+  echo "" >&2
+  echo "NOT VERIFIED: No ENSIP-25 or ERC-8004 link found" >&2
+  echo "{\"verified\":false,\"name\":\"$ENS_NAME\",\"address\":\"$RESOLVED_ADDR\",\"agentId\":$AGENT_ID,\"ensip25\":false,\"erc8004\":false}"
+fi

--- a/ens-agent-identity/scripts/verify-agent-registration.sh
+++ b/ens-agent-identity/scripts/verify-agent-registration.sh
@@ -9,47 +9,39 @@ ENS_NAME="${1:?Usage: verify-agent-registration.sh <ens-name> <agent-id> [chain]
 AGENT_ID="${2:?Usage: verify-agent-registration.sh <ens-name> <agent-id> [chain]}"
 CHAIN="${3:-base}"
 
-# Chain configuration
+# Validate AGENT_ID is a positive integer
+if ! [[ "$AGENT_ID" =~ ^[0-9]+$ ]]; then
+  echo "Error: agent-id must be a positive integer, got: $AGENT_ID" >&2
+  exit 1
+fi
+
+# Chain configuration (RPC, explorer, ERC-7930 prefix, registry address)
 case "$CHAIN" in
   base)
     CHAIN_ID=8453
     RPC_URL="https://mainnet.base.org"
     EXPLORER="basescan.org"
-    # ERC-7930 prefix for Base: version 1, EVM (0x0000), 2-byte chain ref, chain ID 0x2105, 20-byte addr (0x14)
     ERC7930_PREFIX="0x0001000002210514"
+    IDENTITY_REGISTRY="${ERC8004_REGISTRY:-0x8004A169FB4a3325136EB29fA0ceB6D2e539a432}"
     ;;
   ethereum|mainnet)
     CHAIN_ID=1
-    RPC_URL="https://eth.llamarpc.com"
+    RPC_URL="https://eth.drpc.org"
     EXPLORER="etherscan.io"
     ERC7930_PREFIX="0x00010000010114"
+    IDENTITY_REGISTRY="${ERC8004_REGISTRY:-0x8004A169FB4a3325136EB29fA0ceB6D2e539a432}"
     ;;
   sepolia)
     CHAIN_ID=11155111
     RPC_URL="https://rpc.sepolia.org"
     EXPLORER="sepolia.etherscan.io"
     ERC7930_PREFIX="0x0001000003AA36A714"
+    IDENTITY_REGISTRY="${ERC8004_REGISTRY:-0x8004A818BFB912233c491871b3d84c89A494BD9e}"
     ;;
   *)
     echo "Unsupported chain: $CHAIN" >&2
     echo "Supported: base, ethereum, sepolia" >&2
     exit 1
-    ;;
-esac
-
-# Default registry addresses (ERC-8004)
-case "$CHAIN" in
-  ethereum|mainnet)
-    IDENTITY_REGISTRY="${ERC8004_REGISTRY:-0x8004A169FB4a3325136EB29fA0ceB6D2e539a432}"
-    ;;
-  base)
-    IDENTITY_REGISTRY="${ERC8004_REGISTRY:-0x8004A169FB4a3325136EB29fA0ceB6D2e539a432}"
-    ;;
-  sepolia)
-    IDENTITY_REGISTRY="${ERC8004_REGISTRY:-0x8004A818BFB912233c491871b3d84c89A494BD9e}"
-    ;;
-  *)
-    IDENTITY_REGISTRY="${ERC8004_REGISTRY:-}"
     ;;
 esac
 
@@ -65,7 +57,7 @@ echo "" >&2
 # Step 1: Resolve ENS name to address
 echo "Step 1: Resolving ENS name..." >&2
 
-RESOLVED_ADDR=$(node -e "
+RESOLVED_ADDR=$(ENS_NAME="$ENS_NAME" node -e "
 const { createPublicClient, http } = require('viem');
 const { mainnet } = require('viem/chains');
 const { normalize } = require('viem/ens');
@@ -77,7 +69,7 @@ const client = createPublicClient({
 
 (async () => {
   try {
-    const address = await client.getEnsAddress({ name: normalize('$ENS_NAME') });
+    const address = await client.getEnsAddress({ name: normalize(process.env.ENS_NAME) });
     if (address) console.log(address);
   } catch (e) {
     console.error(e.message);
@@ -96,55 +88,55 @@ echo "Address: $RESOLVED_ADDR" >&2
 echo "" >&2
 echo "Step 2: Checking ENSIP-25 verification record..." >&2
 
+ENSIP25_VERIFIED=false
+RECORD_VALUE=""
+
 if [ -n "$IDENTITY_REGISTRY" ]; then
-  # Construct the ERC-7930 registry address
   REGISTRY_LOWER=$(echo "$IDENTITY_REGISTRY" | tr '[:upper:]' '[:lower:]')
   ERC7930_ADDR="${ERC7930_PREFIX}${REGISTRY_LOWER#0x}"
   TEXT_RECORD_KEY="agent-registration[${ERC7930_ADDR}][${AGENT_ID}]"
 
   echo "Text record key: $TEXT_RECORD_KEY" >&2
 
-  RECORD_VALUE=$(node -e "
-  const { createPublicClient, http } = require('viem');
-  const { mainnet } = require('viem/chains');
-  const { normalize } = require('viem/ens');
+  RECORD_VALUE=$(ENS_NAME="$ENS_NAME" TEXT_RECORD_KEY="$TEXT_RECORD_KEY" node -e "
+const { createPublicClient, http } = require('viem');
+const { mainnet } = require('viem/chains');
+const { normalize } = require('viem/ens');
 
-  const client = createPublicClient({
-    chain: mainnet,
-    transport: http('https://eth.drpc.org'),
-  });
+const client = createPublicClient({
+  chain: mainnet,
+  transport: http('https://eth.drpc.org'),
+});
 
-  (async () => {
-    try {
-      const value = await client.getEnsText({
-        name: normalize('$ENS_NAME'),
-        key: '$TEXT_RECORD_KEY'
-      });
-      if (value) console.log(value);
-    } catch (e) {}
-  })();
-  " 2>/dev/null)
+(async () => {
+  try {
+    const value = await client.getEnsText({
+      name: normalize(process.env.ENS_NAME),
+      key: process.env.TEXT_RECORD_KEY
+    });
+    if (value) console.log(value);
+  } catch {}
+})();
+" 2>/dev/null)
 
   if [ -n "$RECORD_VALUE" ]; then
     echo "ENSIP-25 record value: $RECORD_VALUE" >&2
     ENSIP25_VERIFIED=true
   else
     echo "No ENSIP-25 record found" >&2
-    ENSIP25_VERIFIED=false
   fi
 else
   echo "No registry address configured for $CHAIN. Set ERC8004_REGISTRY env var." >&2
-  ENSIP25_VERIFIED=false
 fi
 
-# Step 3: Check ERC-8004 registry (if available)
+# Step 3: Check ERC-8004 registry
 echo "" >&2
 echo "Step 3: Checking ERC-8004 registry..." >&2
 
 ERC8004_VERIFIED=false
+
 if [ -n "$IDENTITY_REGISTRY" ]; then
   # Call tokenURI(uint256) on the Identity Registry (standard ERC-721)
-  # Selector: 0xc87b56dd (tokenURI)
   AGENT_ID_HEX=$(printf '%064x' "$AGENT_ID")
   CALLDATA="0xc87b56dd${AGENT_ID_HEX}"
 
@@ -161,7 +153,6 @@ if [ -n "$IDENTITY_REGISTRY" ]; then
     }" | node -e "
       const data = JSON.parse(require('fs').readFileSync('/dev/stdin', 'utf8'));
       if (data.result && data.result !== '0x') {
-        // Decode ABI-encoded string
         const hex = data.result;
         try {
           const length = parseInt(hex.slice(130, 194), 16);
@@ -169,7 +160,7 @@ if [ -n "$IDENTITY_REGISTRY" ]; then
             const str = Buffer.from(hex.slice(194, 194 + length * 2), 'hex').toString('utf8');
             console.log(str);
           }
-        } catch (e) {}
+        } catch {}
       }
     " 2>/dev/null)
 
@@ -188,32 +179,50 @@ echo "" >&2
 echo "=== Verification Summary ===" >&2
 echo "" >&2
 
-if [ "$ENSIP25_VERIFIED" = "true" ] && [ "$ERC8004_VERIFIED" = "true" ]; then
-  echo "ENS Resolution:       $ENS_NAME -> $RESOLVED_ADDR" >&2
+echo "ENS Resolution:       $ENS_NAME -> $RESOLVED_ADDR" >&2
+
+if [ "$ENSIP25_VERIFIED" = "true" ]; then
   echo "ENSIP-25 Record:      $TEXT_RECORD_KEY = \"$RECORD_VALUE\"" >&2
-  echo "ERC-8004 Registry:    Agent #$AGENT_ID found" >&2
-  echo "" >&2
-  echo "FULLY VERIFIED: $ENS_NAME is agent #$AGENT_ID" >&2
-  echo "{\"verified\":true,\"name\":\"$ENS_NAME\",\"address\":\"$RESOLVED_ADDR\",\"agentId\":$AGENT_ID,\"ensip25\":true,\"erc8004\":true}"
-elif [ "$ENSIP25_VERIFIED" = "true" ]; then
-  echo "ENS Resolution:       $ENS_NAME -> $RESOLVED_ADDR" >&2
-  echo "ENSIP-25 Record:      Set" >&2
-  echo "ERC-8004 Registry:    Not verified" >&2
-  echo "" >&2
-  echo "PARTIAL: ENSIP-25 set but ERC-8004 not confirmed" >&2
-  echo "{\"verified\":\"partial\",\"name\":\"$ENS_NAME\",\"address\":\"$RESOLVED_ADDR\",\"agentId\":$AGENT_ID,\"ensip25\":true,\"erc8004\":false}"
-elif [ "$ERC8004_VERIFIED" = "true" ]; then
-  echo "ENS Resolution:       $ENS_NAME -> $RESOLVED_ADDR" >&2
-  echo "ENSIP-25 Record:      Not set" >&2
-  echo "ERC-8004 Registry:    Agent #$AGENT_ID found" >&2
-  echo "" >&2
-  echo "PARTIAL: ERC-8004 exists but ENSIP-25 not set" >&2
-  echo "{\"verified\":\"partial\",\"name\":\"$ENS_NAME\",\"address\":\"$RESOLVED_ADDR\",\"agentId\":$AGENT_ID,\"ensip25\":false,\"erc8004\":true}"
 else
-  echo "ENS Resolution:       $ENS_NAME -> $RESOLVED_ADDR" >&2
   echo "ENSIP-25 Record:      Not set" >&2
-  echo "ERC-8004 Registry:    Not verified" >&2
-  echo "" >&2
-  echo "NOT VERIFIED: No ENSIP-25 or ERC-8004 link found" >&2
-  echo "{\"verified\":false,\"name\":\"$ENS_NAME\",\"address\":\"$RESOLVED_ADDR\",\"agentId\":$AGENT_ID,\"ensip25\":false,\"erc8004\":false}"
 fi
+
+if [ "$ERC8004_VERIFIED" = "true" ]; then
+  echo "ERC-8004 Registry:    Agent #$AGENT_ID found" >&2
+else
+  echo "ERC-8004 Registry:    Not verified" >&2
+fi
+
+echo "" >&2
+
+# Determine overall status
+if [ "$ENSIP25_VERIFIED" = "true" ] && [ "$ERC8004_VERIFIED" = "true" ]; then
+  VERIFIED="true"
+  echo "FULLY VERIFIED: $ENS_NAME is agent #$AGENT_ID" >&2
+elif [ "$ENSIP25_VERIFIED" = "true" ] || [ "$ERC8004_VERIFIED" = "true" ]; then
+  VERIFIED="partial"
+  if [ "$ENSIP25_VERIFIED" = "true" ]; then
+    echo "PARTIAL: ENSIP-25 set but ERC-8004 not confirmed" >&2
+  else
+    echo "PARTIAL: ERC-8004 exists but ENSIP-25 not set" >&2
+  fi
+else
+  VERIFIED="false"
+  echo "NOT VERIFIED: No ENSIP-25 or ERC-8004 link found" >&2
+fi
+
+# Emit JSON result (all values passed via env vars to prevent injection)
+ENS_NAME="$ENS_NAME" RESOLVED_ADDR="$RESOLVED_ADDR" AGENT_ID="$AGENT_ID" \
+  VERIFIED="$VERIFIED" ENSIP25="$ENSIP25_VERIFIED" ERC8004="$ERC8004_VERIFIED" \
+  node -e "
+    console.log(JSON.stringify({
+      verified: process.env.VERIFIED === 'true' || process.env.VERIFIED === 'false'
+        ? process.env.VERIFIED === 'true'
+        : process.env.VERIFIED,
+      name: process.env.ENS_NAME,
+      address: process.env.RESOLVED_ADDR,
+      agentId: parseInt(process.env.AGENT_ID, 10),
+      ensip25: process.env.ENSIP25 === 'true',
+      erc8004: process.env.ERC8004 === 'true',
+    }));
+  "

--- a/ens-agent-identity/scripts/verify-agent-registration.sh
+++ b/ens-agent-identity/scripts/verify-agent-registration.sh
@@ -155,9 +155,9 @@ if [ -n "$IDENTITY_REGISTRY" ]; then
       if (data.result && data.result !== '0x') {
         const hex = data.result;
         try {
-          const length = parseInt(hex.slice(130, 194), 16);
+          const length = parseInt(hex.slice(66, 130), 16);
           if (length > 0) {
-            const str = Buffer.from(hex.slice(194, 194 + length * 2), 'hex').toString('utf8');
+            const str = Buffer.from(hex.slice(130, 130 + length * 2), 'hex').toString('utf8');
             console.log(str);
           }
         } catch {}


### PR DESCRIPTION
## Summary

- Adds `ens-agent-identity` skill: ENS-based identity layer for Bankr agents
- Human-readable names via NameStone (gasless offchain subnames, CCIP-Read)
- Structured metadata via `agent:*` text records (type, capabilities, chains, a2a endpoint, etc.)
- ENSIP-25 verification linking ENS names to ERC-8004 on-chain identity on Base
- Three scripts: `set-agent-records.sh`, `resolve-agent.sh`, `verify-agent-registration.sh`

## Why

Bankr agents are currently API keys + wallet addresses — no names, no discoverability, no portable reputation. This skill gives agents human-readable ENS names with structured metadata, and bridges them to ERC-8004 on-chain identity via ENSIP-25 verification.

## Tested end-to-end on mainnet

- Registered `alpha-go.bankrtest.eth` via NameStone (CCIP-Read resolution confirmed)
- Registered agent #19327 in ERC-8004 Identity Registry on Base ([tx](https://basescan.org/tx/0x3ff8783a3bdb8742fa9cb300a616a43deeb57768f905c6ed7487fef67c0a23c3))
- ENSIP-25 full verification: ENS name linked to ERC-8004 identity confirmed

## Context

Part of a broader ENS x Bankr integration proposal covering three phases:
1. ENS subnames via NameStone (this PR)
2. Agent metadata via text records (this PR)
3. ERC-8004 identity & reputation (roadmap)

Infrastructure: [NameStone](https://namestone.com) for gasless subname management (built by slobo.eth, ENS Ecosystem steward). Namespace uses mainnet ENS + CCIP-Read (chain-neutral, not pinned to Base).

## Test plan

- [ ] Review SKILL.md prompt guide
- [ ] Review `agent:*` text record schema
- [ ] Review ENSIP-25 verification spec and ERC-7930 encoding
- [ ] Run `set-agent-records.sh` with a NameStone API key
- [ ] Run `resolve-agent.sh` against `alpha-go.bankrtest.eth`
- [ ] Run `verify-agent-registration.sh` against agent #19327 on Base


🤖 Generated with [Claude Code](https://claude.com/claude-code)