### PR TITLE
 Add deployer-intelligence skill

### DIFF
--- a/lexispawn/deployer-intelligence/SKILL.md
+++ b/lexispawn/deployer-intelligence/SKILL.md
@@ -1,155 +1,86 @@
 # deployer-intelligence
 
-**Analyze Base token deployer wallet history to identify serial deployers and track record patterns.**
+Every token screen your agent runs — price, volume, liquidity, momentum — returns identical results for a legitimate project and for the seventh launch from a wallet that abandoned the last six.
+Deployer history is the only signal that distinguishes them before the chart does.
+This skill is that signal.
 
-## Description
+## What it does
 
-This skill analyzes any Base token's deployer wallet to surface:
-- Total contracts deployed by this wallet
-- How many survived past 7 days / 30 days
-- Average peak market caps of previous tokens
-- A 0-100 deployer score based on track record
+Resolves a Base token's deployer wallet via Routescan API. Pulls the wallet's full contract creation history. Checks each prior deployment against DexScreener for survival, liquidity, and market cap. Outputs a 0–100 deployer score.
 
-Use this as a **veto filter** before trading — avoid tokens from deployers with proven failure patterns. Designed specifically for sub-$5M Base tokens where deployer credibility matters.
+Designed as a **veto layer**, not a buy signal. Score below threshold = hard pass, regardless of how the token looks.
 
-## Use Cases
+## Scoring
 
-- **Pre-trade filter:** Check deployer history before entering a position
-- **Risk assessment:** Identify first-time deployers vs serial launchers
-- **Track record analysis:** Distinguish between proven builders and serial rug artists
-- **Intelligence layer:** Add deployer context to trading decisions
+Base score: 50 (neutral). Six adjustments:
 
-## Usage
+| Signal | Condition | Weight |
+|--------|-----------|--------|
+| 30-day survivor | Any prior token active 30+ days | +10 |
+| 7-day survivors | Per token active 7+ days | +5 each (max +20) |
+| Market cap quality | Avg peak mcap > $500K | +10 |
+| Fast deaths | Per token dead < 72h | -10 each (max -30) |
+| Serial failure | 5+ deploys, zero 7-day survivors | -20 |
+| Ghost contracts | 10+ deploys, < 30% with market data | -15 |
 
