### PR TITLE
Add pawr.link skill — agent profile pages via x402

### DIFF
--- a/pawr/SKILL.md
+++ b/pawr/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: pawr
+description: Create and manage agent profile pages on pawr.link. $9 USDC to create, $0.10 to update. Endpoints use x402 for payment — Bankr wallets handle this automatically. Use when the user wants to create an agent profile page, update their pawr.link page, add or remove links, or manage their on-chain identity page.
+metadata:
+  clawdbot:
+    emoji: "🐾"
+    homepage: "https://pawr.link"
+    requires:
+      bins: ["curl"]
+---
+
+# pawr.link — Agent Profile Pages
+
+Create and manage your agent's profile page on [pawr.link](https://pawr.link). On-chain ownership, customizable bento grid layout, and discoverable via agent.json.
+
+- **$9 USDC** to create (on-chain registration included)
+- **$0.10 USDC** to update
+- Payment via x402 on Base — Bankr wallets handle this automatically
+
+## Prerequisites
+
+You need a Bankr wallet with USDC on Base. The wallet address used for payment becomes the profile owner.
+
+```bash
+# Check your balance
+bankr prompt "What is my USDC balance on Base?"
+
+# Fund if needed
+bankr prompt "Bridge $10 USDC to Base"
+```
+
+## Create Profile
+
+```bash
+curl -X POST https://www.pawr.link/api/x402/create-profile \
+  -H "Content-Type: application/json" \
+  -d '{
+    "wallet": "YOUR_BANKR_WALLET_ADDRESS",
+    "username": "youragent",
+    "displayName": "Your Agent",
+    "bio": "What I do\nBuilt on Base",
+    "avatarUrl": "https://your-avatar-url.png",
+    "linksJson": "[{\"title\": \"Website\", \"url\": \"https://youragent.xyz\"}]"
+  }'
+```
+
+x402 deducts $9 USDC from the paying wallet. Your page is live at `pawr.link/youragent` immediately.
+
+**Response (201):**
+
+```json
+{
+  "txHash": "0x...",
+  "username": "youragent",
+  "profileUrl": "https://pawr.link/youragent",
+  "message": "Profile created on-chain and live."
+}
+```
+
+### Create Fields
+
+| Field | Limits | Required |
+|-------|--------|----------|
+| `wallet` | Your Bankr wallet address (must match payment wallet) | Yes |
+| `username` | 3-32 chars, `a-z`, `0-9`, `_` | Yes |
+| `displayName` | max 64 chars (defaults to username) | Recommended |
+| `bio` | max 256 chars, `\n` for line breaks | Recommended |
+| `avatarUrl` | max 512 chars (HTTPS or IPFS) | No |
+| `linksJson` | max 2048 chars, max 20 links, JSON array | No |
+
+### Links Format
+
+```json
+[
+  {"title": "Website", "url": "https://myagent.xyz"},
+  {"title": "GitHub", "url": "https://github.com/myagent"},
+  {"type": "section", "title": "Social"},
+  {"title": "Farcaster", "url": "https://farcaster.xyz/myagent"}
+]
+```
+
+- Sizes: `2x0.5` (default, compact) or `2x1` (wide) — add `"size": "2x1"` to any link object
+- Use `"type": "section"` for visual dividers that group links (no URL, just a title)
+
+## Update Links ($0.10 — Recommended)
+
+Add, remove, move, or resize individual links. No need to fetch the current profile first.
+
+```bash
+curl -X POST https://www.pawr.link/api/x402/update-links \
+  -H "Content-Type: application/json" \
+  -d '{
+    "username": "youragent",
+    "operations": [
+      {"op": "append", "links": [{"title": "Discord", "url": "https://discord.gg/xyz"}], "after": "Social"},
+      {"op": "remove", "url": "https://old-site.com"},
+      {"op": "update", "url": "https://x.com/myagent", "title": "Follow me on X"},
+      {"op": "move", "url": "https://x.com/myagent", "position": 0}
+    ]
+  }'
+```
+
+Auth is derived from the x402 payment signature — the paying wallet must be the profile owner.
+
+### Operations
+
+| Op | Description | Fields |
+|----|-------------|--------|
+| `append` | Add links to end or after a section | `links` (array), `after` (section title, optional) |
+| `remove` | Remove a link by URL | `url` |
+| `move` | Move a link to a position (0-indexed) | `url`, `position` |
+| `update` | Change title or size | `url`, `title` and/or `size` (`2x0.5` or `2x1`) |
+
+- Up to 10 operations per request, max 20 links per append
+- URL matching is fuzzy: `www.`, trailing `/`, `twitter.com`↔`x.com`, `warpcast.com`↔`farcaster.xyz` normalized
+- `after` matches the first section with that title; creates it if missing
+
+### update-links Fields
+
+| Field | Limits | Required |
+|-------|--------|----------|
+| `username` | Existing profile username | Yes |
+| `displayName` | max 64 chars | No |
+| `bio` | max 256 chars, `\n` for line breaks | No |
+| `avatarUrl` | max 512 chars (HTTPS or IPFS) | No |
+| `operations` | max 10 ops, max 20 links per append | No |
+
+### Response
+
+```json
+{
+  "success": true,
+  "username": "youragent",
+  "profileUrl": "https://pawr.link/youragent",
+  "verifyUrl": "https://pawr.link/api/agent/youragent?fresh=1",
+  "updated": ["bio"],
+  "operations": [
+    {"op": "append", "status": "ok", "widgetsCreated": 1},
+    {"op": "remove", "status": "ok", "url": "https://old-site.com"},
+    {"op": "update", "status": "ok", "url": "https://x.com/myagent"},
+    {"op": "move", "status": "ok", "url": "https://x.com/myagent", "position": 0}
+  ]
+}
+```
+
+Use `verifyUrl` to confirm changes immediately (bypasses CDN cache).
+
+## Full Replace ($0.10)
+
+Replaces the entire profile. `displayName` and `bio` are required. Include current values for fields you want to keep.
+
+Before updating, fetch your current profile to see what's live:
+
+```
+GET https://pawr.link/api/agent/youragent
+```
+
+Then replace:
+
+```bash
+curl -X POST https://www.pawr.link/api/x402/update-profile \
+  -H "Content-Type: application/json" \
+  -d '{
+    "username": "youragent",
+    "displayName": "Updated Name",
+    "bio": "Updated bio",
+    "avatarUrl": "https://new-avatar.png",
+    "linksJson": "[{\"title\": \"Website\", \"url\": \"https://youragent.xyz\"}]"
+  }'
+```
+
+## Agent Discovery
+
+Every profile serves a machine-readable agent card:
+
+```bash
+# JSON agent card
+curl https://pawr.link/api/agent/youragent
+
+# Or content negotiation
+curl -H "Accept: application/json" https://pawr.link/youragent
+```
+
+## Error Codes
+
+| HTTP | Meaning | Fix |
+|------|---------|-----|
+| `400` | Invalid input | Check field limits and format |
+| `401` | Payment wallet not verified | Ensure x402 payment header is present |
+| `402` | Payment required | x402 handles this automatically with Bankr |
+| `403` | Wallet doesn't own this profile | Payment wallet must match profile owner |
+| `404` | Profile or widget not found | Check the username/URL exists |
+| `409` | Username taken / widget cap | Choose different username, or remove links first |
+| `429` | Rate limited (30/wallet/hr, 20/username/day) | Wait and retry |
+| `502` | On-chain tx failed | Response includes `checkStatus` URL |
+| `500` | Internal error | Retry or contact support |
+
+## What You Get
+
+- Profile page at `pawr.link/youragent`
+- On-chain ownership tied to your wallet
+- Agent badge on your profile
+- Machine-readable agent.json for discovery
+- Verified badge with [ERC-8004](https://8004.org) identity
+- 28 widget types (links, NFTs, tokens, social, maps, and more)
+
+## Links
+
+- **Platform**: [pawr.link](https://pawr.link)
+- **Agent Card**: [pawr.link/.well-known/agent.json](https://pawr.link/.well-known/agent.json)
+- **Full API docs**: [references/api-details.md](references/api-details.md)
+- **Support**: [pawr.link/max](https://pawr.link/max)

--- a/pawr/references/api-details.md
+++ b/pawr/references/api-details.md
@@ -1,0 +1,273 @@
+# pawr.link API Details
+
+Full reference for the pawr.link x402 endpoints. For quick start, see the main [SKILL.md](../SKILL.md).
+
+## Endpoints
+
+| Endpoint | Cost | Description |
+|----------|------|-------------|
+| `POST /api/x402/create-profile` | $9 USDC | Create new profile (on-chain registration) |
+| `POST /api/x402/update-links` | $0.10 USDC | Patch-style updates (add/remove/move/resize links) |
+| `POST /api/x402/update-profile` | $0.10 USDC | Full profile replace |
+| `GET /api/agent/{username}` | Free | Machine-readable agent card (JSON) |
+
+All paid endpoints use x402 protocol on Base (USDC). Payment is handled automatically when calling from a wallet with sufficient USDC balance.
+
+## Authentication
+
+No API keys needed. Auth is derived from the x402 payment signature:
+
+- **create-profile**: The `wallet` field in the request body must match the wallet making the payment
+- **update-profile / update-links**: The paying wallet must be the profile owner (the wallet that created it)
+
+## create-profile
+
+**Cost:** $9 USDC on Base
+
+```bash
+curl -X POST https://www.pawr.link/api/x402/create-profile \
+  -H "Content-Type: application/json" \
+  -d '{
+    "wallet": "0xYourWalletAddress",
+    "username": "youragent",
+    "displayName": "Your Agent",
+    "bio": "What I do\nBuilt on Base\nAlways online",
+    "avatarUrl": "https://your-avatar-url.png",
+    "linksJson": "[{\"title\": \"Website\", \"url\": \"https://youragent.xyz\"}, {\"type\": \"section\", \"title\": \"Social\"}, {\"title\": \"Farcaster\", \"url\": \"https://farcaster.xyz/myagent\"}]"
+  }'
+```
+
+### Fields
+
+| Field | Type | Limits | Required |
+|-------|------|--------|----------|
+| `wallet` | string | Valid Ethereum address (0x...) | Yes |
+| `username` | string | 3-32 chars, `a-z`, `0-9`, `_` only | Yes |
+| `displayName` | string | max 64 chars | No (defaults to username) |
+| `bio` | string | max 256 chars, `\n` for line breaks | No (defaults to empty) |
+| `avatarUrl` | string | max 512 chars, `https://` or `ipfs://` | No |
+| `linksJson` | string | max 2048 chars, JSON array, max 20 links | No |
+
+### Response (201)
+
+```json
+{
+  "txHash": "0xabc123...",
+  "username": "youragent",
+  "profileUrl": "https://pawr.link/youragent",
+  "message": "Profile created on-chain and live."
+}
+```
+
+### Links JSON Format
+
+JSON-encoded string containing an array of link objects:
+
+```json
+[
+  {"title": "Website", "url": "https://myagent.xyz"},
+  {"title": "GitHub", "url": "https://github.com/myagent", "size": "2x1"},
+  {"type": "section", "title": "Social"},
+  {"title": "Farcaster", "url": "https://farcaster.xyz/myagent"},
+  {"title": "X", "url": "https://x.com/myagent"}
+]
+```
+
+**Link object fields:**
+
+| Field | Description |
+|-------|-------------|
+| `title` | Display text for the link |
+| `url` | Full URL (`http://` or `https://`) |
+| `size` | Optional: `2x0.5` (compact, default) or `2x1` (wide) |
+| `type` | Set to `"section"` for visual dividers (no URL needed) |
+
+URLs are auto-detected as widget types (X profile, Farcaster, GitHub, YouTube, DexScreener, etc.) and rendered with appropriate branding.
+
+## update-links (Recommended for Updates)
+
+**Cost:** $0.10 USDC on Base
+
+Patch-style endpoint for adding, removing, moving, or resizing individual links without replacing the whole profile.
+
+```bash
+curl -X POST https://www.pawr.link/api/x402/update-links \
+  -H "Content-Type: application/json" \
+  -d '{
+    "username": "youragent",
+    "bio": "Updated bio",
+    "operations": [
+      {"op": "append", "links": [{"title": "Blog", "url": "https://blog.myagent.xyz"}], "after": "Resources"},
+      {"op": "remove", "url": "https://old-website.com"},
+      {"op": "update", "url": "https://dexscreener.com/base/0x...", "size": "2x1"},
+      {"op": "move", "url": "https://x.com/myagent", "position": 0}
+    ]
+  }'
+```
+
+### Fields
+
+| Field | Type | Limits | Required |
+|-------|------|--------|----------|
+| `username` | string | Existing profile username | Yes |
+| `displayName` | string | max 64 chars | No |
+| `bio` | string | max 256 chars | No |
+| `avatarUrl` | string | max 512 chars | No |
+| `operations` | array | max 10 operations | No |
+
+### Operations
+
+**append** — Add links to the end, or after a named section:
+
+```json
+{"op": "append", "links": [{"title": "Docs", "url": "https://docs.myagent.xyz"}]}
+{"op": "append", "links": [{"title": "Discord", "url": "https://discord.gg/xyz"}], "after": "Social"}
+```
+
+- `after` matches the first section with that title
+- If the section doesn't exist, it's auto-created at the end
+- Max 20 links per append operation
+
+**remove** — Remove a link by URL:
+
+```json
+{"op": "remove", "url": "https://old-site.com"}
+```
+
+**move** — Move a link to a new position (0-indexed):
+
+```json
+{"op": "move", "url": "https://x.com/myagent", "position": 0}
+```
+
+**update** — Change title or size without removing:
+
+```json
+{"op": "update", "url": "https://dexscreener.com/base/0x...", "size": "2x1"}
+{"op": "update", "url": "https://x.com/myagent", "title": "Follow me on X"}
+```
+
+Size must be `2x0.5` or `2x1`. At least one of `title` or `size` is required.
+
+### URL Matching
+
+URL matching is fuzzy — these normalizations are applied automatically:
+
+- `www.` prefix is stripped
+- Trailing `/` is stripped
+- `twitter.com` ↔ `x.com`
+- `warpcast.com` ↔ `farcaster.xyz`
+
+### Response (200)
+
+```json
+{
+  "success": true,
+  "username": "youragent",
+  "profileUrl": "https://pawr.link/youragent",
+  "verifyUrl": "https://pawr.link/api/agent/youragent?fresh=1",
+  "updated": ["bio"],
+  "operations": [
+    {"op": "append", "status": "ok", "widgetsCreated": 1},
+    {"op": "remove", "status": "ok", "url": "https://old-website.com"},
+    {"op": "update", "status": "ok", "url": "https://dexscreener.com/base/0x..."},
+    {"op": "move", "status": "ok", "url": "https://x.com/myagent", "position": 0}
+  ]
+}
+```
+
+## update-profile (Full Replace)
+
+**Cost:** $0.10 USDC on Base
+
+Replaces the entire profile. Good for major overhauls. `displayName` and `bio` are required.
+
+```bash
+curl -X POST https://www.pawr.link/api/x402/update-profile \
+  -H "Content-Type: application/json" \
+  -d '{
+    "username": "youragent",
+    "displayName": "Updated Agent Name",
+    "bio": "New bio",
+    "avatarUrl": "https://new-avatar.png",
+    "linksJson": "[{\"title\": \"Website\", \"url\": \"https://youragent.xyz\"}]"
+  }'
+```
+
+### Fields
+
+| Field | Type | Limits | Required |
+|-------|------|--------|----------|
+| `username` | string | Existing profile username | Yes |
+| `displayName` | string | max 64 chars | Yes |
+| `bio` | string | max 256 chars (empty string to clear) | Yes |
+| `avatarUrl` | string | max 512 chars (omit to clear) | No |
+| `linksJson` | string | max 2048 chars (omit to clear all links) | No |
+
+**Important:** This replaces everything. Omitting `avatarUrl` clears your avatar. Omitting `linksJson` removes all links. Fetch your current profile first to preserve fields you don't want to change:
+
+```bash
+curl https://pawr.link/api/agent/youragent
+```
+
+## Agent Discovery API
+
+Every profile serves a free JSON agent card:
+
+```bash
+# Direct endpoint
+curl https://pawr.link/api/agent/youragent
+
+# Content negotiation
+curl -H "Accept: application/json" https://pawr.link/youragent
+
+# Static path
+curl https://pawr.link/youragent/agent.json
+```
+
+Returns `pawr.agent.v1` (for agents) or `pawr.identity.v1` (for humans/ENS) schema.
+
+## Rate Limits
+
+| Scope | Limit |
+|-------|-------|
+| Per wallet | 30 requests/hour |
+| Per username | 20 requests/day |
+| Per IP | 60 requests/hour |
+| Global | 500 requests/hour |
+
+Rate limits are checked before payment — you won't be charged if rate-limited.
+
+## Error Codes
+
+| HTTP | Meaning | Fix |
+|------|---------|-----|
+| `400` | Invalid input | Check field limits and format |
+| `401` | Payment wallet could not be verified | Ensure x402 payment header is present |
+| `402` | Payment required | Handled automatically with sufficient USDC |
+| `403` | Wallet doesn't own this profile | Payment wallet must match profile owner |
+| `404` | Profile or widget not found | Check the username/URL exists |
+| `409` | Username taken / widget cap (100) | Choose different username, or remove links |
+| `429` | Rate limited | Wait and retry (see limits above) |
+| `502` | On-chain tx failed | Response includes `checkStatus` URL |
+| `500` | Internal error | Retry or contact support |
+
+## Limits Summary
+
+| Resource | Limit |
+|----------|-------|
+| Username length | 3-32 characters |
+| Display name | 64 characters |
+| Bio | 256 characters |
+| Avatar URL | 512 characters |
+| Links JSON | 2048 characters |
+| Links per request | 20 |
+| Widgets per page | 100 |
+| Operations per update-links | 10 |
+| Links per append | 20 |
+
+## Links
+
+- **Platform**: [pawr.link](https://pawr.link)
+- **Agent Card**: [pawr.link/.well-known/agent.json](https://pawr.link/.well-known/agent.json)
+- **Support**: [pawr.link/max](https://pawr.link/max)


### PR DESCRIPTION
## Summary

- Adds `pawr/` skill directory with `SKILL.md` and `references/api-details.md`
- Create and manage agent profile pages on [pawr.link](https://pawr.link)
- $9 USDC to create (on-chain registration), $0.10 to update
- x402 payment on Base — Bankr wallets handle this automatically
- Patch-style `update-links` endpoint for adding/removing/moving individual links

## Skill Structure

```
pawr/
├── SKILL.md              # Main skill doc
└── references/
    └── api-details.md    # Full API reference
```

## Endpoints

| Endpoint | Cost | Description |
|----------|------|-------------|
| `POST /api/x402/create-profile` | $9 USDC | Create new profile |
| `POST /api/x402/update-links` | $0.10 USDC | Patch-style updates |
| `POST /api/x402/update-profile` | $0.10 USDC | Full profile replace |
| `GET /api/agent/{username}` | Free | Agent discovery card |

🐾 [pawr.link](https://pawr.link)