### PR TITLE
Add Weave Cash skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Bankr Skills equip builders with plug-and-play tools to build more powerful agen
 | yoink | [yoink](yoink/) | Social on-chain game. "Yoink" a token from the current holder. Uses Bankr for transaction execution. |
 | [Neynar](https://neynar.com) | [neynar](neynar/) | Full Farcaster API integration. Post casts, like, recast, follow users, search content, and manage Farcaster identities. |
 | [Hydrex](https://hydrex.fi) | [hydrex](hydrex/) | Liquidity pools on Base. Lock HYDX for voting power, vote on pool strategies, deposit single-sided liquidity into auto-managed vaults, and claim oHYDX rewards. |
+| [Weave Cash](https://www.weavecash.com) | [weave](weave/) | Crypto-to-crypto invoicing and cross-chain payment workflows. Create invoices, generate payment instructions, inspect supported token and network pairs, and monitor settlement with the Weave CLI. |
 
 ## Adding a Skill
 

--- a/weave/SKILL.md
+++ b/weave/SKILL.md
@@ -1,0 +1,181 @@
+---
+name: weave
+description: Crypto-to-crypto invoicing and cross-chain payment workflows for Weave Cash. Use when the user wants to create an invoice, generate payment instructions, list supported token and network pairs, or monitor invoice settlement with the Weave CLI.
+metadata:
+  {
+    "clawdbot":
+      {
+        "emoji": "🧶",
+        "homepage": "https://www.weavecash.com",
+        "requires": { "bins": ["weave"] },
+      },
+  }
+---
+
+# Weave
+
+Use `weave` for Weave Cash invoice workflows:
+
+1. Create a crypto-to-crypto invoice
+2. Generate payment instructions for a buyer
+3. Track settlement until terminal status
+4. Discover currently supported token and network pairs
+
+Weave Cash is crypto-to-crypto only. The merchant chooses what crypto and network they want to receive, and the buyer can pay with another supported asset and network.
+
+## Guardrails
+
+- Do not introduce fiat pricing, fiat settlement, or fiat-denominated behavior unless the user explicitly asks for it.
+- Prefer machine-readable JSON output. Use `--human` only when the user asks for readable terminal output.
+- Never print or store secrets, private keys, JWTs, or credential-bearing URLs.
+- Always discover current support with `weave tokens` instead of hardcoding token and network lists.
+- Treat quote and status requests as network-dependent and failure-prone. Surface command errors clearly.
+
+## Install
+
+Preferred install:
+
+```bash
+go install github.com/AryanJ-NYC/weave-cash/apps/cli/cmd/weave@latest
+```
+
+Fallback install:
+
+```bash
+npm i -g weave-cash-cli
+```
+
+Verify:
+
+```bash
+weave --help
+```
+
+## Preflight
+
+Before choosing assets or networks:
+
+```bash
+weave tokens
+```
+
+This is the runtime source of truth for:
+
+- supported tokens
+- valid token/network pairings
+- accepted network aliases
+
+## Create An Invoice
+
+Use `weave create` to generate a new invoice.
+
+Required inputs:
+
+- `--receive-token`
+- `--amount`
+- `--wallet-address`
+
+Conditionally required:
+
+- `--receive-network` when the selected receive token supports more than one network
+
+Optional:
+
+- `--description`
+- `--buyer-name`
+- `--buyer-email`
+- `--buyer-address`
+
+Example:
+
+```bash
+weave create \
+  --receive-token USDC \
+  --receive-network Ethereum \
+  --amount 25 \
+  --wallet-address 0x1111111111111111111111111111111111111111
+```
+
+Typical JSON response:
+
+```json
+{
+  "id": "inv_123",
+  "invoiceUrl": "https://www.weavecash.com/invoice/inv_123"
+}
+```
+
+Save the invoice ID for quoting and status checks.
+
+## Generate Payment Instructions
+
+Use `weave quote` after the invoice exists and is still pending.
+
+Required inputs:
+
+- invoice ID
+- `--pay-token`
+- `--pay-network`
+- `--refund-address`
+
+Example:
+
+```bash
+weave quote inv_123 \
+  --pay-token USDT \
+  --pay-network Ethereum \
+  --refund-address 0x2222222222222222222222222222222222222222
+```
+
+Expected fields include:
+
+- `depositAddress`
+- `depositMemo` when applicable
+- `amountIn`
+- `amountOut`
+- `timeEstimate`
+- `expiresAt`
+
+## Check Status
+
+One-shot status:
+
+```bash
+weave status inv_123
+```
+
+Watch until terminal state:
+
+```bash
+weave status inv_123 --watch --interval-seconds 5 --timeout-seconds 900
+```
+
+Interpretation:
+
+- exit `0`: terminal success path from the CLI perspective
+- exit `1`: command, API, validation, or network failure
+- exit `2`: watch timed out before a terminal invoice status
+
+`weave get <invoice-id>` is an alias for `weave status <invoice-id>`.
+
+## Human Output
+
+When the user wants readable terminal output instead of JSON:
+
+```bash
+weave tokens --human
+weave status inv_123 --human
+```
+
+## Common Failure Cases
+
+- Invalid token/network pair: rerun `weave tokens` and choose a supported combination.
+- Missing `--receive-network` for a multi-network token: provide an explicit receive network.
+- Quote fails for a non-pending invoice: fetch current status first with `weave status <invoice-id>`.
+- Watch timeout: rerun `weave status <invoice-id>` or extend `--timeout-seconds`.
+
+## Operator Notes
+
+- The installed binary can drift from source docs, so trust `weave tokens` over static assumptions.
+- Keep examples path-safe and generic; do not reuse real wallet secrets or private operational data.
+- If the user asks to install the CLI, ask before running installation commands.


### PR DESCRIPTION
## Summary
- add a new Agent-first CLI for Weave Cash invoice flows

Usage:
  weave [command]

Available Commands:
  completion  Generate the autocompletion script for the specified shell
  create      Create a new invoice
  help        Help about any command
  quote       Generate a payment quote for an invoice
  status      Fetch invoice status (or watch for changes)
  tokens      List supported tokens and networks

Flags:
      --api-url string   Base URL for the Weave Cash API (default "https://www.weavecash.com")
  -h, --help             help for weave
      --human            Render human-readable output instead of JSON

Use "weave [command] --help" for more information about a command. skill for Weave Cash crypto-to-crypto invoice workflows
- document install, invoice creation, quoting, status checks, and runtime token discovery
- add the new skill to the README catalog

## Notes
- the skill emphasizes {"tokens":["BTC","ETH","PAXG","SOL","USDC","USDT","XAUT","ZEC"],"networks":["Bitcoin","Ethereum","Solana","Tron","Zcash"],"tokenNetworkMap":{"BTC":["Bitcoin"],"ETH":["Ethereum"],"PAXG":["Ethereum"],"SOL":["Solana"],"USDC":["Ethereum","Solana"],"USDT":["Ethereum","Solana","Tron"],"XAUT":["Ethereum"],"ZEC":["Zcash"]},"networkAliases":{"Bitcoin":["btc"],"Ethereum":["eth"],"Solana":["sol"],"Tron":["trx"],"Zcash":["zec"]}} as the runtime source of truth for supported token/network pairs
- examples use the current public CLI install paths ( and )