-```javascript
-// Scan a token's deployer
-lexispawn deployer-intelligence scan <TOKEN_CONTRACT_ADDRESS>
+Range: 0–100. Details in `references/scoring-methodology.md`.
 
-// Example:
-lexispawn deployer-intelligence scan 0x1bc0c42215582d5A085795f4baDbaC3ff36d1Bcb
+## Integration
 
-// Returns:
-// {
-//   "token": "CLANKER",
-//   "deployer": "0x250c9fb2b411b48273f69879007803790a6aea47",
-//   "deployerHistory": {
-//     "totalContractsCreated": 11,
-//     "tokensWithMarketData": 1,
-//     "survivedPast7Days": 1,
-//     "survivedPast30Days": 1,
-//     "avgPeakMcap": 29196896
-//   },
-//   "deployerScore": 65
-// }
+This skill sits between inference and execution in the Bankr stack. An agent queries the LLM Gateway, gets a BUY signal, then checks whether the deployer has earned the right to be trusted.
+
+| Score | Read | Action |
+|-------|------|--------|
+| 0–30 | Serial failure or rug pattern | Veto. Skip. |
+| 30–50 | Unknown or mixed record | Reduce position size |
+| 50–70 | Some survivors, moderate credibility | Proceed if other signals align |
+| 70–100 | Proven builder | Full conviction from deployer side |
+
+### In practice
+
+```bash
+# Install
+openclaw skills install lexispawn/deployer-intelligence
+
+# Configure
+export ROUTESCAN_API_KEY="your_key"
+
+# Scan a token's deployer
+node scripts/deployer-scanner.js 0x1bc0c42215582d5A085795f4baDbaC3ff36d1Bcb
+
+# Decision loop:
+# 1. Bankr LLM returns BUY on $TOKEN
+# 2. deployer-intelligence → score 22 → veto, next token
+# 3. Next candidate → score 71 → proceed to position sizing
 ```
 
-## Scoring Methodology
+## Data sources
 
-**Base score:** 50 (neutral)
+- **Routescan API** — `getcontractcreation`, `txlistinternal` (Base chain 8453)
+- **DexScreener API** — token pairs, mcap, liquidity, volume, pair age
 
-**Positive signals:**
-- +10 if any token survived 30+ days
-- +5 per token survived 7+ days (max +20)
-- +10 if average peak mcap > $500K
+## Limitations
 
-**Negative signals:**
-- -10 per token dead <72h (max -30)
-- -20 if 5+ tokens deployed with 0 survivors
-- -15 if >10 contracts but <30% have market data (most never got liquidity)
+**ERC-4337 wallets.** Most 2026 Base tokens deploy via Account Abstraction. UserOp-embedded deployments are invisible to `txlistinternal`. These deployers return 0 history.
 
-**Range:** 0-100
+**Dead-on-arrival tokens.** Contracts that never got a DexScreener pair are counted but not scored.
 
-**Interpretation:**
-- **0-30:** Red flag - proven failure pattern or serial rugger
-- **30-50:** Neutral/unknown - first-time deployer or mixed track record
-- **50-70:** Moderate credibility - some survivors, not all failures
-- **70-100:** Strong track record - consistent survival rates, proven builder
+**No time weighting.** A token that died six months ago penalizes the same as one that died yesterday.
 
-## Data Sources
+**Base only.**
 
-- **Routescan API:** Contract creation history via `txlistinternal` endpoint
-- **DexScreener API:** Token market data (mcap, liquidity, age)
+## Install
 
-Designed for Base chain (ERC-20 tokens). Works with both factory-deployed contracts and traditional EOA deployers. Limited visibility into ERC-4337 Account Abstraction wallet deployment history (API constraint).
+Requires Node.js 18+ and a [Routescan API key](https://routescan.io/api) (free tier).
 
-## Installation
-
-Prerequisites:
-- Node.js 18+
-- Routescan API key (free tier: https://routescan.io/api)
-- Network: Base mainnet
-
-Install:
 ```bash
 openclaw skills install lexispawn/deployer-intelligence
 ```
 
-Configure:
-```bash
-export ROUTESCAN_API_KEY="your_api_key"
-```
-
-## Output Format
-
-```json
-{
-  "token": "SYMBOL",
-  "tokenName": "Full Name",
-  "ca": "0x...",
-  "deployer": "0x...",
-  "deployerHistory": {
-    "totalContractsCreated": 11,
-    "tokensWithMarketData": 1,
-    "dataRate": 9,
-    "survivedPast7Days": 1,
-    "survivedPast30Days": 1,
-    "avgPeakMcap": 29196896,
-    "previousTokens": [
-      {
-        "ca": "0x...",
-        "symbol": "TOKEN",
-        "name": "Token Name",
-        "currentMcap": 1000000,
-        "peakMcap": 2000000,
-        "volume24h": 500000,
-        "liquidity": 100000,
-        "status": "active",
-        "daysOld": 45,
-        "priceUsd": 0.001
-      }
-    ]
-  },
-  "deployerScore": 65,
-  "timestamp": "2026-02-27T19:20:00.000Z"
-}
-```
-
-## Known Limitations
-
-1. **ERC-4337 AA wallets:** Most 2026 Base tokens use Account Abstraction. Deployment history is embedded in UserOp data, not visible via standard `txlistinternal`. These deployers will show 0 history even if they've deployed multiple tokens.
-
-2. **Coverage:** Only tokens with active trading pairs on DexScreener are included in history analysis. Dead tokens with zero liquidity won't appear.
-
-3. **Recency:** No time-weighting — a token that died 6 months ago counts the same as one that died yesterday.
-
-4. **Network:** Base only. Multi-chain support planned.
-
-## Roadmap
-
-- [ ] Multi-chain support (Ethereum, Polygon, Arbitrum)
-- [ ] UserOp decoding for ERC-4337 deployer visibility
-- [ ] Time-weighted scoring (recent failures penalized more)
-- [ ] Deployer watchlist alerts (notify when proven deployer launches new token)
-- [ ] Integration with 15 MINDS analysis pipeline
-
 ## Author
 
-Built by **Lexispawn** (@lexispawn)
-- X: https://twitter.com/lexispawn
-- Farcaster: https://warpcast.com/lexispawn
-- Intelligence hub: https://lexispawn.xyz
-
-Part of the **15 MINDS** trading intelligence system on Base.
+Built by [Lexispawn](https://lexispawn.xyz) · [@lexispawn](https://x.com/lexispawn)
+Part of the 15 MINDS intelligence system on Base.
 
 ## License
 

--- a/lexispawn/deployer-intelligence/references/scoring-methodology.md
+++ b/lexispawn/deployer-intelligence/references/scoring-methodology.md
@@ -1,153 +1,125 @@
-# Deployer Intelligence Scoring Methodology
+# Scoring Methodology
 
-## Purpose
+## Formula
 
-The deployer score (0-100) quantifies a wallet's historical track record of token deployments. It answers: **Has this deployer launched tokens that survived, or is this a pattern of failure?**
+Base score: **50** (neutral). Six adjustments applied in order. Result clamped to 0–100.
 
-## Why This Matters
+### Positive adjustments
 
-Base 2026 has thousands of new token launches daily. Most fail within 72 hours. Knowing whether a deployer has a history of:
-- Building tokens that hold liquidity past 30 days
-- Serial launching with 0% survival rate
-- First-time deployment (unknown risk)
+| # | Condition | Weight |
+|---|-----------|--------|
+| 1 | Any prior token `active` for 30+ days | +10 (once) |
+| 2 | Each prior token `active` for 7+ days | +5 per token (max +20) |
+| 3 | Average peak mcap across tokens with data > $500K | +10 (once) |
 
-...provides edge that market cap and volume alone don't reveal.
+### Negative adjustments
 
-## Scoring Formula
+| # | Condition | Weight |
+|---|-----------|--------|
+| 4 | Each prior token `dead` within 72h of pair creation | -10 per token (max -30) |
+| 5 | 5+ total contracts AND zero tokens survived 7 days | -20 (once) |
+| 6 | 10+ total contracts AND < 30% have DexScreener data | -15 (once) |
 
-### Base Score
-Start at **50** (neutral, no prior data)
+```
+final = Math.max(0, Math.min(100, score))
+```
 
-### Positive Signals
-
-**+10** if any token survived 30+ days
-- Proves the deployer has launched at least one project with staying power
-- Single-flag bonus (doesn't stack)
-
-**+5** per token survived 7+ days (max +20)
-- Each token that made it past the first week adds credibility
-- Capped at 4 tokens to prevent infinite stacking
-
-**+10** if average peak mcap > $500K
-- High mcaps indicate legitimate market interest in deployer's projects
-- Uses average across all tokens with market data
-
-### Negative Signals
-
-**-10** per token dead <72h (max -30)
-- Each token that died within 3 days is a red flag
-- Capped at 3 tokens to prevent score going below floor
-
-**-20** if 5+ tokens deployed with 0 survivors past 7 days
-- Serial deployer with 100% failure rate = major red flag
-- Applied once if condition met
-
-**-15** if >10 contracts deployed but <30% have market data
-- Most deployed contracts never got liquidity = likely test tokens or abandoned launches
-- Indicates high deploy volume with low follow-through
-
-### Range
-**Min:** 0  
-**Max:** 100
-
-Enforced via `Math.max(0, Math.min(100, score))`
-
-## Interpretation Guide
-
-| Score Range | Interpretation | Action |
-|-------------|----------------|--------|
-| **0-30** | Red flag. Proven failure pattern or serial rugger. High risk. | Avoid. Use as veto filter. |
-| **30-50** | Neutral/unknown. First-time deployer or mixed track record. | Proceed with caution. Cross-reference other signals. |
-| **50-70** | Moderate credibility. Some survivors, not all failures. | Acceptable risk if other signals align. |
-| **70-100** | Strong track record. Consistent survival rates, proven builder. | Green light from deployer perspective. |
-
-## Example Scores
-
-### Score 15: Serial Failure
-- 16 contracts deployed
-- 0 have market data (never got liquidity)
-- Result: **Base 50 - 20 (serial failure) - 15 (no data) = 15**
-
-### Score 50: First-Time Deployer
-- 1 contract deployed
-- Token is 10 days old, still active
-- Result: **Base 50 + 0 (no 30d survival yet) = 50**
-
-### Score 65: Proven with Low Success Rate
-- 11 contracts deployed
-- 1 survived 30+ days with $29M peak mcap
-- Result: **Base 50 + 10 (30d survivor) + 10 (high mcap) - 5 (multiple dead <72h) = 65**
-
-### Score 85: Strong Track Record
-- 8 contracts deployed
-- 4 survived 7+ days (3 past 30 days)
-- Average peak mcap $1.2M
-- Result: **Base 50 + 10 (30d survivors) + 20 (four 7d survivors) + 10 (high avg mcap) - 5 (one dead <72h) = 85**
-
-## Data Sources
-
-### Contract Creation History
-**Source:** Routescan API (`txlistinternal` endpoint)
-**Method:** Filter for `type === "create" || type === "create2"` and non-empty `contractAddress`
-**Coverage:** Works for traditional factory contracts and EOA deployers
-
-**Limitation:** ERC-4337 Account Abstraction wallets embed deployments in UserOp initCode. These are invisible to `txlistinternal` without decoding the UserOp data. Most 2026 Base tokens use AA wallets, resulting in many deployers showing 0 history even if they've deployed multiple tokens.
-
-### Token Market Data
-**Source:** DexScreener API (`/token-pairs/v1/base/{address}`)
-**Fields:** mcap (fdv), liquidity, volume, price, age (from pairCreatedAt)
-**Coverage:** Only tokens with active trading pairs
-
-**Limitation:** Tokens that launched but never got liquidity (dead on arrival) won't appear in DexScreener and therefore won't be counted in history.
-
-## Status Classification
-
-Tokens in history are classified as:
+## Token status
 
 | Status | Criteria |
 |--------|----------|
-| **active** | Liquidity > $1K, mcap > 0, price > 0 |
-| **low_liquidity** | Liquidity $1-$1K |
-| **dead** | Liquidity = 0 OR mcap = 0 OR price = 0 |
+| `active` | liquidity > $1K AND mcap > 0 AND price > 0 |
+| `low_liquidity` | liquidity $1–$1K |
+| `dead` | liquidity = 0 OR mcap = 0 OR price = 0 |
 
-## Time Windows
+"Survived N days" requires `active` status AND `daysOld >= N`.
+`daysOld` is measured from DexScreener `pairCreatedAt` (first liquidity), not contract deployment.
 
-- **<72h (dead):** Token died within 3 days of launch (negative signal)
-- **7+ days (survived):** Token maintained liquidity for at least a week (positive signal)
-- **30+ days (survivor):** Token has staying power beyond the initial hype cycle (strong positive signal)
+## Example: score 85 — proven builder
 
-Time is calculated from `pairCreatedAt` (when liquidity was first added), not contract deployment.
+Deployer created 8 contracts. 5 have DexScreener pairs.
 
-## Future Improvements
+| Token | Status | Days old | Mcap |
+|-------|--------|----------|------|
+| A | active | 45 | $1.8M |
+| B | active | 32 | $900K |
+| C | active | 14 | $400K |
+| D | active | 9 | $200K |
+| E | dead | 2 | $0 |
 
-### Planned
-1. **Time-weighted penalties:** Recent failures penalized more than old ones
-2. **Survivor quality weighting:** Token that hit $10M peak scores higher than one that peaked at $100K
-3. **Deployer clustering:** Identify when multiple "different" deployers are actually the same entity
-4. **AA wallet support:** Decode UserOp initCode to surface ERC-4337 deployment history
+```
+Base:                                       50
+#1  30-day survivor exists (A, B):         +10
+#2  7-day survivors (A, B, C, D = 4):      +20  (cap)
+#3  Avg mcap ($825K) > $500K:              +10
+#4  Dead < 72h (E = 1):                    -10
+#5  8 deploys, 4 survived 7d:               —
+#6  8 deploys, 5/8 = 63% have data:         —
+                                           ----
+Total:                                      80
+```
 
-### Under Consideration
-1. **Liquidity lock detection:** Bonus for deployers who lock LP tokens
-2. **Team wallet analysis:** Track whether deployer sold early or held long-term
-3. **Multi-chain aggregation:** Combine track record across Base + Ethereum + other chains
+## Example: score 5 — serial failure
 
-## Validation
+Deployer created 16 contracts. 1 has a DexScreener pair.
 
-Scoring logic validated against:
-- **CLANKER factory** (0x250c9fb2b411b48273f69879007803790a6aea47): 11 deploys, 1 survivor → Score 65 ✅
-- **Unproven AA wallet**: 16 deploys, 0 market data → Score 15 ✅
-- **First-time deployer**: 1 deploy, active → Score 50 ✅
+| Token | Status | Days old | Mcap |
+|-------|--------|----------|------|
+| A | dead | 1 | $0 |
 
-## Usage in 15 MINDS Pipeline
+```
+Base:                                       50
+#1  No 30-day survivor:                      —
+#2  No 7-day survivor:                       —
+#3  Avg mcap ($0) < $500K:                   —
+#4  Dead < 72h (A = 1):                    -10
+#5  16 deploys, 0 survived 7d:             -20
+#6  16 deploys, 1/16 = 6% have data:       -15
+                                           ----
+Total:                                       5
+```
 
-Deployer intelligence is one input into the 15 MINDS trading system:
-1. **DexScreener trending tokens** → filter by mcap/age/liquidity
-2. **Deployer scanner** → identify red flags (score <30 = veto)
-3. **15 MINDS analysis** → query 15 frontier models for conviction
-4. **Execute** → if deployer score >30 AND 3+ models say BUY → trade
+## API endpoints
 
-Deployer score is a **veto filter**, not a buy signal. A score of 85 doesn't mean buy — it means the deployer isn't a known failure pattern. The 15 MINDS verdict determines entry.
+### Routescan — resolve deployer
 
----
+```
+GET https://api.routescan.io/v2/network/mainnet/evm/8453/etherscan/api
+  ?module=contract
+  &action=getcontractcreation
+  &contractaddresses={TOKEN_CA}
+  &apikey={KEY}
+```
 
-**Built by Lexispawn** | Part of the 15 MINDS intelligence system
+Returns `contractCreator`. Fallback: query `txlist` for the token CA, use `from` of earliest transaction.
+
+### Routescan — deployer contract history
+
+```
+GET https://api.routescan.io/v2/network/mainnet/evm/8453/etherscan/api
+  ?module=account
+  &action=txlistinternal
+  &address={DEPLOYER}
+  &startblock=0
+  &endblock=99999999
+  &sort=asc
+  &apikey={KEY}
+```
+
+Filter: `type === "create" || type === "create2"` with non-empty `contractAddress`.
+
+### DexScreener — token market data
+
+```
+GET https://api.dexscreener.com/token-pairs/v1/base/{CONTRACT_ADDRESS}
+```
+
+Returns array of pairs. First pair used. Fields: `fdv` (mcap), `liquidity.usd`, `volume.h24`, `priceUsd`, `pairCreatedAt`.
+Rate limited at 300ms between calls.
+
+## Notes
+
+- `peakMcap` is current mcap at scan time. Historical peak is not tracked via API. A token that hit $5M but sits at $200K scores on $200K.
+- The target token being scanned is excluded from the deployer's history to avoid self-reference.
+- Contracts with no DexScreener pair count toward total deploys (adjustments #5, #6) but receive no status or scoring weight.
+- ERC-4337 wallets: deployments via UserOp `initCode` are invisible to `txlistinternal`. These deployers return 0 history regardless of actual track record.

--- a/lexispawn/deployer-intelligence/scripts/deployer-scanner.js
+++ b/lexispawn/deployer-intelligence/scripts/deployer-scanner.js
@@ -1,100 +1,102 @@
 #!/usr/bin/env node
 /**
- * deployer-scanner.js - FIXED scoring
- * 
- * Bug fix: Track actual contract creations separately from tokens with market data
+ * deployer-scanner.js
+ * Deployer intelligence scoring for Base tokens.
+ * See references/scoring-methodology.md for the full scoring spec.
  */
 
-const ROUTESCAN_API_KEY = process.env.ROUTESCAN_API_KEY || 'rs_a60d758bbed63a5b598141e7';
 const API_BASE = 'https://api.routescan.io/v2/network/mainnet/evm/8453/etherscan/api';
+const DEXSCREENER_BASE = 'https://api.dexscreener.com/token-pairs/v1/base';
+const FETCH_TIMEOUT_MS = 10000;
+const DEXSCREENER_DELAY_MS = 300;
 
-async function sleep(ms) {
+function getApiKey() {
+  const key = process.env.ROUTESCAN_API_KEY;
+  if (!key) throw new Error('ROUTESCAN_API_KEY environment variable not set');
+  return key;
+}
+
+function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 async function fetchWithRetry(url, maxRetries = 3) {
-  for (let i = 0; i < maxRetries; i++) {
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
     try {
-      const response = await fetch(url);
+      const response = await fetch(url, { signal: controller.signal });
+      clearTimeout(timeout);
       if (!response.ok) {
-        if (i === maxRetries - 1) throw new Error(`HTTP ${response.status}`);
-        await sleep(1000 * (i + 1));
+        if (attempt === maxRetries - 1) throw new Error(`HTTP ${response.status}`);
+        await sleep(1000 * (attempt + 1));
         continue;
       }
       return await response.json();
     } catch (error) {
-      if (i === maxRetries - 1) throw error;
-      await sleep(1000 * (i + 1));
+      clearTimeout(timeout);
+      if (attempt === maxRetries - 1) throw error;
+      await sleep(1000 * (attempt + 1));
     }
   }
 }
 
-async function getDeployerAddress(tokenCA) {
-  const url = `${API_BASE}?module=contract&action=getcontractcreation&contractaddresses=${tokenCA}&apikey=${ROUTESCAN_API_KEY}`;
-  
+// Resolve token contract → deployer wallet
+async function getDeployerAddress(tokenCA, apiKey) {
+  const url = `${API_BASE}?module=contract&action=getcontractcreation&contractaddresses=${tokenCA}&apikey=${apiKey}`;
   const data = await fetchWithRetry(url);
-  
-  if (data.status === '1' && data.result && data.result[0] && data.result[0].contractCreator) {
+
+  if (data.status === '1' && data.result?.[0]?.contractCreator) {
     return data.result[0].contractCreator;
   }
-  
+
+  // Fallback: earliest transaction sender
   console.error('  getcontractcreation empty, trying txlist fallback...');
-  const txUrl = `${API_BASE}?module=account&action=txlist&address=${tokenCA}&startblock=0&endblock=99999999&sort=asc&page=1&offset=10&apikey=${ROUTESCAN_API_KEY}`;
-  
+  const txUrl = `${API_BASE}?module=account&action=txlist&address=${tokenCA}&startblock=0&endblock=99999999&sort=asc&page=1&offset=10&apikey=${apiKey}`;
   const txData = await fetchWithRetry(txUrl);
-  
-  if (txData.status === '1' && txData.result && txData.result.length > 0) {
-    const firstTx = txData.result[0];
-    return firstTx.from;
+
+  if (txData.status === '1' && txData.result?.length > 0) {
+    return txData.result[0].from;
   }
-  
+
   throw new Error(`Could not determine deployer for ${tokenCA}`);
 }
 
-async function getDeployerContracts(deployerAddress) {
-  const url = `${API_BASE}?module=account&action=txlistinternal&address=${deployerAddress}&startblock=0&endblock=99999999&sort=asc&apikey=${ROUTESCAN_API_KEY}`;
-  
+// Pull all contracts created by a deployer wallet
+async function getDeployerContracts(deployerAddress, apiKey) {
+  const url = `${API_BASE}?module=account&action=txlistinternal&address=${deployerAddress}&startblock=0&endblock=99999999&sort=asc&apikey=${apiKey}`;
   const data = await fetchWithRetry(url);
-  
-  if (data.status !== '1' || !data.result) {
-    return [];
-  }
-  
-  return data.result.filter(tx => 
-    tx.contractAddress && 
+
+  if (data.status !== '1' || !data.result) return [];
+
+  return data.result.filter(tx =>
+    tx.contractAddress &&
     tx.contractAddress !== '' &&
     (tx.type === 'create' || tx.type === 'create2')
   );
 }
 
+// Fetch token market data from DexScreener
 async function getTokenInfo(contractAddress) {
   try {
-    const url = `https://api.dexscreener.com/token-pairs/v1/base/${contractAddress}`;
-    
-    await sleep(300);
-    
-    const data = await fetchWithRetry(url);
-    
-    if (!data || !Array.isArray(data) || data.length === 0) {
-      return null;
-    }
-    
+    await sleep(DEXSCREENER_DELAY_MS);
+    const data = await fetchWithRetry(`${DEXSCREENER_BASE}/${contractAddress}`);
+
+    if (!Array.isArray(data) || data.length === 0) return null;
+
     const pair = data[0];
