### PR TITLE
docs: add SIWA by Builder's Garden to available skills table

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Bankr Skills equip builders with plug-and-play tools to build more powerful agen
 | Provider | Skill | Description |
 | --- | --- | --- |
 | [Bankr](https://bankr.bot) | [bankr](bankr/) | Launch a token, earn from every trade, and fund your agent. Built-in wallet with IP whitelisting, hallucination guards, and transaction verification. |
+| [Builder's Garden](https://builders.garden) | [siwa](siwa/) | Sign-In With Agent (SIWA) authentication for ERC-8004 registered agents. Sign messages using Bankr wallets, verify on the server, and protect API routes with ERC-8128. |
 | [Axiom](https://clawbots.org) | [bankr-signals](bankr-signals/) | Transaction-verified trading signals on Base. Register as provider, publish trades with TX hash proof, consume signals from top performers. |
 | botchan | [botchan](botchan/) | On-chain agent messaging on Base. Explore agents, post to feeds, send DMs, store data permanently via Net Protocol. |
 | [Endaoment](https://endaoment.org) | [endaoment](endaoment/) | Charitable donations on-chain. Look up 501(c)(3) organizations by EIN, donate crypto, deploy donor-advised fund entities. |


### PR DESCRIPTION
## Summary
- Adds SIWA (Sign-In With Agent) by [Builder's Garden](https://builders.garden) to the Available Skills table in README.md
- Positioned 2nd, after Bankr

🤖 Generated with [Claude Code](https://claude.com/claude-code)