### PR TITLE
docs(bankr): add optional ClawCredit + x402 integration guide

### DIFF
--- a/bankr/SKILL.md
+++ b/bankr/SKILL.md
@@ -360,6 +360,19 @@ For full details — setup paths, model list, provider config, SDK examples, key
 
 **Reference**: [references/llm-gateway.md](references/llm-gateway.md)
 
+### Optional: Pair Bankr with ClawCredit for x402 services
+
+If your agent also calls paid **x402** APIs, you can combine Bankr with ClawCredit:
+
+- Use **Bankr** for wallet actions and Bankr LLM Gateway (`api.bankr.bot`, `llm.bankr.bot`)
+- Use **ClawCredit** for deferred-payment access to external x402 services
+
+Important distinction:
+- HTTP 402 from `llm.bankr.bot` means Bankr LLM credits are empty → top up with `bankr llm credits add ...`
+- HTTP 402 from a non-Bankr x402 endpoint is an x402 payment issue → use direct wallet payment or ClawCredit flow
+
+**Reference**: [references/clawcredit-integration.md](references/clawcredit-integration.md)
+
 ## Capabilities Overview
 
 ### Trading Operations

--- a/bankr/references/clawcredit-integration.md
+++ b/bankr/references/clawcredit-integration.md
@@ -1,0 +1,89 @@
+# ClawCredit Integration (Optional)
+
+Use this when your agent combines:
+- **Bankr** for wallet operations, trading, transfers, and Bankr LLM Gateway usage, and
+- **x402 services** that support deferred credit payments through **ClawCredit**.
+
+This is useful for agents that need both on-chain execution (Bankr) and pay-per-call x402 APIs without keeping crypto funded at all times.
+
+## What each system pays for
+
+| System | Payment model | Typical use |
+|--------|---------------|-------------|
+| Bankr Agent API | Wallet-funded on-chain execution | swaps, transfers, leverage, NFT ops, token launch |
+| Bankr LLM Gateway | Prepaid Bankr LLM credits (USD) | model calls at `llm.bankr.bot` |
+| x402 + ClawCredit | Deferred credit line (USD) | paid x402 APIs/services outside Bankr |
+
+> Important: **ClawCredit does not replace Bankr LLM credits.**
+> If `llm.bankr.bot` returns HTTP 402, top up with `bankr llm credits add ...`.
+
+## When to use ClawCredit with Bankr
+
+Use ClawCredit only for **non-Bankr x402 endpoints** (for example, external x402 partner APIs).
+
+Examples:
+- Use Bankr to trade/transfer on-chain.
+- Use ClawCredit to pay an x402 research API in the same workflow.
+
+## Minimal integration pattern
+
+1. Keep Bankr configured normally (`bankr login`, `bankr whoami`, `bankr llm credits`).
+2. Register/configure ClawCredit once (with explicit user consent to ClawCredit Privacy Policy).
+3. Route requests by endpoint:
+   - `api.bankr.bot` / `llm.bankr.bot` → Bankr flow
+   - external x402 endpoint → ClawCredit `pay(...)`
+
+## Routing example (Node.js pseudo-code)
+
+```javascript
+function isBankrUrl(url) {
+  return url.includes('api.bankr.bot') || url.includes('llm.bankr.bot');
+}
+
+async function callPaidEndpoint(url, payload) {
+  if (isBankrUrl(url)) {
+    // Use Bankr auth + Bankr credits/wallet flows
+    return callBankr(url, payload);
+  }
+
+  // Use ClawCredit for external x402 endpoint
+  return credit.pay({
+    transaction: {
+      recipient: url,
+      amount: 0.05,
+      chain: 'BASE',
+      asset: 'USDC'
+    },
+    request_body: {
+      http: {
+        url,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        timeout_s: 30
+      },
+      body: payload
+    }
+  });
+}
+```
+
+## Operational notes
+
+- Keep Bankr and ClawCredit credentials separate.
+- For ClawCredit, monitor repayment status and reminders to avoid suspension.
+- For Bankr LLM Gateway, enable auto top-up to reduce 402 interruptions:
+
+```bash
+bankr llm credits auto --enable --amount 25 --threshold 5 --tokens USDC
+```
+
+- If a request fails with 402, identify the source first:
+  - `llm.bankr.bot` → Bankr credits issue
+  - x402 merchant endpoint → payment/underwriting issue (direct wallet or ClawCredit path)
+
+## Security checklist
+
+- Use dedicated agent wallets/keys for autonomous workflows.
+- Never hardcode API tokens in source control.
+- Restrict scope with read-only keys/IP allowlists when possible.
+- Keep ClawCredit consent/repayment communication explicit and auditable.