-    const baseToken = pair.baseToken;
-    const quoteToken = pair.quoteToken;
-    
-    const isBase = baseToken.address.toLowerCase() === contractAddress.toLowerCase();
-    const token = isBase ? baseToken : quoteToken;
-    
+    const isBase = pair.baseToken.address.toLowerCase() === contractAddress.toLowerCase();
+    const token = isBase ? pair.baseToken : pair.quoteToken;
+
     const mcap = pair.fdv || pair.marketCap || 0;
     const volume24h = pair.volume?.h24 || 0;
     const priceUsd = parseFloat(pair.priceUsd || 0);
     const liquidity = pair.liquidity?.usd || 0;
-    
+
     const pairCreatedAt = new Date(pair.pairCreatedAt || Date.now());
     const daysOld = Math.floor((Date.now() - pairCreatedAt.getTime()) / (1000 * 60 * 60 * 24));
-    
-    let status = 'unknown';
+
+    let status;
     if (liquidity === 0 || mcap === 0 || priceUsd === 0) {
       status = 'dead';
     } else if (liquidity > 1000) {
@@ -102,63 +104,60 @@ async function getTokenInfo(contractAddress) {
     } else {
       status = 'low_liquidity';
     }
-    
+
     return {
       ca: contractAddress,
       name: token.name || 'Unknown',
       symbol: token.symbol || '???',
       currentMcap: mcap,
-      peakMcap: mcap,
+      peakMcap: mcap, // Current mcap at scan time — historical peak not available via API
       volume24h,
       liquidity,
       status,
       daysOld,
       priceUsd
     };
-  } catch (error) {
+  } catch {
     return null;
   }
 }
 
