### PR TITLE
feat(skills): add stakr vaults skill

### DIFF
--- a/stakr/SKILL.md
+++ b/stakr/SKILL.md
@@ -59,6 +59,24 @@ Use this when the agent wants to **top up** an existing reward or **extend** the
 - More reward or longer duration (or new window after end) → `modifyRewardToken(token, amount, settings)`.
 - Ensure the vault has been created via the factory and the agent (or its controlled address) is the vault owner to call these.
 
+## Executing Transactions via Bankr
+
+To submit any Stakr call (vault creation, `addRewardToken`, `modifyRewardToken`), first encode calldata, then submit the transaction via the Bankr wallet API.
+
+Use a natural-language Bankr agent prompt:
+
+```bash
+bankr agent prompt "Call addRewardToken on vault 0x... with token 0x... amount 1000 USDC starting tomorrow for 7 days"
+```
+
+Or submit raw encoded calldata directly:
+
+```bash
+bankr wallet submit --to <vault-address> --data <encoded-calldata> --chain base
+```
+
+For calldata encoding help, see the [vault API reference](references/vault-api.md).
+
 ### 3. Streaming rewards (continuous incentives)
 
 Agents can **stream** rewards over time instead of funding one large window up front:

--- a/stakr/references/vault-api.md
+++ b/stakr/references/vault-api.md
@@ -59,6 +59,16 @@ Agents can **stream** rewards by using `modifyRewardToken` repeatedly instead of
 
 This pattern lets agents fund incentives in chunks and extend the program over time without locking a large lump sum upfront.
 
+### Execution via Bankr wallet
+
+Use this file to build and validate function calldata (`createStakrVault`, `addRewardToken`, `modifyRewardToken`, etc.), then submit the transaction with Bankr wallet:
+
+```bash
+bankr wallet submit --to <vault-address-or-factory> --data <encoded-calldata> --chain base
+```
+
+For a natural-language execution flow, see the skill guide section in [../SKILL.md](../SKILL.md).
+
 ### Other reward-related
 
 | Function           | Signature                                     | Notes                                                                  |


### PR DESCRIPTION
This skill gives agents the context to interact with the Stakr protocol: ERC-4626 tokenized vaults with multi-reward staking for any ERC-20 token. Use it when building integrations, scripts, or tooling that create vaults, add rewards, modify reward schedules, or let an agent operate its "own" staking vault.