### PR TITLE
feat: add VaultAgent skill — NFT vault liquidity on NFTX V3

### DIFF
--- a/vault-agent/SKILL.md
+++ b/vault-agent/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: vault-agent
+description: Execute NFT vault liquidity on NFTX V3. Browse vaults, simulate and execute mint/redeem/swap on-chain. Simulate to confirm to execute safety pattern.
+version: 1.0.0
+metadata:
+  openclaw:
+    emoji: "🏦"
+    homepage: https://github.com/Aleks-NFT/VaultAgent
+    requires:
+      env:
+        - ETH_RPC_URL
+    primaryEnv: ETH_RPC_URL
+---
+
+# VaultAgent — NFT Vault Liquidity on NFTX V3
+
+MCP server for NFT vault operations on NFTX V3 Ethereum Mainnet.
+All write ops enforce simulate → confirm → execute. No tx without user approval.
+
+## Use when
+
+- User asks about NFTX vault liquidity, TVL, floor prices
+- User wants to simulate or execute mint, redeem, or swap on NFTX
+- User says get my Milady back from NFTX or deposit Azuki into NFTX
+- User asks about Dutch auction premiums for targeted redeems
+- Any query about NFTX vaults: MILADY, PUNK, BAYC, AZUKI
+
+## Tools
+
+Read: list_vaults, get_vault_info, get_premium_window, simulate_mint
+Write: execute_mint, execute_redeem, execute_swap
+
+## Safety rule
+
+Always: 1) simulate 2) show cost to user 3) ask confirm 4) execute only after yes.
+
+## Install
+
+npx skillsadd Aleks-NFT/VaultAgent
+
+## Contract
+
+FeeWrapper: 0xd9f3eddf463a06b89f022e2596f66fc495119f58 (Mainnet, verified)
+GitHub: github.com/Aleks-NFT/VaultAgent


### PR DESCRIPTION
First Web3/NFT skill for NFTX V3 vault operations.

VaultAgent gives OpenClaw execution-grade access to NFTX V3 vaults on Ethereum Mainnet.

What it does:
- Browse active vaults (MILADY, PUNK, BAYC, AZUKI, etc.)
- Analyze Dutch auction premiums before targeted redeems
- Simulate mint/redeem/swap with full cost breakdown
- Execute on-chain via verified FeeWrapper contract

All write ops enforce simulate → confirm → execute. No tx without explicit user confirmation.

Tech:
- MCP server, TypeScript, 7 tools (4 read + 3 write)
- Contract: 0xd9f3eddf463a06b89f022e2596f66fc495119f58 — verified on Etherscan
- Fee: 0.25% on routed transactions
- Kill-switch: pause()/unpause()

GitHub: https://github.com/Aleks-NFT/VaultAgent
Etherscan: https://etherscan.io/address/0xd9f3eddf463a06b89f022e2596f66fc495119f58