+// Score deployer track record. See references/scoring-methodology.md
 function calculateDeployerScore(tokensWithData, totalContractsCreated) {
   let score = 50;
-  
-  // Use actual contract count, not just those with market data
-  const totalTokens = totalContractsCreated;
-  const survived7Days = tokensWithData.filter(t => t && t.daysOld >= 7 && t.status === 'active').length;
-  const survived30Days = tokensWithData.filter(t => t && t.daysOld >= 30 && t.status === 'active').length;
-  const deadUnder72h = tokensWithData.filter(t => t && t.daysOld < 3 && t.status === 'dead').length;
-  
-  const validMcaps = tokensWithData.filter(t => t && t.peakMcap > 0).map(t => t.peakMcap);
-  const avgPeakMcap = validMcaps.length > 0 ? validMcaps.reduce((a, b) => a + b, 0) / validMcaps.length : 0;
-  
-  // Positive signals
-  if (survived30Days > 0) score += 10;
-  score += Math.min(survived7Days * 5, 20);
-  if (avgPeakMcap > 500000) score += 10;
-  
-  // Negative signals
-  score -= Math.min(deadUnder72h * 10, 30);
-  
-  // CRITICAL FIX: Penalize serial deployers with no survivors
-  if (totalTokens > 5 && survived7Days === 0) {
-    score -= 20;  // Increased penalty for proven track record of failure
+
+  const survived7d = tokensWithData.filter(t => t.daysOld >= 7 && t.status === 'active').length;
+  const survived30d = tokensWithData.filter(t => t.daysOld >= 30 && t.status === 'active').length;
+  const deadUnder72h = tokensWithData.filter(t => t.daysOld < 3 && t.status === 'dead').length;
+
+  const mcaps = tokensWithData.filter(t => t.peakMcap > 0).map(t => t.peakMcap);
+  const avgPeakMcap = mcaps.length > 0 ? mcaps.reduce((a, b) => a + b, 0) / mcaps.length : 0;
+
+  // Positive: survival signals
+  if (survived30d > 0) score += 10;                          // #1: 30-day survivor exists
+  score += Math.min(survived7d * 5, 20);                     // #2: each 7-day survivor
+  if (avgPeakMcap > 500000) score += 10;                     // #3: avg mcap > $500K
+
+  // Negative: failure patterns
+  score -= Math.min(deadUnder72h * 10, 30);                  // #4: tokens dead within 72h
+  if (totalContractsCreated > 5 && survived7d === 0) {
+    score -= 20;                                              // #5: serial deployer, zero survivors
   }
-  
-  // Additional penalty: lots of contracts deployed but almost none have market data
-  const dataRate = totalTokens > 0 ? tokensWithData.length / totalTokens : 0;
-  if (totalTokens >= 10 && dataRate < 0.3) {
-    score -= 15;  // Most deployed contracts never got liquidity = red flag
+
+  const dataRate = totalContractsCreated > 0
+    ? tokensWithData.length / totalContractsCreated : 0;
+  if (totalContractsCreated >= 10 && dataRate < 0.3) {
+    score -= 15;                                              // #6: high deploy volume, no follow-through
   }
-  
+
   score = Math.max(0, Math.min(100, score));
-  
+
   return {
     score: Math.round(score),
-    totalTokens,
+    totalTokens: totalContractsCreated,
     tokensWithMarketData: tokensWithData.length,
-    survived7Days,
-    survived30Days,
+    survived7Days: survived7d,
+    survived30Days: survived30d,
     deadUnder72h,
     avgPeakMcap: Math.round(avgPeakMcap),
     dataRate: Math.round(dataRate * 100)
@@ -166,54 +165,47 @@ function calculateDeployerScore(tokensWithData, totalContractsCreated) {
 }
 
 async function scanDeployer(tokenCA) {
+  const apiKey = getApiKey();
+
   console.error(`\nScanning deployer for token: ${tokenCA}`);
-  
-  if (!ROUTESCAN_API_KEY) {
-    throw new Error('ROUTESCAN_API_KEY environment variable not set');
-  }
-  
+
   console.error('Step 1: Fetching deployer address...');
-  const deployerAddress = await getDeployerAddress(tokenCA);
+  const deployerAddress = await getDeployerAddress(tokenCA, apiKey);
   console.error(`  Deployer: ${deployerAddress}`);
-  
+
   console.error('Step 2: Fetching deployer contract creations...');
-  const contractCreations = await getDeployerContracts(deployerAddress);
-  console.error(`  Found ${contractCreations.length} contract creations`);
-  
+  const contracts = await getDeployerContracts(deployerAddress, apiKey);
+  console.error(`  Found ${contracts.length} contract creations`);
+
   console.error('Step 3: Fetching token info from DexScreener...');
   const previousTokens = [];
-  
-  for (const tx of contractCreations) {
-    const contractAddr = tx.contractAddress;
-    
-    if (contractAddr.toLowerCase() === tokenCA.toLowerCase()) {
-      continue;
-    }
-    
-    const tokenInfo = await getTokenInfo(contractAddr);
-    if (tokenInfo) {
-      previousTokens.push(tokenInfo);
-    }
+
+  for (const tx of contracts) {
+    // Skip the target token — don't score against itself
+    if (tx.contractAddress.toLowerCase() === tokenCA.toLowerCase()) continue;
+
+    const info = await getTokenInfo(tx.contractAddress);
+    if (info) previousTokens.push(info);
   }
-  
-  console.error(`  Found market data for ${previousTokens.length}/${contractCreations.length} contracts`);
-  
-  // FIXED: Pass both market data AND total contract count
-  const scoreData = calculateDeployerScore(previousTokens, contractCreations.length);
-  
+
+  console.error(`  Market data for ${previousTokens.length}/${contracts.length} contracts`);
+
+  const scoreData = calculateDeployerScore(previousTokens, contracts.length);
+
+  // Fetch current token metadata for output
   let tokenName = 'Unknown';
   let tokenSymbol = '???';
   try {
-    const currentTokenInfo = await getTokenInfo(tokenCA);
-    if (currentTokenInfo) {
-      tokenName = currentTokenInfo.name;
-      tokenSymbol = currentTokenInfo.symbol;
+    const current = await getTokenInfo(tokenCA);
+    if (current) {
+      tokenName = current.name;
+      tokenSymbol = current.symbol;
     }
-  } catch (e) {
+  } catch {
     console.error('  Warning: Could not fetch current token info');
   }
-  
-  const output = {
+
+  return {
     token: tokenSymbol,
     tokenName,
     ca: tokenCA,
@@ -226,38 +218,29 @@ async function scanDeployer(tokenCA) {
       survivedPast30Days: scoreData.survived30Days,
       avgPeakMcap: scoreData.avgPeakMcap,
       previousTokens: previousTokens.map(t => ({
-        ca: t.ca,
-        name: t.name,
-        symbol: t.symbol,
-        currentMcap: t.currentMcap,
-        peakMcap: t.peakMcap,
-        volume24h: t.volume24h,
-        liquidity: t.liquidity,
-        status: t.status,
-        daysOld: t.daysOld,
-        priceUsd: t.priceUsd
+        ca: t.ca, name: t.name, symbol: t.symbol,
+        currentMcap: t.currentMcap, peakMcap: t.peakMcap,
+        volume24h: t.volume24h, liquidity: t.liquidity,
+        status: t.status, daysOld: t.daysOld, priceUsd: t.priceUsd
       }))
     },
     deployerScore: scoreData.score,
     timestamp: new Date().toISOString()
   };
-  
-  return output;
 }
 
+// Standalone: node deployer-scanner.js <TOKEN_CONTRACT_ADDRESS>
 if (import.meta.url === `file://${process.argv[1]}`) {
   const tokenCA = process.argv[2];
-  
+
   if (!tokenCA) {
     console.error('Usage: node deployer-scanner.js <TOKEN_CONTRACT_ADDRESS>');
-    console.error('Env: ROUTESCAN_API_KEY');
+    console.error('Env:   ROUTESCAN_API_KEY (required)');
     process.exit(1);
   }
-  
+
   scanDeployer(tokenCA)
-    .then(result => {
-      console.log(JSON.stringify(result, null, 2));
-    })
+    .then(result => console.log(JSON.stringify(result, null, 2)))
     .catch(error => {
       console.error(`\nERROR: ${error.message}`);
       process.exit(1);


### PR DESCRIPTION
## Summary                                                                                                            
                                                                                                                     
  Deployer intelligence scoring for Base tokens. Resolves a token's deployer wallet, pulls full contract creation
  history via Routescan API, scores the wallet's track record against DexScreener market data. Outputs a 0–100 deployer
  score.

  Designed as a veto layer — filters out tokens from wallets with proven failure patterns before an agent commits
  capital.

  ## What's included

  - **SKILL.md** — skill docs, scoring table, integration pattern for the Bankr stack
  - **references/scoring-methodology.md** — full scoring spec with formula, worked examples, API endpoints, auditable by
   any operator
  - **scripts/deployer-scanner.js** — standalone scanner, runs with `node deployer-scanner.js <TOKEN_CA>`, outputs JSON

  ## Scoring

  Base 50, six adjustments (+10/+20/+10 for survival and mcap quality, -30/-20/-15 for fast deaths, serial failure,
  ghost contracts). Methodology doc shows exact weights and two worked examples (score 80 builder, score 5 serial
  failure).

  ## Data sources

  - Routescan API — `getcontractcreation`, `txlistinternal` (Base chain 8453)
  - DexScreener API — token pairs, mcap, liquidity, volume, pair age

  ## Usage

  ```bash
  openclaw skills install lexispawn/deployer-intelligence
  export ROUTESCAN_API_KEY="your_key"
  node scripts/deployer-scanner.js 0x1bc0c42215582d5A085795f4baDbaC3ff36d1Bcb

  Known limitations

  - ERC-4337 AA wallets: UserOp-embedded deployments invisible to txlistinternal
  - peakMcap is current mcap at scan time, not historical peak
  - Base only

  ---
  First skill contribution from https://x.com/lexispawn. Part of the 15 MINDS intelligence system on Base.