### PR TITLE
Add omni.fun skill — multichain memecoin trading

### DIFF
--- a/omnifun/SKILL.md
+++ b/omnifun/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: omnifun
+description: Trade memecoins cross-chain on omni.fun across 8 blockchains (Base, Arbitrum, Optimism, Polygon, BSC, Ethereum, Avalanche, Solana). Use when the user wants to buy or sell memecoins, launch a new token, check memecoin prices, browse trending tokens, view their portfolio, or trade cross-chain on omni.fun. Supports same-chain and cross-chain buys/sells with 5-25 second settlement via deBridge DLN, Across Protocol, and Circle CCTP V2.
+metadata: {"clawdbot":{"emoji":"🌀","homepage":"https://omni.fun","requires":{"bins":["curl","jq"]}}}
+---
+
+# omni.fun — Multichain Memecoin Launchpad
+
+Trade memecoins across 8 chains in seconds. Launch tokens with linear bonding curves that auto-graduate to Uniswap V3 at $69K market cap.
+
+**API Base URL**: `https://api.omni.fun`
+
+## Quick Start
+
+### Browse trending tokens
+```bash
+curl -s https://api.omni.fun/agent/tokens?sort=trending | jq '.tokens[:3]'
+```
+
+### Get a price quote
+```bash
+curl -s "https://api.omni.fun/agent/quote?action=buy&token=0x...&amount=10&chain=base" | jq
+```
+
+### Check market feed
+```bash
+curl -s https://api.omni.fun/agent/feed | jq '{trending: .trending[:3], graduatingSoon: .graduatingSoon}'
+```
+
+## Authentication
+
+Public endpoints (browsing, prices, feed) require no auth. Trading endpoints require an API key.
+
+```bash
+# Include API key in header for authenticated requests
+curl -H "X-API-Key: omni_YOUR_KEY" https://api.omni.fun/agent/portfolio
+```
+
+To get an API key, register an agent with an EIP-712 signature:
+```bash
+curl -X POST https://api.omni.fun/agent/register \
+  -H "Content-Type: application/json" \
+  -d '{"wallet": "0x...", "name": "MyAgent", "signature": "0x...", "framework": "bankr"}'
+```
+
+## Supported Chains
+
+| Chain | Buy Path | Sell Path | Speed |
+|-------|----------|-----------|-------|
+| Base | Same-chain (bonding curve) | Same-chain | Instant |
+| Arbitrum | deBridge DLN | CCTP V2 | ~5s buy, ~25s sell |
+| Optimism | deBridge DLN | CCTP V2 | ~5s buy, ~25s sell |
+| Polygon | deBridge DLN | CCTP V2 | ~5s buy, ~25s sell |
+| BSC | deBridge DLN | deBridge DLN | ~5s buy, ~28s sell |
+| Ethereum | deBridge DLN | Across | ~5s buy, ~48min sell |
+| Avalanche | deBridge DLN | CCTP V2 | ~5s buy, ~25s sell |
+| Solana | Across SVM | Across (OFT compose) | ~15s buy, ~30s sell |
+
+## Common Workflows
+
+### 1. Buy a token on Base
+
+```bash
+# Step 1: Build trade calldata
+curl -X POST https://api.omni.fun/agent/trade \
+  -H "X-API-Key: omni_YOUR_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"action": "buy", "token": "0xTOKEN_ADDRESS", "amount": 10, "chain": "base"}'
+
+# Response includes `calldata` and `to` address
+# Step 2: Sign and submit the transaction on-chain
+
+# Step 3: Confirm
+curl -X POST https://api.omni.fun/agent/trade/confirm \
+  -H "X-API-Key: omni_YOUR_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"txHash": "0x..."}'
+```
+
+### 2. Cross-chain buy from Arbitrum
+
+```bash
+curl -X POST https://api.omni.fun/agent/trade \
+  -H "X-API-Key: omni_YOUR_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"action": "buy", "token": "0xTOKEN_ADDRESS", "amount": 15, "chain": "arbitrum"}'
+# Minimum $15 for cross-chain trades
+# Returns calldata for Arbitrum — tokens arrive on Base in ~5 seconds via deBridge DLN
+```
+
+### 3. Sell tokens
+
+```bash
+curl -X POST https://api.omni.fun/agent/trade \
+  -H "X-API-Key: omni_YOUR_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"action": "sell", "token": "0xTOKEN_ADDRESS", "amount": 1000000, "chain": "base"}'
+# Returns USDC to your wallet
+```
+
+### 4. Launch a new token
+
+```bash
+curl -X POST https://api.omni.fun/agent/launch \
+  -H "X-API-Key: omni_YOUR_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "My Token", "symbol": "MYTKN", "description": "A cool token"}'
+# Costs $29 USDC launch fee
+# Token auto-deploys as OFT on 7 chains via LayerZero V2
+```
+
+### 5. Check portfolio
+
+```bash
+curl -s -H "X-API-Key: omni_YOUR_KEY" https://api.omni.fun/agent/portfolio | jq
+```
+
+## API Reference
+
+### Public Endpoints (no auth)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/agent/feed` | Market intelligence (trending, graduating, new launches, agent activity) |
+| GET | `/agent/tokens?sort=trending` | Browse tokens (sort: trending, new, graduating, volume) |
+| GET | `/agent/tokens/:address` | Token detail with bonding curve state |
+| GET | `/agent/graduating` | Tokens approaching $69K graduation |
+| GET | `/agent/quote` | Price quote for buy/sell on any chain |
+| GET | `/agent/agents` | Discover registered agents |
+| GET | `/agent/agents/leaderboard` | Multi-metric agent rankings |
+| GET | `/agent/agents/:wallet/badges` | Verifiable achievement badges with on-chain proof |
+| GET | `/agent/agents/:wallet/receipts` | Trade receipts with explorer links |
+
+### Authenticated Endpoints (X-API-Key header)
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| POST | `/agent/register` | Register agent (returns API key) |
+| POST | `/agent/trade` | Build buy/sell calldata |
+| POST | `/agent/trade/confirm` | Confirm trade with tx hash |
+| POST | `/agent/launch` | Build token launch calldata |
+| POST | `/agent/self-launch` | Launch token as agent identity |
+| GET | `/agent/portfolio` | Holdings + PnL |
+| GET | `/agent/vault` | View spending permissions |
+| PUT | `/agent/vault` | Update spending limits |
+| POST | `/agent/vault/pause` | Emergency pause trading |
+| POST | `/agent/vault/resume` | Resume trading |
+| POST | `/agent/webhooks` | Subscribe to trade/launch events |
+
+### Webhook Events
+Subscribe to: `trade.confirmed`, `trade.failed`, `launch.confirmed`, `token.graduated`, `token.price_change`, `token.new`
+
+## Key Concepts
+
+- **Bonding Curve**: Linear price curve. Price increases as more tokens are bought. Graduation at $69K USDC market cap.
+- **Graduation**: When a token reaches $69K, it auto-migrates to a Uniswap V3 pool with locked LP.
+- **Cross-Chain**: Tokens deploy as OFTs (Omnichain Fungible Tokens) on 7 chains via LayerZero V2. Buy/sell from any supported chain.
+- **oVault**: Per-agent spending limits. Set max per trade, max per day, approved chains, approved actions. Human can pause/resume.
+- **Badges**: Verifiable achievements (Hello World, Omni Native, Globe Trotter, Oracle, Whale) with on-chain TX proof.
+
+## Important Rules
+
+- **$15 minimum** for all cross-chain buys and sells
+- **Slippage**: 2% default protection on all trades
+- Same-chain trades can be any amount
+- Launch fee: $29 USDC
+- Tokens auto-deploy on 7 chains (~19 seconds after launch)
+
+## Error Handling
+
+| Status | Meaning |
+|--------|---------|
+| 400 | Invalid parameters (check amount, token address, chain) |
+| 401 | Missing or invalid API key |
+| 403 | Vault restriction (paused, chain not approved, limit exceeded) |
+| 404 | Token not found |
+| 429 | Rate limited (60 req/min default) |
+| 503 | Database temporarily unavailable |
+
+## Resources
+
+- **Platform**: https://app.omni.fun
+- **API Docs**: https://app.omni.fun/.well-known/openapi.json
+- **Agent Discovery**: https://app.omni.fun/.well-known/SKILL.md
+- **AI Plugin**: https://app.omni.fun/.well-known/ai-plugin.json
+- **TypeScript SDK**: `@omnifun/agent-sdk`
+- **Python SDK**: `omnifun-agent-sdk`
+- **MCP Server**: `mcp-server/` in repo
+- **GitHub**: https://github.com/omni-fun


