### PR TITLE
add builder-data skill from Talent

### DIFF
--- a/builder-data/SKILL.md
+++ b/builder-data/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: builder-data
+description: Query builder reputation data via Talent Protocol API. Get Builder Rank, verify humans, resolve identities (Twitter/Farcaster/GitHub/wallet), search by location/country, get credentials, and enrich with GitHub data.
+---
+
+# Talent Powers
+
+Query professional data from [Talent Protocol](https://talent.app) - a platform that tracks builders
+
+**Use this skill to:**
+- Find verified developers by location, skills, or identity (Twitter/GitHub/Farcaster/wallet)
+- Check builder reputation (ranks by default, scores only when asked)
+- Map Twitter accounts with Wallet addresses
+- Verify human identity from a wallet
+- Search for builder's credentials (earnings, contributions, hackathons, contracts, etc)
+- Check the projects each builder is shipping
+
+## Required Credentials
+
+| Variable | Required | Description | Get it at |
+|----------|----------|-------------|-----------|
+| `TALENT_API_KEY` | **Yes** | API key for Talent Protocol (read access to profile/identity data) | https://talent.app/~/settings/api |
+| `GITHUB_TOKEN` | No | Personal access token for higher GitHub rate limits (60/hr → 5,000/hr) | https://github.com/settings/tokens |
+
+**Base URL:** `https://api.talentprotocol.com`
+
+```bash
+curl -H "X-API-KEY: $TALENT_API_KEY" "https://api.talentprotocol.com/..."
+```
+
+## Endpoints
+
+| Endpoint | Purpose |
+|----------|---------|
+| `/search/advanced/profiles` | Search profiles by identity, tags, rank, verification |
+| `/profile` | Get profile by ID |
+| `/accounts` | Get connected wallets, GitHub, socials |
+| `/socials` | Get social profiles + bios |
+| `/credentials` | Get data points (earnings, followers, hackathons, etc.) |
+| `/human_checkmark` | Check if human-verified (optional, don't use by default) |
+| `/scores` | Get ranks (default) or scores (only when explicitly asked) |
+
+## Key Parameters
+
+**Identity lookup:**
+```
+query[identity]={handle}&query[identity_type]={twitter|github|farcaster|ens|wallet}
+```
+
+**Filters (all optional, only use when relevant to the query):**
+```
+query[tags][]=developer              # filter by tag (developer, designer, etc.)
+query[verified_nationality]=true     # only verified nationality
+query[human_checkmark]=true          # only human-verified (reduces results significantly)
+```
+
+**Sorting:**
+```
+sort[score][order]=desc&sort[score][scorer]=Builder%20Score
+```
+
+**Pagination:** `page=1&per_page=250` (max 250)
+
+## URL Encoding
+
+`[` = `%5B`, `]` = `%5D`, Space = `%20`
+
+## Response Fields
+
+**Default → Ranks (always use unless user asks for scores):**
+- `builder_score.rank_position` - Primary rank metric
+- `scores[].rank_position` where `slug = "builder_score"` - Latest rank
+
+**Only when user explicitly asks for scores:**
+- `builder_score.points` - Score value
+- `scores[].points` - Individual score values
+
+- `location` - User-entered location (returned in response)
+
+## Location Filter
+
+**DO NOT USE** `query[standardized_location]=Country` - doesn't work.
+
+**USE `customQuery` with regex:**
+
+```bash
+curl -X POST -H "X-API-KEY: $TALENT_API_KEY" -H "Content-Type: application/json" \
+  "https://api.talentprotocol.com/search/advanced/profiles" \
+  -d '{
+    "customQuery": {
+      "regexp": {
+        "standardized_location": {
+          "value": ".*argentina.*",
+          "case_insensitive": true
+        }
+      }
+    },
+    "sort": { "score": { "order": "desc", "scorer": "Builder Score" } },
+    "perPage": 50
+  }'
+```
+
+See [use-cases.md](references/use-cases.md#by-location-country) for more examples.
+
+## Limitations
+
+- Max 250 per page
+- GET only for most endpoints (POST for customQuery)
+- Simple `query[standardized_location]` param broken - use `customQuery` regex
+
+## GitHub Enrichment
+
+Get projects/repos via GitHub after resolving username from `/accounts`:
+
+```bash
+# 1. Get GitHub username
+/accounts?id={profile_id} → { "source": "github", "username": "..." }
+
+# 2. Query GitHub
+GET https://api.github.com/users/{username}                           # Profile
+GET https://api.github.com/users/{username}/repos?sort=stars&per_page=5   # Top repos
+GET https://api.github.com/users/{username}/repos?sort=pushed&per_page=5  # Recent
+GET https://api.github.com/users/{username}/events/public             # Commits
+GET https://api.github.com/search/issues?q=author:{username}+type:pr+state:open  # Open PRs
+```
+
+**GitHub Token (recommended):** Without a token, GitHub limits to 60 requests/hr. With a personal access token, you get 5,000/hr.
+- Create one at: https://github.com/settings/tokens → "Generate new token (classic)" → no scopes needed for public data
+- Use it: `-H "Authorization: token $GITHUB_TOKEN"`
+
+## References
+
+- [endpoints.md](references/endpoints.md) - Full endpoint docs
+- [use-cases.md](references/use-cases.md) - Common patterns
+- [github-enrichment.md](references/github-enrichment.md) - GitHub data

--- a/builder-data/references/endpoints.md
+++ b/builder-data/references/endpoints.md
@@ -1,0 +1,211 @@
+# Endpoints
+
+**API Key:** https://talent.app/~/settings/api
+
+```bash
+curl -H "X-API-KEY: $TALENT_API_KEY" "https://api.talentprotocol.com/..."
+```
+
+**URL Encoding:** `[` = `%5B`, `]` = `%5D`
+
+---
+
+## /search/advanced/profiles
+
+### GET (identity, tags, verification)
+
+```bash
+curl -H "X-API-KEY: $TALENT_API_KEY" \
+  "https://api.talentprotocol.com/search/advanced/profiles?query%5Bidentity%5D=jessepollak&query%5Bidentity_type%5D=twitter"
+```
+
+| Parameter | Example |
+|-----------|---------|
+| `query[identity]` | `jessepollak` |
+| `query[identity_type]` | `twitter`, `github`, `farcaster`, `ens`, `wallet` |
+| `query[verified_nationality]` | `true` |
+| `query[human_checkmark]` | `true` (optional - reduces results, only use when user asks) |
+| `query[tags][]` | `developer` |
+| `sort[score][order]` | `desc` |
+| `sort[score][scorer]` | `Builder Score` |
+| `page` | `1` |
+| `per_page` | `250` (max) |
+
+### POST with customQuery (for location filtering)
+
+**DO NOT USE** `query[standardized_location]` - it doesn't work.
+
+**USE POST with `customQuery` regex:**
+
+```bash
+curl -X POST -H "X-API-KEY: $TALENT_API_KEY" -H "Content-Type: application/json" \
+  "https://api.talentprotocol.com/search/advanced/profiles" \
+  -d '{
+    "customQuery": {
+      "regexp": {
+        "standardized_location": {
+          "value": ".*argentina.*",
+          "case_insensitive": true
+        }
+      }
+    },
+    "sort": { "score": { "order": "desc", "scorer": "Builder Score" } },
+    "perPage": 50
+  }'
+```
+
+> **Note:** `"humanCheckmark": true` is optional. Don't include it by default — it reduces results. Only add when user explicitly asks.
+
+See [use-cases.md](use-cases.md#by-location-country) for more location examples.
+
+### Response
+
+```json
+{
+  "profiles": [{
+    "id": "uuid",
+    "name": "username",
+    "display_name": "Name",
+    "bio": "...",
+    "location": "Buenos Aires, Argentina",
+    "human_checkmark": true,
+    "tags": ["developer"],
+    "builder_score": { "rank_position": 127, "points": 229 },
+    "scores": [
+      { "slug": "builder_score", "rank_position": 154 }
+    ]
+  }],
+  "pagination": { "current_page": 1, "total": 100 }
+}
+```
+
+**Default:** Use `rank_position` fields. Only include `points` when user explicitly asks for scores.
+
+---
+
+## /profile
+
+```bash
+curl -H "X-API-KEY: $TALENT_API_KEY" \
+  "https://api.talentprotocol.com/profile?id={profile_id}"
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `id` | Profile ID, wallet, or identifier |
+| `account_source` | `farcaster`, `github`, `wallet` |
+
+---
+
+## /accounts
+
+Get connected wallets and platforms. Use to find GitHub username for enrichment.
+
+```bash
+curl -H "X-API-KEY: $TALENT_API_KEY" \
+  "https://api.talentprotocol.com/accounts?id={profile_id}"
+```
+
+**Response:**
+
+```json
+{
+  "accounts": [
+    { "source": "wallet", "identifier": "0x..." },
+    { "source": "github", "username": "jessepollak" },
+    { "source": "farcaster", "username": "jesse" },
+    { "source": "x_twitter", "username": "jessepollak" }
+  ]
+}
+```
+
+---
+
+## /socials
+
+Get social profiles with bios and follower counts.
+
+```bash
+curl -H "X-API-KEY: $TALENT_API_KEY" \
+  "https://api.talentprotocol.com/socials?id={profile_id}"
+```
+
+**Response:**
+
+```json
+{
+  "socials": [
+    { "social_name": "Twitter", "handle": "jessepollak", "bio": "...", "followers_count": 5000 },
+    { "social_name": "Github", "handle": "jessepollak", "followers_count": 200 },
+    { "social_name": "Farcaster", "handle": "jesse", "followers_count": 1500 }
+  ]
+}
+```
+
+---
+
+## /credentials
+
+Get all data points: earnings, followers, hackathons, events, memberships.
+
+```bash
+curl -H "X-API-KEY: $TALENT_API_KEY" \
+  "https://api.talentprotocol.com/credentials?id={profile_id}"
+```
+
+**Response:**
+
+```json
+{
+  "credentials": [
+    { "slug": "github_total_contributions", "readable_value": "500" },
+    { "slug": "total_earnings", "readable_value": "1250" },
+    { "slug": "eth_global_hacker", "points": 10 },
+    { "slug": "base_basecamp", "points": 5 }
+  ]
+}
+```
+
+**Common slugs:**
+
+| Category | Slugs |
+|----------|-------|
+| Followers | `total_followers`, `twitter_followers`, `github_followers`, `farcaster_followers` |
+| Earnings | `total_earnings`, `total_builder_earnings`, `base_builder_rewards_eth` |
+| Events | `base_basecamp`, `farcaster_farcon_nyc_2025_attendee` |
+| Hackathons | `eth_global_hacker`, `eth_global_finalist`, `devfolio_hackathons_won` |
+| Verification | `talent_protocol_human_checkmark`, `world_id_human`, `coinbase_verified_account` |
+| Memberships | `developer_dao_member`, `fwb_member` |
+
+---
+
+## /human_checkmark
+
+```bash
+curl -H "X-API-KEY: $TALENT_API_KEY" \
+  "https://api.talentprotocol.com/human_checkmark?id={profile_id}"
+```
+
+**Response:** `{ "human_checkmark": true }`
+
+---
+
+## /data_points
+
+List available data point slugs for a profile.
+
+```bash
+curl -H "X-API-KEY: $TALENT_API_KEY" \
+  "https://api.talentprotocol.com/data_points?id={profile_id}"
+```
+
+---
+
+## Errors
+
+| Status | Meaning |
+|--------|---------|
+| 400 | Bad request (e.g., per_page > 250) |
+| 401 | Missing/invalid API key |
+| 404 | Profile not found |
+| 302 | Used POST instead of GET |

--- a/builder-data/references/github-enrichment.md
+++ b/builder-data/references/github-enrichment.md
@@ -1,0 +1,130 @@
+# GitHub Enrichment
+
+Get projects/repos by resolving identity → GitHub username → GitHub API.
+
+**GitHub Token:** https://github.com/settings/tokens (60 req/hr without, 5000 with)
+
+---
+
+## Flow
+
+```bash
+# 1. Get GitHub username from Talent Protocol
+curl -H "X-API-KEY: $TALENT_API_KEY" \
+  "https://api.talentprotocol.com/accounts?id={profile_id}"
+# Response: { "source": "github", "username": "jessepollak" }
+
+# 2. Query GitHub API
+```
+
+---
+
+## Endpoints
+
+| Data | Endpoint |
+|------|----------|
+| Profile & company | `GET /users/{username}` |
+| Top repos | `GET /users/{username}/repos?sort=stars&per_page=5` |
+| Recent repos | `GET /users/{username}/repos?sort=pushed&per_page=5` |
+| Activity/commits | `GET /users/{username}/events/public` |
+| Open PRs | `GET /search/issues?q=author:{username}+type:pr+state:open&per_page=5` |
+| README | `GET /repos/{owner}/{repo}/readme` |
+| Languages | `GET /repos/{owner}/{repo}/languages` |
+
+---
+
+## Profile
+
+```bash
+curl https://api.github.com/users/{username}
+```
+
+```json
+{
+  "login": "jessepollak",
+  "name": "Jesse Pollak",
+  "company": "@coinbase",
+  "bio": "Building @base",
+  "location": "San Francisco",
+  "public_repos": 142,
+  "followers": 5200
+}
+```
+
+---
+
+## Repos
+
+```bash
+# Top by stars
+curl "https://api.github.com/users/{username}/repos?sort=stars&direction=desc&per_page=5"
+
+# Recent
+curl "https://api.github.com/users/{username}/repos?sort=pushed&direction=desc&per_page=5"
+```
+
+```json
+{
+  "name": "repo-name",
+  "description": "...",
+  "stargazers_count": 1250,
+  "language": "TypeScript",
+  "fork": false,
+  "pushed_at": "2024-01-28T00:00:00Z"
+}
+```
+
+**Forked repos:** Filter where `fork=true`
+
+**Languages:** Aggregate `language` field from repos
+
+---
+
+## Open PRs
+
+```bash
+curl "https://api.github.com/search/issues?q=author:{username}+type:pr+state:open&per_page=5"
+```
+
+---
+
+## Activity & Commits
+
+```bash
+curl "https://api.github.com/users/{username}/events/public?per_page=100"
+```
+
+Filter by `type`:
+- `PushEvent` - commits
+- `PullRequestEvent` - PRs
+- `IssuesEvent` - issues
+
+Extract commits from PushEvent:
+```javascript
+events.filter(e => e.type === 'PushEvent')
+  .flatMap(e => e.payload.commits)
+  .slice(0, 5)
+```
+
+---
+
+## README
+
+```bash
+curl -H "Accept: application/vnd.github.raw" \
+  "https://api.github.com/repos/{owner}/{repo}/readme"
+```
+
+---
+
+## Auth
+
+```bash
+curl -H "Authorization: token $GITHUB_TOKEN" \
+  "https://api.github.com/users/{username}"
+```
+
+| API | Without token | With token |
+|-----|---------------|------------|
+| REST | 60/hr | 5,000/hr |
+| Search | 10/min | 30/min |

--- a/builder-data/references/use-cases.md
+++ b/builder-data/references/use-cases.md
@@ -1,0 +1,170 @@
+# Use Cases
+
+**URL Encoding:** `[` = `%5B`, `]` = `%5D`
+
+---
+
+## Identity → Wallets
+
+```bash
+# 1. Search by identity
+curl -H "X-API-KEY: $TALENT_API_KEY" \
+  "https://api.talentprotocol.com/search/advanced/profiles?query%5Bidentity%5D={handle}&query%5Bidentity_type%5D={identity_type}"
+# Response: profiles[0].id → use as profile_id
+
+# 2. Get wallets from profile ID
+curl -H "X-API-KEY: $TALENT_API_KEY" \
+  "https://api.talentprotocol.com/accounts?id={profile_id}"
+# Filter: source = "wallet"
+```
+
+**Identity types:** `twitter`, `github`, `farcaster`, `ens`, `lens`, `basename`, `wallet`
+
+---
+
+## Get Rank (default behavior)
+
+Response from `/search/advanced/profiles` includes:
+
+```json
+{
+  "builder_score": { "rank_position": 127 },
+  "scores": [
+    { "slug": "builder_score", "rank_position": 154 }
+  ]
+}
+```
+
+**Default:** Always return `rank_position` values. Use `builder_score.rank_position` for latest rank.
+
+**Only when user explicitly asks for scores:** include `points` values from `builder_score.points` or `scores[].points`.
+
+---
+
+## Get the Top Builders
+
+```bash
+curl -H "X-API-KEY: $TALENT_API_KEY" \
+  "https://api.talentprotocol.com/search/advanced/profiles?sort%5Bscore%5D%5Border%5D=desc&sort%5Bscore%5D%5Bscorer%5D=Builder%20Score&per_page=250"
+```
+
+---
+
+## By Location (Country)
+
+**DO NOT USE** `query[standardized_location]=Country` - it doesn't work.
+
+**USE `customQuery` with regex** - this queries the internal `standardized_location` field:
+
+### Top Builders from Argentina
+
+```bash
+curl -X POST -H "X-API-KEY: $TALENT_API_KEY" -H "Content-Type: application/json" \
+  "https://api.talentprotocol.com/search/advanced/profiles" \
+  -d '{
+    "customQuery": {
+      "regexp": {
+        "standardized_location": {
+          "value": ".*argentina.*",
+          "case_insensitive": true
+        }
+      }
+    },
+    "sort": { "score": { "order": "desc", "scorer": "Builder Score" } },
+    "perPage": 50
+  }'
+```
+
+### Top Builders from Brazil
+
+```bash
+curl -X POST -H "X-API-KEY: $TALENT_API_KEY" -H "Content-Type: application/json" \
+  "https://api.talentprotocol.com/search/advanced/profiles" \
+  -d '{
+    "customQuery": {
+      "regexp": {
+        "standardized_location": {
+          "value": ".*brazil.*",
+          "case_insensitive": true
+        }
+      }
+    },
+    "sort": { "score": { "order": "desc", "scorer": "Builder Score" } },
+    "perPage": 50
+  }'
+```
+
+### Pattern
+
+Replace country in regex: `"value": ".*{country}.*"`
+
+Examples: `.*united states.*`, `.*germany.*`, `.*nigeria.*`, `.*india.*`
+
+### More precise (country at end of string)
+
+To avoid matching "Georgia, USA" when searching for Georgia (country):
+
+```json
+{
+  "customQuery": {
+    "regexp": {
+      "standardized_location": {
+        "value": ".*,\\s*argentina$",
+        "case_insensitive": true
+      }
+    }
+  }
+}
+```
+
+This matches locations ending with ", argentina" (e.g., "Buenos Aires, Argentina")
+
+---
+
+## Credentials
+
+All from `/credentials?id={profile_id}`.
+
+**Discover all available data points:** Use `/data_issuers_meta` to get the full list of data issuers and credential slugs available. [API docs](https://docs.talentprotocol.com/docs/talent-api/api-reference/get-data-issuers-and-credentials-available)
+
+```bash
+curl -H "X-API-KEY: $TALENT_API_KEY" \
+  "https://api.talentprotocol.com/data_issuers_meta"
+```
+
+**Common credential slugs:**
+
+| Data | Slug |
+|------|------|
+| Total followers | `total_followers` |
+| Total earnings | `total_earnings` |
+| Verification | `talent_protocol_human_checkmark` |
+| Contracts | `base_mainnet_active_contracts`, `base_mainnet_contracts_deployed` |
+
+---
+
+## GitHub Enrichment
+
+```bash
+# 1. Get GitHub username from /accounts
+{ "source": "github", "username": "jessepollak" }
+
+# 2. Query GitHub API
+curl "https://api.github.com/users/{username}"                    # Profile, company
+curl "https://api.github.com/users/{username}/repos?sort=stars&per_page=5"   # Top repos
+curl "https://api.github.com/users/{username}/repos?sort=pushed&per_page=5"  # Recent
+curl "https://api.github.com/users/{username}/events/public"      # Commits, activity
+curl "https://api.github.com/search/issues?q=author:{username}+type:pr+state:open&per_page=5"  # Open PRs
+curl "https://api.github.com/repos/{owner}/{repo}/readme"         # README
+```
+
+GitHub token for higher rate limits: https://github.com/settings/tokens
+
+---
+
+## Batch Farcaster
+
+```bash
+curl -H "X-API-KEY: $TALENT_API_KEY" \
+  "https://api.talentprotocol.com/farcaster/scores?fids%5B%5D=123&fids%5B%5D=456"
+```


### PR DESCRIPTION
## Summary

- Adds the `builder-data` skill from [Talent](https://github.com/talentprotocol/builder-data)
- Query builder reputation data via Talent API
- Get Builder Rank, verify humans, resolve identities (Twitter/Farcaster/GitHub/wallet)
- Search builders by location/country
- Get credentials (earnings, hackathons, contributions, contracts)
- Enrich profiles with GitHub data

## Files Added

```
builder-data/
├── SKILL.md
└── references/
    ├── endpoints.md
    ├── use-cases.md
    └── github-enrichment.md
```