### PR TITLE
docs: add Hydrex to available skills table

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Bankr Skills equip builders with plug-and-play tools to build more powerful agen
 | [Veil Cash](https://veil.cash) | [veil](veil/) | Privacy-preserving transactions. Deposit into shielded pools, perform ZK withdrawals, manage private transfers. |
 | yoink | [yoink](yoink/) | Social on-chain game. "Yoink" a token from the current holder. Uses Bankr for transaction execution. |
 | [Neynar](https://neynar.com) | [neynar](neynar/) | Full Farcaster API integration. Post casts, like, recast, follow users, search content, and manage Farcaster identities. |
+| [Hydrex](https://hydrex.fi) | [hydrex](hydrex/) | Liquidity pools on Base. Lock HYDX for voting power, vote on pool strategies, deposit single-sided liquidity into auto-managed vaults, and claim oHYDX rewards. |
 
 ## Adding a Skill
 


### PR DESCRIPTION
Adds Hydrex to the Available Skills table in README.md, following the merge of PR #55 which added the hydrex skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)