--- a/bankr/references/error-handling.md
+++ b/bankr/references/error-handling.md
@@ -98,7 +98,7 @@ bankr prompt "What is my balance?"
 |------|---------|--------|
 | **400** | Bad request | Check prompt format, validate parameters |
 | **401** | Unauthorized | Fix API key (see Authentication section) |
-| **402** | Payment required | For LLM Gateway: top up via `bankr llm credits add 25` or at [bankr.bot/llm?tab=credits](https://bankr.bot/llm?tab=credits) (`bankr llm credits` to check). For Agent API: ensure wallet has funds for fees |
+| **402** | Payment required | For `llm.bankr.bot`: top up via `bankr llm credits add 25` or at [bankr.bot/llm?tab=credits](https://bankr.bot/llm?tab=credits) (`bankr llm credits` to check). For Bankr Agent API: ensure wallet has funds for fees. For **external x402 endpoints**: use direct wallet payment or a ClawCredit flow (see [clawcredit integration](./clawcredit-integration.md)). |
 | **403** | Forbidden | Agent API access not enabled — enable at https://bankr.bot/api |
 | **429** | Rate limited | Wait and retry with exponential backoff |
 | **500** | Server error | Retry after delay |

--- a/bankr/references/llm-gateway.md
+++ b/bankr/references/llm-gateway.md
@@ -339,6 +339,7 @@ message = client.messages.create(
 - Set up auto top-up to prevent this: `bankr llm credits auto --enable --amount 25 --threshold 5 --tokens USDC`
 - New wallets start with $0 — you must add credits before first use
 - LLM credits are separate from your trading wallet balance
+- If your 402 came from a **non-Bankr x402 endpoint**, this section does not apply; see [clawcredit integration](./clawcredit-integration.md)
 
 ### Model not found
 - Use exact model IDs (e.g., `claude-sonnet-4.6`, not `claude-3-sonnet`)


### PR DESCRIPTION
## Summary
This PR adds an **optional** ClawCredit integration path for agents that use Bankr and also call paid external x402 APIs.

### What changed
- Added new reference doc: `bankr/references/clawcredit-integration.md`
  - system boundaries (Bankr Agent API / Bankr LLM credits / x402 + ClawCredit)
  - endpoint routing guidance (`api.bankr.bot` + `llm.bankr.bot` vs external x402 endpoints)
  - 402 troubleshooting split by source
  - minimal routing pseudo-code and operational checklist
- Updated `bankr/SKILL.md`
  - added an "Optional: Pair Bankr with ClawCredit for x402 services" section
  - linked to the new integration reference
- Updated `bankr/references/error-handling.md`
  - clarified HTTP 402 handling for Bankr endpoints vs external x402 endpoints
- Updated `bankr/references/llm-gateway.md`
  - added a note clarifying that non-Bankr x402 402 errors should follow the ClawCredit path

## Why
Users increasingly run mixed workflows where Bankr handles on-chain actions and separate x402 services are used in the same agent. This PR documents a safe, explicit integration model and prevents confusing Bankr LLM-credit errors with x402 payment errors.

## Scope
Documentation-only changes. No runtime behavior changes.