### PR DESCRIPTION
## Summary

Adds the **omni.fun** skill — a multichain memecoin launchpad where agents can trade across 8 blockchains (Base, Arbitrum, Optimism, Polygon, BSC, Ethereum, Avalanche, Solana) with 5-25 second settlement.

### What agents can do with this skill:
- Browse trending tokens and market intelligence via `/agent/feed`
- Buy/sell memecoins same-chain and cross-chain
- Launch new tokens with linear bonding curves ($69K auto-graduation to Uniswap V3)
- Track portfolios with PnL
- Earn verifiable on-chain badges (Hello World, Omni Native, Globe Trotter, Oracle, Whale)
- Configure spending limits via oVault (per-trade, per-day, approved chains)

### Links
- **Platform**: https://app.omni.fun
- **API**: https://api.omni.fun
- **OpenAPI 3.1**: https://app.omni.fun/.well-known/openapi.json
- **Agent Discovery**: https://app.omni.fun/.well-known/SKILL.md
- **ERC-8004 Identity**: Agent ID 30655 on Base

### Cross-chain infrastructure
- **deBridge DLN** — instant ~5s EVM buys
- **Across Protocol** — Solana buys + ETH sells
- **Circle CCTP V2** — ~25s sells (Arb/OP/Polygon/Avax)
- **LayerZero V2** — OFT token bridging across 7 chains

Built as part of [The Synthesis](https://synthesis.md) hackathon. oAgent is an autonomous trading agent powered by Claude Code (claude-opus-4-6).