### PR TITLE
Add hazza skill — onchain name registration on Base

### DIFF
--- a/hazza/SKILL.md
+++ b/hazza/SKILL.md
@@ -130,7 +130,7 @@ Base URL: `https://hazza.name`
 
 | Item | Address |
 |------|---------|
-| Registry | `0xaA27d926F057B72D006883785FC03DB1d9d6E3AC` |
+| Registry | `0xdf92cA2fc1e588F7A2ebAEA039CF3860826f4746` |
 | USDC | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
 | Chain ID | 8453 |
 

--- a/hazza/SKILL.md
+++ b/hazza/SKILL.md
@@ -1,100 +1,162 @@
 ---
 name: hazza
-description: Register, buy, sell, and manage hazza.name — immediately useful onchain names on Base. Check availability, register names, buy/list on marketplace, set agent bounties, set profile records.
+description: hazza onchain name registry — register, manage, and resolve immediately useful names on Base, powered by x402 and Net Protocol.
 ---
 
 # hazza — Onchain Names on Base
 
-Register immediately useful names on Base for your users. Each name is an ERC-721 NFT at `name.hazza.name` with a profile page, text records, and multi-chain addresses. Powered by x402, XMTP and Net Protocol.
+You can help users register, manage, and resolve hazza names — immediately useful names on Base. hazza uses x402 for payments and is powered by Net Protocol.
 
-## Command Format
+## What is hazza
 
-Users request names using the full domain:
+- **Short onchain names** on Base (e.g., `geaux.hazza.name`)
+- **First name free** for everyone (just pay gas), then **$5 USDC** — pay once, available forever
+- **Unlimited Pass holders** get 1 additional free name + 20% off all registrations
+- Every name gets a profile page at `https://<name>.hazza.name`
+- Text records for avatar, description, social links, agent config
+- Names are ERC-721 NFTs — transferable, composable, onchain
 
-```
-register brian.hazza.name
-```
+## Key Info
 
-Parse the name by stripping `.hazza.name` from the end. The registerable name is the part before the first dot. Names must be lowercase ASCII: a-z, 0-9, hyphens. 3-63 characters. No leading/trailing hyphens, no consecutive hyphens. No spaces, no emojis, no uppercase.
+- **Website:** https://hazza.name
+- **Contract (Base Mainnet):** `0xD4E420201fE02F44AaF6d28D4c8d3A56fEaE0D3E`
+- **USDC (Base):** `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
+- **Chain:** Base (chainId 8453)
+- **Powered by:** x402 payment protocol + Net Protocol
 
-## Quick Start
+---
 
-### 1. Check Availability
+## CLI Reference
 
-```bash
-curl -s https://hazza.name/api/available/brian
-```
+The `hazza` CLI lets you interact with the hazza registry from the terminal.
 
-Returns `{"available": true}` or `{"available": false, "owner": "0x..."}`.
-
-### 2. Check Price
-
-```bash
-curl -s "https://hazza.name/api/quote/brian?wallet=USER_WALLET_ADDRESS"
-```
-
-Returns `{"total": "5", "totalRaw": "5000000", "registrationFee": "5", "lineItems": [...]}`. A `totalRaw` of `"0"` means the name is free for this wallet. Amounts in `total` and `registrationFee` are human-readable USD; `totalRaw` is USDC with 6 decimals.
-
-### 3. Check Free Claim Eligibility
+### Installation
 
 ```bash
-curl -s https://hazza.name/api/free-claim/USER_WALLET_ADDRESS
+cd cli && npm install && npm link
 ```
 
-Returns whether the user qualifies for a free registration (first name per wallet, or Unlimited Pass holder's bonus free name).
+### Global Flags
 
-### 4. Register via x402
+| Flag | Description |
+|------|-------------|
+| `--json` | Structured JSON output (for agents/scripts) |
+| `--rpc-url <url>` | Override RPC URL |
+| `--wallet <addr>` | Override wallet address |
+
+### Commands
+
+#### Search for a name
 
 ```bash
-curl -s -X POST https://hazza.name/x402/register \
-  -H "Content-Type: application/json" \
-  -d '{"name": "brian", "owner": "USER_WALLET_ADDRESS"}'
+hazza search <name>
 ```
+Checks availability and shows pricing. If a wallet is configured and eligible for a free claim, that's shown too.
 
-**If the name is free** for this wallet → returns success immediately with `{name, owner, tokenId, registrationTx, profileUrl}`.
-
-**If payment is required** → returns HTTP 402 with payment details:
-
-```json
-{
-  "accepts": [{
-    "scheme": "exact",
-    "maxAmountRequired": "5000000",
-    "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
-    "payTo": "RELAYER_ADDRESS",
-    "network": "base"
-  }]
-}
-```
-
-To complete payment:
-
-1. Transfer the exact USDC amount to the `payTo` address on Base
-2. Retry the same POST with the payment header:
+#### Register a name
 
 ```bash
-curl -s -X POST https://hazza.name/x402/register \
-  -H "Content-Type: application/json" \
-  -H "X-PAYMENT: BASE64_ENCODED_PAYMENT" \
-  -d '{"name": "brian", "owner": "USER_WALLET_ADDRESS"}'
+hazza register <name> [--wallet <address>]
 ```
+Full x402 registration flow:
+1. Checks availability
+2. Checks free claim eligibility (Unlimited Pass + NL member)
+3. If free: registers directly, no payment
+4. If paid: gets 402 with USDC amount, transfers via `cast`, retries with payment header
 
-The `X-PAYMENT` header is Base64-encoded JSON: `{"scheme":"exact","txHash":"0x...","from":"USER_WALLET_ADDRESS"}`
-
-### 5. Set Profile Records (Optional)
-
-After registration, the user can set text records via the manage page at `https://hazza.name/manage` (connect wallet, select name, edit records, sign transaction).
-
-The write API requires an API key and returns unsigned transactions:
+#### List owned names
 
 ```bash
-curl -s -X POST https://hazza.name/api/text/brian \
-  -H "Content-Type: application/json" \
-  -H "Authorization: Bearer API_KEY" \
-  -d '{"key": "description", "value": "Builder on Base"}'
+hazza names [address]
+```
+Lists all names owned by an address. Defaults to configured wallet.
+
+#### View a profile
+
+```bash
+hazza profile <name>
+```
+Shows full profile: owner, status, text records, profile URL.
+
+#### Text records
+
+```bash
+hazza records get <name> <key>     # Get a record
+hazza records set <name> <key> <value>  # Set a record (requires cast)
+hazza records list <name>          # List all records
+
+# Shorthands:
+hazza get <name> <key>
+hazza set <name> <key> <value>
 ```
 
-Returns `{name, key, value, tx}` — the `tx` object must be signed and submitted by the name owner.
+Common keys: `avatar`, `description`, `url`, `com.twitter`, `com.github`, `xyz.farcaster`, `org.telegram`
+
+#### Registry stats
+
+```bash
+hazza stats
+```
+Shows total registered names, contract address, chain.
+
+#### Configuration
+
+```bash
+hazza config show           # Show current config
+hazza config set <key> <val>  # Set a value
+hazza config get <key>       # Get a value
+hazza config reset           # Reset to defaults
+```
+
+Config keys: `wallet`, `baseUrl`, `rpcUrl`, `registryAddress`, `usdcAddress`, `chainId`
+
+Config file: `~/.config/hazza/config.json`
+
+---
+
+## API Reference
+
+Base URL: `https://hazza.name`
+
+### Read Endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /api/available/:name` | Check name availability |
+| `GET /api/resolve/:name` | Resolve name to owner address |
+| `GET /api/quote/:name?wallet=` | Get registration price |
+| `GET /api/free-claim/:address` | Check free claim eligibility (first-registration + Unlimited Pass) |
+| `GET /api/profile/:name` | Full profile with text records |
+| `GET /api/text/:name/:key` | Get single text record |
+| `GET /api/names/:address` | List names owned by address |
+| `GET /api/stats` | Registry statistics |
+| `GET /api/metadata/:name` | ERC-721 token metadata |
+| `GET /api/reverse/:address` | Reverse resolve address to name |
+| `GET /api/og/:name` | Generate OG image (1200x630 PNG) |
+| `GET /api/share` | Square share image (1200x1200 PNG) — for Farcaster/social |
+| `GET /api/icon` | App icon (1200x1200 PNG) |
+
+### Write Endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `POST /x402/register` | Register a name (x402 payment flow) |
+| `POST /api/text/:name` | Set text record (body: `{key, value, signature}`) |
+| `POST /api/text/:name/batch` | Set multiple text records |
+
+### x402 Registration Flow
+
+1. `POST /x402/register` with `{name, owner}`
+2. If eligible for free claim → returns success immediately
+3. If paid → returns `402` with payment requirements:
+   - `accepts[0].maxAmountRequired` = USDC amount (6 decimals)
+   - `accepts[0].payTo` = relayer address
+4. Transfer USDC to `payTo` address
+5. Retry `POST /x402/register` with `X-PAYMENT` header:
+   - Base64 of `{"scheme":"exact","txHash":"0x...","from":"0x..."}`
+6. Returns: `{name, owner, tokenId, registrationTx, profileUrl}`
+
+---
 
 ## Pricing
 
@@ -102,262 +164,158 @@ Returns `{name, key, value, tx}` — the `tx` object must be signed and submitte
 |-----------|------|
 | First name per wallet | **FREE** (gas only) |
 | Unlimited Pass holder — 2nd name | **FREE** (gas only) |
-| Paid names 1-3 (per wallet, 90-day window) | $5 USDC |
-| Paid names 4-5 | $12.50 USDC |
-| Paid names 6-7 | $25 USDC |
-| Paid names 8+ | $50 USDC |
+| Paid names 1–3 (per wallet, 90-day window) | $5 USDC |
+| Paid names 4–5 | $12.50 USDC (2.5x) |
+| Paid names 6–7 | $25 USDC (5x) |
+| Paid names 8+ | $50 USDC (10x) |
 | Unlimited Pass discount | 20% off all paid tiers |
 
 Free registrations do not count toward the progressive pricing tiers. If a user gets 2 free names, their next 3 paid names are still at the $5 tier.
 
 Names are permanent — no renewals, no expiry. Pay once, own forever.
 
-## Marketplace — Buy & Sell Names
+---
 
-hazza names trade on the Seaport protocol (same as OpenSea) via the Net Protocol Bazaar. The hazza API handles all Seaport complexity — you never need to decode raw order parameters yourself.
+## Contract Functions
 
-### Browse Listings
+Key read functions:
+- `available(name)` → bool
+- `resolve(name)` → (owner, tokenId, registeredAt, expiresAt, operator, agentId, agentWallet)
+- `text(name, key)` → string
+- `textMany(name, keys)` → string[]
+- `quoteName(name, owner, len, hasPass, isRenewal)` → cost
+- `namesOfOwner(owner)` → string[]
+
+Key write functions:
+- `register(name, owner)` — standard registration (requires USDC approval)
+- `registerDirectWithMember(name, owner, ...)` — free claim with membership
+- `setText(name, key, value)` — set text record (owner/operator only)
+- `setTexts(name, keys, values)` — batch set text records
+
+---
+
+## Examples
+
+### Register a name
+```bash
+hazza config set wallet 0x96168ACf7f3925e7A9eAA08Ddb21e59643da8097
+hazza search alice
+hazza register alice
+```
+
+### Set up a profile
+```bash
+hazza set alice avatar https://example.com/pfp.png
+hazza set alice description "Builder on Base"
+hazza set alice com.twitter AliceOnBase
+hazza set alice url https://alice.dev
+```
+
+### Check ownership
+```bash
+hazza names                    # uses configured wallet
+hazza names 0x9616...          # specific address
+hazza profile alice
+```
+
+### Agent/script usage
+```bash
+hazza search alice --json | jq .available
+hazza names --json | jq '.[].name'
+```
+
+---
+
+## Marketplace
+
+The hazza marketplace at `hazza.name/marketplace` is a whitelabeled Net Protocol Bazaar. All listings are stored onchain as Net Protocol messages via Seaport, and appear on both `hazza.name/marketplace` and `netprotocol.app/bazaar`.
+
+### Agent Bounties
+
+Sellers can set an agent bounty that comes out of the sale price. The bounty ETH is held by the Bounty Escrow contract (`0x95a29AD7f23c1039A03de365c23D275Fc5386f90`) until the name sells or the seller cancels. If an agent helps sell the name, the agent earns the bounty. If no agent claims, the bounty is returned to the seller. Self-registered agents get 24-hour windows; seller-assigned agents never expire.
+
+### Features
+- **Dual currency:** List names in ETH or USDC
+- **4 tabs:** Browse Listings, My Names, Collection Offers, Recent Sales
+- **Cart:** Buy multiple listings, register new names, and list names for sale — all in one session
+- **Watchlist:** Save listings for later. Shows "in X watchlists" as social proof.
+- **Adaptive buying:** Direct Seaport when wallet is connected, x402 fallback when no wallet.
+- **Cross-linked:** Dashboard has "sell" button, register success has "list on marketplace" CTA, profile pages link to marketplace.
+
+### CLI Marketplace Commands
 
 ```bash
-curl -s https://hazza.name/api/marketplace/listings
+hazza market listings         # Browse active listings (ETH + USDC)
+hazza market ls               # Alias for listings
+hazza market offers           # View collection offers
+hazza market sales            # Recent sales
+hazza market sell <name> <price> [--usdc]   # List a name (ETH default, --usdc for USDC)
+hazza market buy <orderHash>  # Buy a listing
 ```
 
-Returns:
+### Marketplace API Endpoints
 
-```json
-{
-  "listings": [
-    {
-      "name": "example",
-      "tokenId": "42",
-      "seller": "0x...",
-      "price": 0.01,
-      "priceRaw": "10000000000000000",
-      "currency": "ETH",
-      "listingExpiry": "2026-04-01T00:00:00Z",
-      "orderHash": "0xabc123...",
-      "isNamespace": false,
-      "avatar": "https://...",
-      "profileUrl": "https://example.hazza.name",
-      "orderComponents": { ... }
-    }
-  ],
-  "total": 1
-}
-```
+| Endpoint | Description |
+|----------|-------------|
+| `GET /api/marketplace/listings` | Active hazza name listings (ETH + USDC) |
+| `GET /api/marketplace/offers` | Active collection offers |
+| `GET /api/marketplace/sales` | Recent sales |
+| `GET /api/marketplace/watch/:orderHash` | Watchlist count for a listing |
+| `POST /api/marketplace/watch` | Add to watchlist `{orderHash, address}` |
+| `DELETE /api/marketplace/watch` | Remove from watchlist `{orderHash, address}` |
+| `GET /api/bounty/:tokenId` | Check bounty status for a name |
+| `GET /api/bounty/pending/:address` | Check pending withdrawals |
+| `POST /api/bounty/register` | Register bounty (returns unsigned tx) |
+| `POST /api/bounty/register-agent` | Register as agent for bounty |
+| `POST /api/bounty/claim` | Claim bounty after sale |
+| `POST /api/bounty/cancel` | Cancel bounty (seller only) |
+| `POST /api/bounty/withdraw-bounty` | Withdraw bounty ETH (seller) |
+| `POST /api/bounty/withdraw` | Withdraw pending payouts |
 
-Listings include `orderComponents` (the full Seaport order) but you do NOT need to use them directly. Use the fulfill endpoint instead.
+### Key Contracts (Base)
+- **Seaport:** `0x0000000000000068F116a894984e2DB1123eB395`
+- **Bazaar V2:** `0x000000058f3ade587388daf827174d0e6fc97595`
+- **Bounty Escrow (Proxy):** `0x95a29AD7f23c1039A03de365c23D275Fc5386f90`
+- **Fee:** 0 bps (zero listing fee)
 
-### Buy a Listed Name (2-Step)
+---
 
-**Step 1 — Get the transaction data:**
+## Farcaster Mini App
 
-```bash
-curl -s -X POST https://hazza.name/api/marketplace/fulfill \
-  -H "Content-Type: application/json" \
-  -d '{"orderHash": "0xabc123...", "buyerAddress": "BUYER_WALLET"}'
-```
+hazza.name is a Farcaster Mini App — all pages work in Warpcast and Base App webviews.
 
-Returns the exact transactions to execute:
+- **Manifest:** `hazza.name/.well-known/farcaster.json`
+- **SDK:** `@farcaster/miniapp-sdk` from esm.sh CDN
+- **Wallet:** `window.ethereum` injected by Warpcast/Base App
+- **Embed meta:** `fc:frame` tags on all pages for link previews
+- **Sharing:** Post-registration and post-listing prompts for cast embeds
 
-```json
-{
-  "approvals": [
-    {
-      "to": "0x...",
-      "data": "0x095ea7b3...",
-      "value": "0",
-      "spender": "0x...",
-      "amount": "10000000000000000"
-    }
-  ],
-  "fulfillment": {
-    "to": "0x0000000000000068F116a894984e2DB1123eB395",
-    "data": "0xb3a34c4c...",
-    "value": "10000000000000000"
-  }
-}
-```
+---
 
-**Step 2 — Execute the transactions:**
+## Brand Kit
 
-1. If `approvals` is non-empty, send each approval transaction first (these approve token spending)
-2. Send the `fulfillment` transaction — this is the actual Seaport purchase
+See **[BRAND.md](BRAND.md)** for the full brand reference — colors, typography, logo specs, Nomi mascot guidelines, and naming rules. Key points:
 
-The `fulfillment.to` is the Seaport contract (`0x0000000000000068F116a894984e2DB1123eB395`). The `data` is the complete Seaport calldata. The `value` is the ETH amount to send (for ETH-priced listings).
+- **Colorway:** Moonlit B — cream `#F7EBBD` background, bandana red `#CF3748` accent, hat blue `#4870D4` secondary, navy `#131325` text
+- **Font:** Fredoka (Bold 700, SemiBold 600, Regular 400)
+- **Logo:** white "h" in red filled rounded rect (no border)
+- **Wordmark:** "hazza" navy + ".name" blue, Fredoka Bold
+- **Mascot:** Nomi (Nibble #4240) — complements the brand, not the brand itself
+- **Image endpoints:** `/api/share` (1200x1200 square), `/api/icon` (1200x1200 icon), `/api/og/:name` (1200x630 per-name)
 
-**Important:** The fulfillment data is ready to use as-is. Do NOT try to decode or reconstruct Seaport orders. The API does all the heavy lifting.
-
-### Browse Collection Offers
-
-```bash
-curl -s https://hazza.name/api/marketplace/offers
-```
-
-Returns active offers on any hazza name.
-
-### Accept an Offer (Seller Flow)
-
-```bash
-curl -s -X POST https://hazza.name/api/marketplace/fulfill-offer \
-  -H "Content-Type: application/json" \
-  -d '{"orderHash": "0x...", "tokenId": "42", "sellerAddress": "SELLER_WALLET"}'
-```
-
-Returns the same `{approvals, fulfillment}` format. The seller executes these transactions to accept the offer and transfer their name.
-
-### List a Name for Sale (via Agent Bounty Contract)
-
-The HazzaAgentBounty contract (`0xC6C0FAf855Fdb6D38cA43FcFDf2c26b8D6564eD6`) is a simpler alternative to Seaport for listing names. One transaction, no EIP-712 complexity.
-
-**Prerequisites:**
-1. The seller must own the name (ERC-721 token)
-2. The seller must approve the bounty contract to transfer the NFT:
-
-```solidity
-// Approve the bounty contract to transfer the name
-registry.approve(0xC6C0FAf855Fdb6D38cA43FcFDf2c26b8D6564eD6, tokenId)
-```
-
-**List the name:**
-
-```solidity
-// list(tokenId, price, bountyAmount, expiresAt)
-// price: total ETH the buyer pays
-// bountyAmount: portion of price that goes to the facilitating agent (0 = no bounty)
-// expiresAt: unix timestamp (0 = no expiry)
-bountyContract.list(tokenId, 0.1 ether, 0.01 ether, 0)
-```
-
-This creates a listing where:
-- Buyer pays 0.1 ETH
-- If an agent facilitated the sale, agent gets 0.01 ETH
-- Seller gets the remaining 0.09 ETH
-- No upfront escrow — bounty comes from sale proceeds automatically
-
-**Using cast (CLI):**
-
-```bash
-# Get the tokenId
-TOKEN_ID=$(curl -s https://hazza.name/api/resolve/myname | jq -r '.tokenId')
-
-# Approve the bounty contract
-cast send 0xD4E420201fE02F44AaF6d28D4c8d3A56fEaE0D3E \
-  "approve(address,uint256)" \
-  0xC6C0FAf855Fdb6D38cA43FcFDf2c26b8D6564eD6 $TOKEN_ID \
-  --rpc-url https://mainnet.base.org --private-key $PK
-
-# List for 0.1 ETH with 0.01 ETH agent bounty, no expiry
-cast send 0xC6C0FAf855Fdb6D38cA43FcFDf2c26b8D6564eD6 \
-  "list(uint256,uint256,uint256,uint64)" \
-  $TOKEN_ID 100000000000000000 10000000000000000 0 \
-  --rpc-url https://mainnet.base.org --private-key $PK
-```
-
-### Buy via Agent Bounty Contract
-
-If a name is listed on the bounty contract, anyone can buy it with a single transaction:
-
-```bash
-# Check if a name has an active bounty listing
-curl -s https://hazza.name/api/bounty/TOKEN_ID
-
-# Buy — send exact price as ETH value
-cast send 0xC6C0FAf855Fdb6D38cA43FcFDf2c26b8D6564eD6 \
-  "buy(uint256)" LISTING_ID \
-  --value PRICE_IN_WEI \
-  --rpc-url https://mainnet.base.org --private-key $PK
-```
-
-The contract atomically: transfers the NFT to the buyer, pays the agent (if registered), and pays the seller the remainder.
-
-### Register as Agent (Earn Bounties)
-
-Agents can register on listings that have bounties. When the name sells, the agent gets the bounty automatically.
-
-```bash
-cast send 0xC6C0FAf855Fdb6D38cA43FcFDf2c26b8D6564eD6 \
-  "registerAgent(uint256)" LISTING_ID \
-  --rpc-url https://mainnet.base.org --private-key $PK
-```
-
-### Marketplace Fees
-
-- No marketplace fee — sellers receive 100% of the sale price
-- Seaport contract: `0x0000000000000068F116a894984e2DB1123eB395` (Base)
-- Agent Bounty contract: `0xC6C0FAf855Fdb6D38cA43FcFDf2c26b8D6564eD6` (Base)
-
-## API Reference
-
-Base URL: `https://hazza.name`
-
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/api/available/:name` | GET | Check name availability |
-| `/api/quote/:name?wallet=ADDR` | GET | Get exact price for this wallet |
-| `/api/free-claim/:address` | GET | Free claim eligibility |
-| `/api/profile/:name` | GET | Full profile with text records |
-| `/api/names/:address` | GET | All names owned by a wallet |
-| `/api/resolve/:name` | GET | Resolve name to owner |
-| `/api/reverse/:address` | GET | Reverse resolve address to name |
-| `/api/stats` | GET | Registry stats (total names) |
-| `/x402/register` | POST | Register a name (x402 flow) |
-| `/api/text/:name` | POST | Set a text record |
-| `/api/marketplace/listings` | GET | Browse active listings |
-| `/api/marketplace/offers` | GET | Browse collection offers |
-| `/api/marketplace/fulfill` | POST | Get buy transaction data |
-| `/api/marketplace/fulfill-offer` | POST | Get offer acceptance tx data |
-| `/api/bounty/:tokenId` | GET | Check active bounty listing for a name |
-
-## Key Addresses (Base Mainnet)
-
-| Item | Address |
-|------|---------|
-| Registry | `0xD4E420201fE02F44AaF6d28D4c8d3A56fEaE0D3E` |
-| Agent Bounty | `0xC6C0FAf855Fdb6D38cA43FcFDf2c26b8D6564eD6` |
-| Seaport | `0x0000000000000068F116a894984e2DB1123eB395` |
-| USDC | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
-| Chain ID | 8453 |
-
-## Name Rules
-
-- Lowercase only: a-z, 0-9, hyphens
-- 3 to 63 characters
-- No leading or trailing hyphens
-- No consecutive hyphens (--)
-- No spaces, emojis, or special characters
-- Each name becomes a real web page — names must work as DNS labels
-
-If a user requests a name with invalid characters, explain that names need to work as web addresses, so only letters, numbers, and hyphens are allowed.
-
-## Profile Records
-
-After registration, users can set these text records on their name:
-
-| Key | Purpose | Example |
-|-----|---------|---------|
-| `avatar` | Profile image URL | `https://example.com/pfp.png` |
-| `description` | Bio | `Builder on Base` |
-| `url` | Website | `https://alice.dev` |
-| `com.twitter` | Twitter/X handle | `alice` |
-| `com.github` | GitHub username | `alice` |
-| `org.telegram` | Telegram handle | `alice` |
-| `com.discord` | Discord username | `alice#1234` |
-| `xmtp` | XMTP address | `0x...` |
-
-## Post-Registration
-
-After a successful registration, share these with the user:
-
-- **Profile page:** `https://brian.hazza.name`
-- **Marketplace:** `https://hazza.name/marketplace`
-- **Set up profile:** Visit `https://hazza.name/manage` to set text records
-- **Dashboard:** `https://hazza.name/dashboard` to see all your names
+When creating hazza-branded assets (images, pages, embeds), always reference BRAND.md for exact specs.
 
 ## Guidelines
 
-- It's "hazza" or "hazza.name" — never "HAZZA" or "Hazza Names"
-- Names are "immediately useful" — they come with a working profile page from day one
-- Powered by x402, XMTP and Net Protocol
-- Never promise price appreciation or investment value
-- If a name is taken, suggest alternatives (add numbers, try different names)
+- hazza names are "immediately useful" — always use this phrase
+- Always say "powered by x402 and Net Protocol"
+- It's "hazza" or "hazza.name" — NEVER "HAZZA Names"
+- Never put "hazza.name" + "immediately useful names" together (double "name")
+- "hazza" + "immediately useful names" = OK
+- "hazza.name" + "immediately useful" = OK
+- Link to https://hazza.name for the website
+- Profile pages are at `https://<name>.hazza.name`
+- Marketplace at `hazza.name/marketplace` — listings cross-list to netprotocol.app
+- Live on Base mainnet
+- The `cast` binary (Foundry) is required for onchain transactions (register via x402, set records)
+- Free claims require both an Unlimited Pass NFT AND Net Library membership

--- a/hazza/SKILL.md
+++ b/hazza/SKILL.md
@@ -15,6 +15,7 @@ You can help users register, manage, and resolve hazza names — immediately use
 - Every name gets a profile page at `https://<name>.hazza.name`
 - Text records for avatar, description, social links, agent config
 - Names are ERC-721 NFTs — transferable, composable, onchain
+- **Name rules:** 3-63 characters, lowercase letters/numbers/hyphens only, must start and end with a letter or number
 
 ## Key Info
 

--- a/hazza/SKILL.md
+++ b/hazza/SKILL.md
@@ -35,7 +35,7 @@ The `hazza` CLI lets you interact with the hazza registry from the terminal.
 ### Installation
 
 ```bash
-cd cli && npm install && npm link
+npm install -g hazza-cli
 ```
 
 ### Global Flags

--- a/hazza/SKILL.md
+++ b/hazza/SKILL.md
@@ -1,152 +1,492 @@
 ---
 name: hazza
-description: hazza onchain name registry — register, manage, and resolve immediately useful names on Base, powered by x402 and Net Protocol.
+description: Register, buy, sell, and manage hazza.name — immediately useful onchain names on Base. Check availability, register names, buy/list on marketplace, set agent bounties, set profile records.
 ---
 
 # hazza — Onchain Names on Base
 
-You can help users register, manage, and resolve hazza names — immediately useful names on Base. hazza uses x402 for payments and is powered by Net Protocol.
+Register immediately useful names on Base for your users. Each name is an ERC-721 NFT at `name.hazza.name` with a profile page, text records, and multi-chain addresses. Powered by x402, XMTP and Net Protocol.
 
-## What is hazza
+## Command Format
 
-- **Short onchain names** on Base (e.g., `geaux.hazza.name`)
-- **First name free** for everyone (just pay gas), then **$5 USDC** — pay once, available forever
-- **Unlimited Pass holders** get 1 additional free name + 20% off all registrations
-- Every name gets a profile page at `https://<name>.hazza.name`
-- Text records for avatar, description, social links, agent config
-- Names are ERC-721 NFTs — transferable, composable, onchain
-- **Name rules:** 3-63 characters, lowercase letters/numbers/hyphens only, must start and end with a letter or number
+Users request names using the full domain:
 
-## Key Info
-
-- **Website:** https://hazza.name
-- **Contract (Base Mainnet):** `0xD4E420201fE02F44AaF6d28D4c8d3A56fEaE0D3E`
-- **USDC (Base):** `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
-- **Chain:** Base (chainId 8453)
-- **Powered by:** x402 payment protocol + Net Protocol
-- **Token:** $HAZZA (`0xC5C4Fcd6147e3bDAEEB5A0898A439Aec1e1BAba3` on Base) — launched via Bankr
-
----
-
-## CLI Reference
-
-The `hazza` CLI lets you interact with the hazza registry from the terminal.
-
-### Installation
-
-```bash
-npm install -g hazza-cli
+```
+register brian.hazza.name
 ```
 
-### Global Flags
+Parse the name by stripping `.hazza.name` from the end. The registerable name is the part before the first dot. Names must be lowercase ASCII: a-z, 0-9, hyphens. 3-63 characters. No leading/trailing hyphens, no consecutive hyphens. No spaces, no emojis, no uppercase.
 
-| Flag | Description |
-|------|-------------|
-| `--json` | Structured JSON output (for agents/scripts) |
-| `--rpc-url <url>` | Override RPC URL |
-| `--wallet <addr>` | Override wallet address |
+## Quick Start
 
-### Commands
-
-#### Search for a name
+### 1. Check Availability
 
 ```bash
-hazza search <name>
+curl -s https://hazza.name/api/available/brian
 ```
-Checks availability and shows pricing. If a wallet is configured and eligible for a free claim, that's shown too.
 
-#### Register a name
+Returns `{"available": true}` or `{"available": false, "owner": "0x..."}`.
+
+### 2. Check Price
 
 ```bash
-hazza register <name> [--wallet <address>]
+curl -s "https://hazza.name/api/quote/brian?wallet=USER_WALLET_ADDRESS"
 ```
-Full x402 registration flow:
-1. Checks availability
-2. Checks free claim eligibility (Unlimited Pass + NL member)
-3. If free: registers directly, no payment
-4. If paid: gets 402 with USDC amount, transfers via `cast`, retries with payment header
 
-#### List owned names
+Returns `{"total": "5", "totalRaw": "5000000", "registrationFee": "5", "lineItems": [...]}`. A `totalRaw` of `"0"` means the name is free for this wallet. Amounts in `total` and `registrationFee` are human-readable USD; `totalRaw` is USDC with 6 decimals.
+
+### 3. Check Free Claim Eligibility
 
 ```bash
-hazza names [address]
+curl -s https://hazza.name/api/free-claim/USER_WALLET_ADDRESS
 ```
-Lists all names owned by an address. Defaults to configured wallet.
 
-#### View a profile
+Returns whether the user qualifies for a free registration (first name per wallet, or Unlimited Pass holder's bonus free name).
+
+### 4. Register via x402
 
 ```bash
-hazza profile <name>
+curl -s -X POST https://hazza.name/x402/register \
+  -H "Content-Type: application/json" \
+  -d '{"name": "brian", "owner": "USER_WALLET_ADDRESS"}'
 ```
-Shows full profile: owner, status, text records, profile URL.
 
-#### Text records
+**If the name is free** for this wallet → returns success immediately with `{name, owner, tokenId, registrationTx, profileUrl}`.
+
+**If payment is required** → returns HTTP 402 with payment details:
+
+```json
+{
+  "accepts": [{
+    "scheme": "exact",
+    "maxAmountRequired": "5000000",
+    "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "payTo": "RELAYER_ADDRESS",
+    "network": "base"
+  }]
+}
+```
+
+To complete payment:
+
+1. Transfer the exact USDC amount to the `payTo` address on Base
+2. Retry the same POST with the payment header:
 
 ```bash
-hazza records get <name> <key>     # Get a record
-hazza records set <name> <key> <value>  # Set a record (requires cast)
-hazza records list <name>          # List all records
-
-# Shorthands:
-hazza get <name> <key>
-hazza set <name> <key> <value>
+curl -s -X POST https://hazza.name/x402/register \
+  -H "Content-Type: application/json" \
+  -H "X-PAYMENT: BASE64_ENCODED_PAYMENT" \
+  -d '{"name": "brian", "owner": "USER_WALLET_ADDRESS"}'
 ```
 
-Common keys: `avatar`, `description`, `url`, `com.twitter`, `com.github`, `xyz.farcaster`, `org.telegram`
+The `X-PAYMENT` header is Base64-encoded JSON: `{"scheme":"exact","txHash":"0x...","from":"USER_WALLET_ADDRESS"}`
 
-#### Registry stats
+### 5. Set Profile Records (Optional)
+
+After registration, the user can set text records via the manage page at `https://hazza.name/manage` (connect wallet, select name, edit records, sign transaction).
+
+The write API requires an API key and returns unsigned transactions:
 
 ```bash
-hazza stats
+curl -s -X POST https://hazza.name/api/text/brian \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer API_KEY" \
+  -d '{"key": "description", "value": "Builder on Base"}'
 ```
-Shows total registered names, contract address, chain.
 
-#### Configuration
+Returns `{name, key, value, tx}` — the `tx` object must be signed and submitted by the name owner.
+
+## Pricing
+
+| Situation | Cost |
+|-----------|------|
+| First name per wallet | **FREE** (gas only) |
+| Unlimited Pass holder — 2nd name | **FREE** (gas only) |
+| Paid names 1-3 (per wallet, 90-day window) | $5 USDC |
+| Paid names 4-5 | $12.50 USDC |
+| Paid names 6-7 | $25 USDC |
+| Paid names 8+ | $50 USDC |
+| Unlimited Pass discount | 20% off all paid tiers |
+
+Free registrations do not count toward the progressive pricing tiers. If a user gets 2 free names, their next 3 paid names are still at the $5 tier.
+
+Names are permanent — no renewals, no expiry. Pay once, own forever.
+
+## Marketplace — Buy & Sell Names
+
+hazza names trade on the Seaport protocol (same as OpenSea) via the Net Protocol Bazaar. The hazza API handles all Seaport complexity — you never need to decode raw order parameters yourself.
+
+### Browse Listings
 
 ```bash
-hazza config show           # Show current config
-hazza config set <key> <val>  # Set a value
-hazza config get <key>       # Get a value
-hazza config reset           # Reset to defaults
+curl -s https://hazza.name/api/marketplace/listings
 ```
 
-Config keys: `wallet`, `baseUrl`, `rpcUrl`, `registryAddress`, `usdcAddress`, `chainId`
+Returns:
 
-Config file: `~/.config/hazza/config.json`
+```json
+{
+  "listings": [
+    {
+      "name": "example",
+      "tokenId": "42",
+      "seller": "0x...",
+      "price": 0.01,
+      "priceRaw": "10000000000000000",
+      "currency": "ETH",
+      "listingExpiry": "2026-04-01T00:00:00Z",
+      "orderHash": "0xabc123...",
+      "isNamespace": false,
+      "avatar": "https://...",
+      "profileUrl": "https://example.hazza.name",
+      "orderComponents": { ... }
+    }
+  ],
+  "total": 1
+}
+```
 
----
+Listings include `orderComponents` (the full Seaport order) but you do NOT need to use them directly. Use the fulfill endpoint instead.
+
+### Buy a Listed Name (2-Step)
+
+**Step 1 — Get the transaction data:**
+
+```bash
+curl -s -X POST https://hazza.name/api/marketplace/fulfill \
+  -H "Content-Type: application/json" \
+  -d '{"orderHash": "0xabc123...", "buyerAddress": "BUYER_WALLET"}'
+```
+
+Returns the exact transactions to execute:
+
+```json
+{
+  "approvals": [
+    {
+      "to": "0x...",
+      "data": "0x095ea7b3...",
+      "value": "0",
+      "spender": "0x...",
+      "amount": "10000000000000000"
+    }
+  ],
+  "fulfillment": {
+    "to": "0x0000000000000068F116a894984e2DB1123eB395",
+    "data": "0xb3a34c4c...",
+    "value": "10000000000000000"
+  }
+}
+```
+
+**Step 2 — Execute the transactions:**
+
+1. If `approvals` is non-empty, send each approval transaction first (these approve token spending)
+2. Send the `fulfillment` transaction — this is the actual Seaport purchase
+
+The `fulfillment.to` is the Seaport contract (`0x0000000000000068F116a894984e2DB1123eB395`). The `data` is the complete Seaport calldata. The `value` is the ETH amount to send (for ETH-priced listings).
+
+**Important:** The fulfillment data is ready to use as-is. Do NOT try to decode or reconstruct Seaport orders. The API does all the heavy lifting.
+
+### Browse Collection Offers
+
+```bash
+curl -s https://hazza.name/api/marketplace/offers
+```
+
+Returns active offers on any hazza name.
+
+### Accept an Offer (Seller Flow)
+
+```bash
+curl -s -X POST https://hazza.name/api/marketplace/fulfill-offer \
+  -H "Content-Type: application/json" \
+  -d '{"orderHash": "0x...", "tokenId": "42", "sellerAddress": "SELLER_WALLET"}'
+```
+
+Returns the same `{approvals, fulfillment}` format. The seller executes these transactions to accept the offer and transfer their name.
+
+### List a Name for Sale (Seaport + Bazaar)
+
+All listings go through Seaport and the Net Protocol Bazaar. This ensures every listing appears on **both** hazza.name/marketplace and netprotocol.app/bazaar simultaneously.
+
+**How it works:**
+1. Seller approves Seaport to transfer the NFT (`setApprovalForAll`)
+2. Seller signs an EIP-712 Seaport order (offer = NFT, consideration = ETH payment)
+3. Seller submits the signed order to the Bazaar contract
+4. Listing is live everywhere
+
+The hazza.name UI handles all of this — users just enter a price and sign.
+
+### Agent Bounty
+
+When listing, the seller can optionally set an agent bounty. The bounty comes out of the sale price. The bounty ETH is held by the Bounty Escrow contract (`0x95a29AD7f23c1039A03de365c23D275Fc5386f90`) until the name sells or the seller cancels.
+
+**How it works:**
+- Seller sets a bounty amount when listing — the ETH is held until the sale completes or the listing is cancelled
+- Agents register on the bounty for the name (self-registered agents expire after 24 hours, seller-assigned agents never expire)
+- When the name sells, the agent claims the bounty
+- If the seller cancels or no agent claims, the bounty is returned to the seller
+
+**Example:** List "coolname" for 0.1 ETH with a 0.01 ETH bounty. Name sells for 0.1 ETH. Seller nets 0.09 ETH (sale price minus bounty). Agent earns 0.01 ETH. If no agent claims, the bounty is returned.
+
+### Bounty Escrow API
+
+All bounty operations are available as unsigned transaction endpoints from the worker:
+
+```bash
+# Check if a name has a bounty
+curl -s https://hazza.name/api/bounty/TOKEN_ID
+
+# Check pending withdrawals for an address
+curl -s https://hazza.name/api/bounty/pending/ADDRESS
+
+# Register a bounty (returns unsigned tx — send with ETH value)
+curl -s -X POST https://hazza.name/api/bounty/register \
+  -H "Content-Type: application/json" \
+  -d '{"tokenId": "TOKEN_ID", "bountyAmountWei": "10000000000000000"}'
+
+# Register as agent for a bounty
+curl -s -X POST https://hazza.name/api/bounty/register-agent \
+  -H "Content-Type: application/json" \
+  -d '{"tokenId": "TOKEN_ID", "agentAddress": "0x..."}'
+
+# Claim bounty after sale
+curl -s -X POST https://hazza.name/api/bounty/claim \
+  -H "Content-Type: application/json" \
+  -d '{"tokenId": "TOKEN_ID"}'
+
+# Cancel bounty (seller only)
+curl -s -X POST https://hazza.name/api/bounty/cancel \
+  -H "Content-Type: application/json" \
+  -d '{"tokenId": "TOKEN_ID"}'
+
+# Withdraw bounty ETH (seller, only when no agent active)
+curl -s -X POST https://hazza.name/api/bounty/withdraw-bounty \
+  -H "Content-Type: application/json" \
+  -d '{"tokenId": "TOKEN_ID"}'
+
+# Withdraw pending payouts
+curl -s -X POST https://hazza.name/api/bounty/withdraw \
+  -H "Content-Type: application/json" \
+  -d '{"address": "0x..."}'
+```
+
+### Cancel a Listing
+
+```bash
+curl -s -X POST https://hazza.name/api/marketplace/cancel \
+  -H "Content-Type: application/json" \
+  -d '{"orderHash": "0xabc123..."}'
+```
+
+Returns an unsigned Seaport cancel transaction. The seller's wallet must execute it (only the original offerer can cancel).
+
+```json
+{
+  "cancel": { "to": "0x0000000000000068F116a894984e2DB1123eB395", "data": "0x...", "value": "0" },
+  "listing": { "orderHash": "0xabc123...", "name": "coolname", "tokenId": "42", "offerer": "0x..." }
+}
+```
+
+### Edit a Listing (Cancel + Relist)
+
+Seaport has no native edit — editing means cancelling the old order and creating a new one. This endpoint handles both in one call.
+
+```bash
+curl -s -X POST https://hazza.name/api/marketplace/edit \
+  -H "Content-Type: application/json" \
+  -d '{"orderHash": "0xabc123...", "sellerAddress": "0x...", "newPriceWei": "200000000000000000"}'
+```
+
+Accepts: `orderHash` (required), `sellerAddress` (required), `newPriceWei` (optional), `newDuration` in seconds (optional), `newBounty` (optional).
+
+Returns: `cancel` tx (send first), then `newListing.eip712` data to sign and submit to Bazaar.
+
+**For Bankr/SIWA flow:** When acting on behalf of a user, execute the cancel tx with the user's delegated wallet, then sign the new EIP-712 order and submit to Bazaar. The user sees it as a single "edit" action.
+
+### Marketplace Fees
+
+- No marketplace fee — sellers receive the sale price minus any optional agent bounty
+- Seaport contract: `0x0000000000000068F116a894984e2DB1123eB395` (Base)
+- Bazaar contract: `0x000000058f3ade587388daf827174d0e6fc97595` (Base)
+- Bounty Escrow (Proxy): `0x95a29AD7f23c1039A03de365c23D275Fc5386f90`
 
 ## API Reference
 
 Base URL: `https://hazza.name`
 
-### Read Endpoints
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/available/:name` | GET | Check name availability |
+| `/api/quote/:name?wallet=ADDR` | GET | Get exact price for this wallet |
+| `/api/free-claim/:address` | GET | Free claim eligibility |
+| `/api/profile/:name` | GET | Full profile with text records, master inheritance, Helixa Cred |
+| `/api/identity/:address` | GET | Resolve address to display name + master profile + Helixa Cred |
+| `/api/names/:address` | GET | All names owned by a wallet |
+| `/api/resolve/:name` | GET | Resolve name to owner |
+| `/api/reverse/:address` | GET | Reverse resolve address to name |
+| `/api/stats` | GET | Registry stats (total names) |
+| `/api/directory` | GET | Paginated list of all names |
+| `/x402/register` | POST | Register a name (x402 flow) |
+| `/api/text/:name` | POST | Set a text record |
+| `/api/marketplace/listings` | GET | Browse active listings |
+| `/api/marketplace/offers` | GET | Browse collection offers |
+| `/api/marketplace/fulfill` | POST | Get buy transaction data |
+| `/api/marketplace/fulfill-offer` | POST | Get offer acceptance tx data |
+| `/api/marketplace/cancel` | POST | Cancel a listing (returns unsigned Seaport cancel tx) |
+| `/api/marketplace/edit` | POST | Edit a listing (cancel + relist with new params) |
+| `/api/bounty/:tokenId` | GET | Check bounty status for a name |
+| `/api/bounty/pending/:address` | GET | Check pending withdrawals |
+| `/api/bounty/register` | POST | Register bounty (returns unsigned tx) |
+| `/api/bounty/register-agent` | POST | Register as agent for bounty |
+| `/api/bounty/claim` | POST | Claim bounty after sale |
+| `/api/bounty/cancel` | POST | Cancel bounty (seller only) |
+| `/api/bounty/withdraw-bounty` | POST | Withdraw bounty ETH (seller) |
+| `/api/bounty/withdraw` | POST | Withdraw pending payouts |
 
-| Endpoint | Description |
-|----------|-------------|
-| `GET /api/available/:name` | Check name availability |
-| `GET /api/resolve/:name` | Resolve name to owner address |
-| `GET /api/quote/:name?wallet=&verifiedPass=true` | Get registration price (wallet required for accurate pricing) |
-| `GET /api/free-claim/:address` | Check free claim eligibility (first-registration + Unlimited Pass) |
-| `GET /api/profile/:name` | Full profile with text records |
-| `GET /api/text/:name/:key` | Get single text record |
-| `GET /api/names/:address` | List names owned by address |
-| `GET /api/stats` | Registry statistics |
-| `GET /api/metadata/:name` | ERC-721 token metadata |
-| `GET /api/reverse/:address` | Reverse resolve address to name |
-| `GET /api/og/:name` | Generate OG image (1200x630 PNG) |
-| `GET /api/share` | Square share image (1200x1200 PNG) — for Farcaster/social |
-| `GET /api/icon` | App icon (1200x1200 PNG) |
+## Resolving an Address to a Person
 
-### Agent Identity (ERC-8004)
+When you have a wallet address and want to know who owns it, use `/api/identity/:address` — it returns the best display name and master profile in one call:
 
-Agents register directly on the ERC-8004 registry (`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`), then link to their hazza name via text records:
+```bash
+curl -s https://hazza.name/api/identity/0xaf5e770478e45650e36805d1ccaab240309f4a20
+```
+
+```json
+{
+  "wallet": "0xaf5e...",
+  "primaryName": "cheryl",
+  "ens": "cheryl.netlibrary.eth",
+  "display": "cheryl",
+  "truncated": "0xaf5e...4a20",
+  "xmtp": "0x0816...0408",
+  "avatar": "https://...",
+  "description": "...",
+  "profileUrl": "https://cheryl.hazza.name",
+  "helixaCred": { "tokenId": 57, "credScore": 63 }
+}
+```
+
+Use `display` as the user-facing name (primary hazza name > ENS > truncated address). Use `xmtp` to DM them. Use `helixaCred.credScore` to surface their reputation. Use `profileUrl` to link to their main page.
+
+## Profile Response Shape
+
+`GET /api/profile/:name` returns a rich object that already accounts for master inheritance and Helixa Cred:
+
+```json
+{
+  "name": "mybiz",
+  "registered": true,
+  "owner": "0x...",
+  "ownerEns": "alice.eth",
+  "ownerPrimaryName": "alice",
+  "tokenId": "42",
+  "texts": { "avatar": "...", "description": "...", "...": "..." },
+  "ownTexts": { "site.key": "..." },
+  "inheritedFrom": "alice",
+  "helixaData": { "tokenId": 1128, "credScore": 63, "autoDetected": true, "...": "..." },
+  "url": "https://mybiz.hazza.name"
+}
+```
+
+- `texts` is the merged view (master records + own records, own wins) — display this on profile pages.
+- `ownTexts` is the raw on-chain records for THIS name only — use this when editing so you don't accidentally save inherited values.
+- `inheritedFrom` is the master name if any, else `null`.
+- `ownerPrimaryName` lets you link the owner display to their primary name's profile.
+- `helixaData.autoDetected: true` means the cred score came from an address-search fallback rather than an explicit `helixa.id` text record.
+
+## Key Addresses (Base Mainnet)
+
+| Item | Address |
+|------|---------|
+| Registry | `0xD4E420201fE02F44AaF6d28D4c8d3A56fEaE0D3E` |
+| Seaport | `0x0000000000000068F116a894984e2DB1123eB395` |
+| Bazaar | `0x000000058f3ade587388daf827174d0e6fc97595` |
+| Bounty Escrow (Proxy) | `0x95a29AD7f23c1039A03de365c23D275Fc5386f90` |
+| ERC-8004 Registry | `0x8004A169FB4a3325136EB29fA0ceB6D2e539a432` |
+| $HAZZA Token | `0xC5C4Fcd6147e3bDAEEB5A0898A439Aec1e1BAba3` |
+| USDC | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+| Chain ID | 8453 |
+
+## Name Rules
+
+- Lowercase only: a-z, 0-9, hyphens
+- 3 to 63 characters
+- No leading or trailing hyphens
+- No consecutive hyphens (--)
+- No spaces, emojis, or special characters
+- Each name becomes a real web page — names must work as DNS labels
+
+If a user requests a name with invalid characters, explain that names need to work as web addresses, so only letters, numbers, and hyphens are allowed.
+
+## Profile Records
+
+After registration, users can set these text records on their name:
+
+| Key | Purpose | Example |
+|-----|---------|---------|
+| `avatar` | Profile image URL | `https://example.com/pfp.png` |
+| `description` | Bio | `Builder on Base` |
+| `url` | Website | `https://alice.dev` |
+| `com.twitter` | Twitter/X handle | `alice` |
+| `com.github` | GitHub username | `alice` |
+| `xyz.farcaster` | Farcaster handle | `alice` |
+| `org.telegram` | Telegram handle | `alice` |
+| `com.discord` | Discord username | `alice#1234` |
+| `com.linkedin` | LinkedIn username | `alice` |
+| `xmtp` | XMTP messaging address | `0x...` |
+| `message.delegate` | Forward inbound messages to this address | `0x...` |
+| `message.mode` | Routing mode: `all`, `delegate-all`, `delegate-agents` | `delegate-agents` |
+| `master` | Inherit profile from another hazza name | `geaux` |
+| `helixa.id` | Pin a specific Helixa agent token ID | `57` |
+| `net.profile` | Net Protocol storage key for custom profile | `my-profile-v1` |
+| `netlibrary.member` | Net Library member number | `21` |
+| `site.key` | Net Protocol storage key for custom HTML site | `my-site-v1` |
+| `agent.uri` | URI to agent metadata JSON | `https://...` |
+
+## Master Profile (Inheritance)
+
+Set `master` on a name to a different hazza name to inherit that name's profile records. This lets one identity feed many names — for example, every name a user owns can inherit avatar/bio/socials/xmtp from their primary name without re-typing them.
+
+**Behavior:**
+- The name's own records always win over the master's records
+- `master` and `site.key` are NOT inherited — each name controls its own custom site override
+- Set to empty string to remove the link
+
+**Example:** `mybiz` sets `master` to `geaux`. `https://mybiz.hazza.name` now displays geaux's avatar, bio, twitter, etc., but can still override any of those by setting its own records. `mybiz` can also have its own `site.key` to look like a fully custom website while keeping the inherited identity on the back end.
+
+## Helixa Cred (Reputation Score)
+
+hazza profile pages auto-detect the owner's [Helixa](https://helixa.xyz) agent (if any) and display a Cred Score badge. No setup is required — it works for any wallet that owns a Helixa agent. Score is 0–100, color-coded by tier (junk/marginal/qualified/prime/preferred).
+
+**Optional override:** if a name represents a project distinct from the owner's personal Helixa identity, set `helixa.id` to that agent's token ID to pin a specific agent.
+
+## CLI
+
+A Node CLI is available for users who prefer the terminal:
+
+```bash
+npm install -g hazza-cli
+hazza search alice
+hazza register alice
+hazza names 0x...
+hazza profile alice
+hazza set alice avatar https://example.com/pfp.png
+hazza set alice description "Builder on Base"
+```
+
+Source: <https://github.com/geaux-eth/hazza/tree/master/cli>
+
+## Agent Identity (ERC-8004)
+
+Agents register on the ERC-8004 registry (`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`) and link to their hazza name via text records:
 
 1. `POST /api/agent/register` with `{name, agentURI}` (optional: `agentWallet`) — returns unsigned 8004 register tx + instructions
-2. Agent signs and submits the tx from the name owner wallet, gets agentId from Transfer event (topics[3])
-3. `POST /api/agent/confirm` with `{name, agentId, txHash}` (optional: `agentWallet`) — verifies 8004 token is owned by name owner, sets text records via relayer
+2. Agent signs and submits the tx from the name owner wallet, gets `agentId` from the Transfer event (`topics[3]`)
+3. `POST /api/agent/confirm` with `{name, agentId, txHash}` (optional: `agentWallet`) — verifies the 8004 token is owned by the name owner, then sets the agent text records via the relayer
 
-Or pass `agentURI` and `agentWallet` in the `POST /x402/register` body at registration time — agent text records are set automatically (but you still need to register on 8004 separately).
+Or pass `agentURI` and `agentWallet` in the `POST /x402/register` body at registration time — agent text records are set automatically (you still need to register on 8004 separately).
 
 Agent text records:
 - `agent.8004id` — ERC-8004 agent token ID (set by `/api/agent/confirm`)
@@ -156,232 +496,23 @@ Agent text records:
 - `agent.model` — LLM model the agent runs
 - `agent.status` — operational status (e.g., "active")
 
-### Write Endpoints
+## $HAZZA Token
 
-| Endpoint | Description |
-|----------|-------------|
-| `POST /x402/register` | Register a name (x402, optional: `agentURI`, `agentWallet`) |
-| `POST /x402/text/:name` | Set text record via x402 ($0.02 USDC, no API key) |
-| `POST /x402/text/:name/batch` | Batch set text records via x402 ($0.02 USDC, no API key) |
-| `POST /api/agent/register` | Get unsigned 8004 register tx for a name |
-| `POST /api/agent/confirm` | Verify 8004 registration + link to hazza name |
-| `POST /api/text/:name` | Set text record (API key auth, returns unsigned tx) |
-| `POST /api/text/:name/batch` | Batch set text records (API key auth, returns unsigned txs) |
+The hazza protocol token `$HAZZA` (`0xC5C4Fcd6147e3bDAEEB5A0898A439Aec1e1BAba3` on Base) is launched and traded via Bankr. The token is a utility/governance token tied to the protocol — it does **not** confer name discounts or unlock free claims (those are tied to Unlimited Pass and first-name-per-wallet logic).
 
-### Two Ways to Write Records
+## Post-Registration
 
-**x402 path (recommended for agents):** Pay $0.02 USDC per request, relayer executes the transaction. No API key, no gas management. You can only update records on names you own — the `from` address in the X-PAYMENT header must match the name owner.
+After a successful registration, share these with the user:
 
-**API key path:** Generate an API key on-chain, get unsigned transaction data back, sign and submit yourself. Free (no $0.02 fee) but you need ETH for gas and must be the owner/operator.
-
-### x402 Registration Flow
-
-1. `POST /x402/register` with `{name, owner}`
-2. If eligible for free claim → returns success immediately
-3. If paid → returns `402` with payment requirements:
-   - `accepts[0].scheme` = `"exact"` (direct USDC transfer)
-   - `accepts[0].network` = `"base"` (chain)
-   - `accepts[0].maxAmountRequired` = USDC amount in raw units (6 decimals, e.g. `"5000000"` = $5)
-   - `accepts[0].asset` = USDC contract address
-   - `accepts[0].payTo` = relayer address (transfer USDC here)
-4. Transfer USDC to `payTo` address
-5. Retry `POST /x402/register` with `X-PAYMENT` header:
-   - Base64 of `{"scheme":"exact","txHash":"0x...","from":"0x..."}`
-6. Returns: `{name, owner, tokenId, registrationTx, profileUrl}`
-
-### x402 Text Record Flow
-
-1. `POST /x402/text/:name` with `{key, value}` (or `/x402/text/:name/batch` with `{records: [{key, value}, ...]}`)
-2. Returns `402` with payment requirements: `maxAmountRequired: "20000"` ($0.02 USDC)
-3. Transfer $0.02 USDC to `payTo` address
-4. Retry with `X-PAYMENT` header: Base64 of `{"scheme":"exact","txHash":"0x...","from":"0x..."}`
-5. `from` must be the name owner — relayer verifies ownership before executing
-6. Returns: `{name, key, value, tx, profileUrl}` (or `{name, records, tx, profileUrl}` for batch)
-
----
-
-## Pricing
-
-| Situation | Cost |
-|-----------|------|
-| First name per wallet | **FREE** (gas only) |
-| Unlimited Pass holder — 2nd name | **FREE** (gas only) |
-| Paid names 1–3 (per wallet, 90-day window) | $5 USDC |
-| Paid names 4–5 | $12.50 USDC (2.5x) |
-| Paid names 6–7 | $25 USDC (5x) |
-| Paid names 8+ | $50 USDC (10x) |
-| Unlimited Pass discount | 20% off all paid tiers |
-
-Free registrations do not count toward the progressive pricing tiers. If a user gets 2 free names, their next 3 paid names are still at the $5 tier.
-
-Names are permanent — no renewals, no expiry. Pay once, own forever.
-
----
-
-## Contract Functions
-
-Key read functions:
-- `available(name)` → bool
-- `resolve(name)` → (owner, tokenId, registeredAt, expiresAt, operator, agentId, agentWallet)
-- `text(name, key)` → string
-- `textMany(name, keys)` → string[]
-- `quoteName(name, owner, len, hasPass, isRenewal)` → cost
-- `namesOfOwner(owner)` → string[]
-
-Key write functions:
-- `register(name, owner)` — standard registration (requires USDC approval)
-- `registerDirectWithMember(name, owner, ...)` — free claim with membership
-- `setText(name, key, value)` — set text record (owner/operator only)
-- `setTexts(name, keys, values)` — batch set text records
-
----
-
-## Examples
-
-### Register a name
-```bash
-hazza config set wallet 0x96168ACf7f3925e7A9eAA08Ddb21e59643da8097
-hazza search alice
-hazza register alice
-```
-
-### Set up a profile
-```bash
-hazza set alice avatar https://example.com/pfp.png
-hazza set alice description "Builder on Base"
-hazza set alice com.twitter AliceOnBase
-hazza set alice url https://alice.dev
-```
-
-### Check ownership
-```bash
-hazza names                    # uses configured wallet
-hazza names 0x9616...          # specific address
-hazza profile alice
-```
-
-### Agent/script usage
-```bash
-hazza search alice --json | jq .available
-hazza names --json | jq '.[].name'
-```
-
----
-
-## Marketplace
-
-The hazza marketplace at `hazza.name/marketplace` is a whitelabeled Net Protocol Bazaar. All listings are stored onchain as Net Protocol messages via Seaport, and appear on both `hazza.name/marketplace` and `netprotocol.app/bazaar`.
-
-### Agent Bounties
-
-Sellers can set an agent bounty that comes out of the sale price. The bounty ETH is held by the Bounty Escrow contract (`0x95a29AD7f23c1039A03de365c23D275Fc5386f90`) until the name sells or the seller cancels. If an agent helps sell the name, the agent earns the bounty. If no agent claims, the bounty is returned to the seller. Self-registered agents get 24-hour windows; seller-assigned agents never expire.
-
-### Features
-- **Dual currency:** List names in ETH or USDC
-- **4 tabs:** Browse Listings, My Names, Collection Offers, Recent Sales
-- **Cart:** Buy multiple listings, register new names, and list names for sale — all in one session
-- **Watchlist:** Save listings for later. Shows "in X watchlists" as social proof.
-- **Adaptive buying:** Direct Seaport when wallet is connected, x402 fallback when no wallet.
-- **Cross-linked:** Dashboard has "sell" button, register success has "list on marketplace" CTA, profile pages link to marketplace.
-
-### CLI Marketplace Commands
-
-```bash
-hazza market listings         # Browse active listings (ETH + USDC)
-hazza market ls               # Alias for listings
-hazza market offers           # View collection offers
-hazza market sales            # Recent sales
-hazza market sell <name> <price> [--usdc]   # List a name (ETH default, --usdc for USDC)
-hazza market buy <orderHash>  # Buy a listing
-```
-
-### Listing Helper (for agents)
-
-Agents don't need to know Seaport internals. Call the listing helper to get everything needed to list a name:
-
-```
-POST /api/marketplace/list-helper
-{
-  "name": "alice",
-  "price": "0.1",
-  "seller": "0xAGENT_WALLET",
-  "duration": 0,
-  "bountyAmount": "0.01"
-}
-
-→ Returns:
-  - typedData: EIP-712 data to sign with agent's wallet
-  - bazaarSubmit: order parameters for Bazaar.submit() call
-  - approvalNeeded: setApprovalForAll tx if Seaport isn't approved yet
-  - bountyRegistration: registerBounty tx if bounty was set
-```
-
-Agent flow: call list-helper → sign typedData → call Bazaar.submit() with signature → optionally register bounty. All from the agent's own wallet.
-
-### Marketplace API Endpoints
-
-| Endpoint | Description |
-|----------|-------------|
-| `POST /api/marketplace/list-helper` | Build Seaport listing data for agent signing |
-| `GET /api/marketplace/listings` | Active hazza name listings (ETH + USDC) |
-| `GET /api/marketplace/offers` | Active collection offers |
-| `GET /api/marketplace/sales` | Recent sales |
-| `GET /api/marketplace/watch/:orderHash` | Watchlist count for a listing |
-| `POST /api/marketplace/watch` | Add to watchlist `{orderHash, address}` |
-| `DELETE /api/marketplace/watch` | Remove from watchlist `{orderHash, address}` |
-| `GET /api/bounty/:tokenId` | Check bounty status for a name |
-| `GET /api/bounty/pending/:address` | Check pending withdrawals |
-| `POST /api/bounty/register` | Register bounty (returns unsigned tx) |
-| `POST /api/bounty/register-agent` | Register as agent for bounty |
-| `POST /api/bounty/claim` | Claim bounty after sale |
-| `POST /api/bounty/cancel` | Cancel bounty (seller only) |
-| `POST /api/bounty/withdraw-bounty` | Withdraw bounty ETH (seller) |
-| `POST /api/bounty/withdraw` | Withdraw pending payouts |
-
-### Key Contracts (Base)
-- **Seaport:** `0x0000000000000068F116a894984e2DB1123eB395`
-- **Bazaar V2:** `0x000000058f3ade587388daf827174d0e6fc97595`
-- **Bounty Escrow (Proxy):** `0x95a29AD7f23c1039A03de365c23D275Fc5386f90`
-- **Fee:** 0 bps (zero listing fee)
-
----
-
-## Farcaster Mini App
-
-hazza.name is a Farcaster Mini App — all pages work in Warpcast and Base App webviews.
-
-- **Manifest:** `hazza.name/.well-known/farcaster.json`
-- **SDK:** `@farcaster/miniapp-sdk` from esm.sh CDN
-- **Wallet:** `window.ethereum` injected by Warpcast/Base App
-- **Embed meta:** `fc:frame` tags on all pages for link previews
-- **Sharing:** Post-registration and post-listing prompts for cast embeds
-
----
-
-## Brand Kit
-
-See **[BRAND.md](BRAND.md)** for the full brand reference — colors, typography, logo specs, Nomi mascot guidelines, and naming rules. Key points:
-
-- **Colorway:** Moonlit B — cream `#F7EBBD` background, bandana red `#CF3748` accent, hat blue `#4870D4` secondary, navy `#131325` text
-- **Font:** Fredoka (Bold 700, SemiBold 600, Regular 400)
-- **Logo:** white "h" in red filled rounded rect (no border)
-- **Wordmark:** "hazza" navy + ".name" blue, Fredoka Bold
-- **Mascot:** Nomi (Nibble #4240) — complements the brand, not the brand itself
-- **Image endpoints:** `/api/share` (1200x1200 square), `/api/icon` (1200x1200 icon), `/api/og/:name` (1200x630 per-name)
-
-When creating hazza-branded assets (images, pages, embeds), always reference BRAND.md for exact specs.
+- **Profile page:** `https://brian.hazza.name`
+- **Marketplace:** `https://hazza.name/marketplace`
+- **Set up profile:** Visit `https://hazza.name/manage` to set text records
+- **Dashboard:** `https://hazza.name/dashboard` to see all your names
 
 ## Guidelines
 
-- hazza names are "immediately useful" — always use this phrase
-- Always say "powered by x402 and Net Protocol"
-- It's "hazza" or "hazza.name" — NEVER "HAZZA Names"
-- Never put "hazza.name" + "immediately useful names" together (double "name")
-- "hazza" + "immediately useful names" = OK
-- "hazza.name" + "immediately useful" = OK
-- Link to https://hazza.name for the website
-- Profile pages are at `https://<name>.hazza.name`
-- Marketplace at `hazza.name/marketplace` — listings cross-list to netprotocol.app
-- Live on Base mainnet
-- The `cast` binary (Foundry) is required for onchain transactions (register via x402, set records)
-- Free claims require both an Unlimited Pass NFT AND Net Library membership
+- It's "hazza" or "hazza.name" — never "HAZZA" or "Hazza Names"
+- Names are "immediately useful" — they come with a working profile page from day one
+- Powered by x402, XMTP and Net Protocol
+- Never promise price appreciation or investment value
+- If a name is taken, suggest alternatives (add numbers, try different names)

--- a/hazza/SKILL.md
+++ b/hazza/SKILL.md
@@ -112,6 +112,106 @@ Free registrations do not count toward the progressive pricing tiers. If a user 
 
 Names are permanent — no renewals, no expiry. Pay once, own forever.
 
+## Marketplace — Buy & Sell Names
+
+hazza names trade on the Seaport protocol (same as OpenSea) via the Net Protocol Bazaar. The hazza API handles all Seaport complexity — you never need to decode raw order parameters yourself.
+
+### Browse Listings
+
+```bash
+curl -s https://hazza.name/api/marketplace/listings
+```
+
+Returns:
+
+```json
+{
+  "listings": [
+    {
+      "name": "example",
+      "tokenId": "42",
+      "seller": "0x...",
+      "price": 0.01,
+      "priceRaw": "10000000000000000",
+      "currency": "ETH",
+      "listingExpiry": "2026-04-01T00:00:00Z",
+      "orderHash": "0xabc123...",
+      "isNamespace": false,
+      "avatar": "https://...",
+      "profileUrl": "https://example.hazza.name",
+      "orderComponents": { ... }
+    }
+  ],
+  "total": 1
+}
+```
+
+Listings include `orderComponents` (the full Seaport order) but you do NOT need to use them directly. Use the fulfill endpoint instead.
+
+### Buy a Listed Name (2-Step)
+
+**Step 1 — Get the transaction data:**
+
+```bash
+curl -s -X POST https://hazza.name/api/marketplace/fulfill \
+  -H "Content-Type: application/json" \
+  -d '{"orderHash": "0xabc123...", "buyerAddress": "BUYER_WALLET"}'
+```
+
+Returns the exact transactions to execute:
+
+```json
+{
+  "approvals": [
+    {
+      "to": "0x...",
+      "data": "0x095ea7b3...",
+      "value": "0",
+      "spender": "0x...",
+      "amount": "10000000000000000"
+    }
+  ],
+  "fulfillment": {
+    "to": "0x0000000000000068F116a894984e2DB1123eB395",
+    "data": "0xb3a34c4c...",
+    "value": "10000000000000000"
+  }
+}
+```
+
+**Step 2 — Execute the transactions:**
+
+1. If `approvals` is non-empty, send each approval transaction first (these approve token spending)
+2. Send the `fulfillment` transaction — this is the actual Seaport purchase
+
+The `fulfillment.to` is the Seaport contract (`0x0000000000000068F116a894984e2DB1123eB395`). The `data` is the complete Seaport calldata. The `value` is the ETH amount to send (for ETH-priced listings).
+
+**Important:** The fulfillment data is ready to use as-is. Do NOT try to decode or reconstruct Seaport orders. The API does all the heavy lifting.
+
+### Browse Collection Offers
+
+```bash
+curl -s https://hazza.name/api/marketplace/offers
+```
+
+Returns active offers on any hazza name.
+
+### Accept an Offer (Seller Flow)
+
+```bash
+curl -s -X POST https://hazza.name/api/marketplace/fulfill-offer \
+  -H "Content-Type: application/json" \
+  -d '{"orderHash": "0x...", "tokenId": "42", "sellerAddress": "SELLER_WALLET"}'
+```
+
+Returns the same `{approvals, fulfillment}` format. The seller executes these transactions to accept the offer and transfer their name.
+
+### Marketplace Fees
+
+- 2% marketplace fee on all sales
+- Seaport contract: `0x0000000000000068F116a894984e2DB1123eB395` (Base)
+- Treasury: `0x62B7399B2ac7e938Efad06EF8746fDBA3B351900`
+
 ## API Reference
 
 Base URL: `https://hazza.name`
@@ -128,6 +228,10 @@ Base URL: `https://hazza.name`
 | `/api/stats` | GET | Registry stats (total names) |
 | `/x402/register` | POST | Register a name (x402 flow) |
 | `/api/text/:name` | POST | Set a text record |
+| `/api/marketplace/listings` | GET | Browse active listings |
+| `/api/marketplace/offers` | GET | Browse collection offers |
+| `/api/marketplace/fulfill` | POST | Get buy transaction data |
+| `/api/marketplace/fulfill-offer` | POST | Get offer acceptance tx data |
 
 ## Key Addresses (Base Mainnet)
 

--- a/hazza/SKILL.md
+++ b/hazza/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: hazza
-description: Register and manage hazza.name — immediately useful onchain names on Base. Check availability, register names, set profile records.
+description: Register, buy, sell, and manage hazza.name — immediately useful onchain names on Base. Check availability, register names, buy/list on marketplace, set agent bounties, set profile records.
 ---
 
 # hazza — Onchain Names on Base
@@ -206,11 +206,86 @@ curl -s -X POST https://hazza.name/api/marketplace/fulfill-offer \
 
 Returns the same `{approvals, fulfillment}` format. The seller executes these transactions to accept the offer and transfer their name.
 
+### List a Name for Sale (via Agent Bounty Contract)
+
+The HazzaAgentBounty contract (`0xC6C0FAf855Fdb6D38cA43FcFDf2c26b8D6564eD6`) is a simpler alternative to Seaport for listing names. One transaction, no EIP-712 complexity.
+
+**Prerequisites:**
+1. The seller must own the name (ERC-721 token)
+2. The seller must approve the bounty contract to transfer the NFT:
+
+```solidity
+// Approve the bounty contract to transfer the name
+registry.approve(0xC6C0FAf855Fdb6D38cA43FcFDf2c26b8D6564eD6, tokenId)
+```
+
+**List the name:**
+
+```solidity
+// list(tokenId, price, bountyAmount, expiresAt)
+// price: total ETH the buyer pays
+// bountyAmount: portion of price that goes to the facilitating agent (0 = no bounty)
+// expiresAt: unix timestamp (0 = no expiry)
+bountyContract.list(tokenId, 0.1 ether, 0.01 ether, 0)
+```
+
+This creates a listing where:
+- Buyer pays 0.1 ETH
+- If an agent facilitated the sale, agent gets 0.01 ETH
+- Seller gets the remaining 0.09 ETH
+- No upfront escrow — bounty comes from sale proceeds automatically
+
+**Using cast (CLI):**
+
+```bash
+# Get the tokenId
+TOKEN_ID=$(curl -s https://hazza.name/api/resolve/myname | jq -r '.tokenId')
+
+# Approve the bounty contract
+cast send 0xD4E420201fE02F44AaF6d28D4c8d3A56fEaE0D3E \
+  "approve(address,uint256)" \
+  0xC6C0FAf855Fdb6D38cA43FcFDf2c26b8D6564eD6 $TOKEN_ID \
+  --rpc-url https://mainnet.base.org --private-key $PK
+
+# List for 0.1 ETH with 0.01 ETH agent bounty, no expiry
+cast send 0xC6C0FAf855Fdb6D38cA43FcFDf2c26b8D6564eD6 \
+  "list(uint256,uint256,uint256,uint64)" \
+  $TOKEN_ID 100000000000000000 10000000000000000 0 \
+  --rpc-url https://mainnet.base.org --private-key $PK
+```
+
+### Buy via Agent Bounty Contract
+
+If a name is listed on the bounty contract, anyone can buy it with a single transaction:
+
+```bash
+# Check if a name has an active bounty listing
+curl -s https://hazza.name/api/bounty/TOKEN_ID
+
+# Buy — send exact price as ETH value
+cast send 0xC6C0FAf855Fdb6D38cA43FcFDf2c26b8D6564eD6 \
+  "buy(uint256)" LISTING_ID \
+  --value PRICE_IN_WEI \
+  --rpc-url https://mainnet.base.org --private-key $PK
+```
+
+The contract atomically: transfers the NFT to the buyer, pays the agent (if registered), and pays the seller the remainder.
+
+### Register as Agent (Earn Bounties)
+
+Agents can register on listings that have bounties. When the name sells, the agent gets the bounty automatically.
+
+```bash
+cast send 0xC6C0FAf855Fdb6D38cA43FcFDf2c26b8D6564eD6 \
+  "registerAgent(uint256)" LISTING_ID \
+  --rpc-url https://mainnet.base.org --private-key $PK
+```
+
 ### Marketplace Fees
 
-- 2% marketplace fee on all sales
+- No marketplace fee — sellers receive 100% of the sale price
 - Seaport contract: `0x0000000000000068F116a894984e2DB1123eB395` (Base)
-- Treasury: `0x62B7399B2ac7e938Efad06EF8746fDBA3B351900`
+- Agent Bounty contract: `0xC6C0FAf855Fdb6D38cA43FcFDf2c26b8D6564eD6` (Base)
 
 ## API Reference
 
@@ -232,12 +307,15 @@ Base URL: `https://hazza.name`
 | `/api/marketplace/offers` | GET | Browse collection offers |
 | `/api/marketplace/fulfill` | POST | Get buy transaction data |
 | `/api/marketplace/fulfill-offer` | POST | Get offer acceptance tx data |
+| `/api/bounty/:tokenId` | GET | Check active bounty listing for a name |
 
 ## Key Addresses (Base Mainnet)
 
 | Item | Address |
 |------|---------|
 | Registry | `0xD4E420201fE02F44AaF6d28D4c8d3A56fEaE0D3E` |
+| Agent Bounty | `0xC6C0FAf855Fdb6D38cA43FcFDf2c26b8D6564eD6` |
+| Seaport | `0x0000000000000068F116a894984e2DB1123eB395` |
 | USDC | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
 | Chain ID | 8453 |
 

--- a/hazza/SKILL.md
+++ b/hazza/SKILL.md
@@ -23,6 +23,7 @@ You can help users register, manage, and resolve hazza names — immediately use
 - **USDC (Base):** `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
 - **Chain:** Base (chainId 8453)
 - **Powered by:** x402 payment protocol + Net Protocol
+- **Token:** $HAZZA (`0xC5C4Fcd6147e3bDAEEB5A0898A439Aec1e1BAba3` on Base) — launched via Bankr
 
 ---
 

--- a/hazza/SKILL.md
+++ b/hazza/SKILL.md
@@ -141,8 +141,16 @@ Base URL: `https://hazza.name`
 | Endpoint | Description |
 |----------|-------------|
 | `POST /x402/register` | Register a name (x402 payment flow) |
-| `POST /api/text/:name` | Set text record (body: `{key, value, signature}`) |
-| `POST /api/text/:name/batch` | Set multiple text records |
+| `POST /x402/text/:name` | Set text record via x402 ($0.02 USDC, no API key) |
+| `POST /x402/text/:name/batch` | Batch set text records via x402 ($0.02 USDC, no API key) |
+| `POST /api/text/:name` | Set text record (API key auth, returns unsigned tx) |
+| `POST /api/text/:name/batch` | Batch set text records (API key auth, returns unsigned txs) |
+
+### Two Ways to Write Records
+
+**x402 path (recommended for agents):** Pay $0.02 USDC per request, relayer executes the transaction. No API key, no gas management. The `from` address in the payment must own the name.
+
+**API key path:** Generate an API key on-chain, get unsigned transaction data back, sign and submit yourself. Free (no $0.02 fee) but you need ETH for gas and must be the owner/operator.
 
 ### x402 Registration Flow
 
@@ -155,6 +163,15 @@ Base URL: `https://hazza.name`
 5. Retry `POST /x402/register` with `X-PAYMENT` header:
    - Base64 of `{"scheme":"exact","txHash":"0x...","from":"0x..."}`
 6. Returns: `{name, owner, tokenId, registrationTx, profileUrl}`
+
+### x402 Text Record Flow
+
+1. `POST /x402/text/:name` with `{key, value}` (or `/x402/text/:name/batch` with `{records: [{key, value}, ...]}`)
+2. Returns `402` with payment requirements: `maxAmountRequired: "20000"` ($0.02 USDC)
+3. Transfer $0.02 USDC to `payTo` address
+4. Retry with `X-PAYMENT` header: Base64 of `{"scheme":"exact","txHash":"0x...","from":"0x..."}`
+5. `from` must be the name owner — relayer verifies ownership before executing
+6. Returns: `{name, key, value, tx, profileUrl}` (or `{name, records, tx, profileUrl}` for batch)
 
 ---
 

--- a/hazza/SKILL.md
+++ b/hazza/SKILL.md
@@ -124,7 +124,7 @@ Base URL: `https://hazza.name`
 |----------|-------------|
 | `GET /api/available/:name` | Check name availability |
 | `GET /api/resolve/:name` | Resolve name to owner address |
-| `GET /api/quote/:name?wallet=` | Get registration price |
+| `GET /api/quote/:name?wallet=&verifiedPass=true` | Get registration price (wallet required for accurate pricing) |
 | `GET /api/free-claim/:address` | Check free claim eligibility (first-registration + Unlimited Pass) |
 | `GET /api/profile/:name` | Full profile with text records |
 | `GET /api/text/:name/:key` | Get single text record |
@@ -140,13 +140,19 @@ Base URL: `https://hazza.name`
 
 Agents register directly on the ERC-8004 registry (`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`), then link to their hazza name via text records:
 
-1. `POST /api/agent/register` with `{name, agentURI}` — returns unsigned 8004 register tx
-2. Agent signs and submits the tx, gets agentId from receipt
-3. `POST /api/agent/confirm` with `{name, agentId, txHash}` — verifies ownership, sets text records
+1. `POST /api/agent/register` with `{name, agentURI}` (optional: `agentWallet`) — returns unsigned 8004 register tx + instructions
+2. Agent signs and submits the tx from the name owner wallet, gets agentId from Transfer event (topics[3])
+3. `POST /api/agent/confirm` with `{name, agentId, txHash}` (optional: `agentWallet`) — verifies 8004 token is owned by name owner, sets text records via relayer
 
-Or pass `agentURI` and `agentWallet` in the `POST /x402/register` body at registration time.
+Or pass `agentURI` and `agentWallet` in the `POST /x402/register` body at registration time — agent text records are set automatically (but you still need to register on 8004 separately).
 
-Agent text records: `agent.8004id`, `agent.wallet`, `agent.uri`, `agent.endpoint`, `agent.model`, `agent.status`
+Agent text records:
+- `agent.8004id` — ERC-8004 agent token ID (set by `/api/agent/confirm`)
+- `agent.wallet` — agent's operational wallet address
+- `agent.uri` — agent metadata URI (same as the URI passed to 8004 register)
+- `agent.endpoint` — agent's API endpoint URL
+- `agent.model` — LLM model the agent runs
+- `agent.status` — operational status (e.g., "active")
 
 ### Write Endpoints
 
@@ -162,7 +168,7 @@ Agent text records: `agent.8004id`, `agent.wallet`, `agent.uri`, `agent.endpoint
 
 ### Two Ways to Write Records
 
-**x402 path (recommended for agents):** Pay $0.02 USDC per request, relayer executes the transaction. No API key, no gas management. The `from` address in the payment must own the name.
+**x402 path (recommended for agents):** Pay $0.02 USDC per request, relayer executes the transaction. No API key, no gas management. You can only update records on names you own — the `from` address in the X-PAYMENT header must match the name owner.
 
 **API key path:** Generate an API key on-chain, get unsigned transaction data back, sign and submit yourself. Free (no $0.02 fee) but you need ETH for gas and must be the owner/operator.
 
@@ -171,8 +177,11 @@ Agent text records: `agent.8004id`, `agent.wallet`, `agent.uri`, `agent.endpoint
 1. `POST /x402/register` with `{name, owner}`
 2. If eligible for free claim → returns success immediately
 3. If paid → returns `402` with payment requirements:
-   - `accepts[0].maxAmountRequired` = USDC amount (6 decimals)
-   - `accepts[0].payTo` = relayer address
+   - `accepts[0].scheme` = `"exact"` (direct USDC transfer)
+   - `accepts[0].network` = `"base"` (chain)
+   - `accepts[0].maxAmountRequired` = USDC amount in raw units (6 decimals, e.g. `"5000000"` = $5)
+   - `accepts[0].asset` = USDC contract address
+   - `accepts[0].payTo` = relayer address (transfer USDC here)
 4. Transfer USDC to `payTo` address
 5. Retry `POST /x402/register` with `X-PAYMENT` header:
    - Base64 of `{"scheme":"exact","txHash":"0x...","from":"0x..."}`

--- a/hazza/SKILL.md
+++ b/hazza/SKILL.md
@@ -33,7 +33,7 @@ Returns `{"available": true}` or `{"available": false, "owner": "0x..."}`.
 curl -s "https://hazza.name/api/quote/brian?wallet=USER_WALLET_ADDRESS"
 ```
 
-Returns `{"totalCost": "5000000", "registrationFee": "5000000"}` (USDC, 6 decimals). A `totalCost` of `"0"` means the name is free for this wallet.
+Returns `{"total": "5", "totalRaw": "5000000", "registrationFee": "5", "lineItems": [...]}`. A `totalRaw` of `"0"` means the name is free for this wallet. Amounts in `total` and `registrationFee` are human-readable USD; `totalRaw` is USDC with 6 decimals.
 
 ### 3. Check Free Claim Eligibility
 
@@ -62,7 +62,7 @@ curl -s -X POST https://hazza.name/x402/register \
     "maxAmountRequired": "5000000",
     "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
     "payTo": "RELAYER_ADDRESS",
-    "network": "base-mainnet"
+    "network": "base"
   }]
 }
 ```
@@ -83,15 +83,18 @@ The `X-PAYMENT` header is Base64-encoded JSON: `{"scheme":"exact","txHash":"0x..
 
 ### 5. Set Profile Records (Optional)
 
-After registration, help the user set up their profile:
+After registration, the user can set text records via the manage page at `https://hazza.name/manage` (connect wallet, select name, edit records, sign transaction).
+
+The write API requires an API key and returns unsigned transactions:
 
 ```bash
 curl -s -X POST https://hazza.name/api/text/brian \
   -H "Content-Type: application/json" \
-  -d '{"key": "description", "value": "Builder on Base", "signature": "SIGNED_MESSAGE"}'
+  -H "Authorization: Bearer API_KEY" \
+  -d '{"key": "description", "value": "Builder on Base"}'
 ```
 
-The signature is an EIP-191 personal sign of `setText:brian:description:Builder on Base` by the name owner.
+Returns `{name, key, value, tx}` — the `tx` object must be signed and submitted by the name owner.
 
 ## Pricing
 
@@ -130,7 +133,7 @@ Base URL: `https://hazza.name`
 
 | Item | Address |
 |------|---------|
-| Registry | `0xdf92cA2fc1e588F7A2ebAEA039CF3860826f4746` |
+| Registry | `0xD4E420201fE02F44AaF6d28D4c8d3A56fEaE0D3E` |
 | USDC | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
 | Chain ID | 8453 |
 
@@ -166,7 +169,8 @@ After a successful registration, share these with the user:
 
 - **Profile page:** `https://brian.hazza.name`
 - **Marketplace:** `https://hazza.name/marketplace`
-- **Set up profile:** Visit `https://hazza.name/dashboard` to manage records
+- **Set up profile:** Visit `https://hazza.name/manage` to set text records
+- **Dashboard:** `https://hazza.name/dashboard` to see all your names
 
 ## Guidelines
 

--- a/hazza/SKILL.md
+++ b/hazza/SKILL.md
@@ -270,10 +270,34 @@ hazza market sell <name> <price> [--usdc]   # List a name (ETH default, --usdc f
 hazza market buy <orderHash>  # Buy a listing
 ```
 
+### Listing Helper (for agents)
+
+Agents don't need to know Seaport internals. Call the listing helper to get everything needed to list a name:
+
+```
+POST /api/marketplace/list-helper
+{
+  "name": "alice",
+  "price": "0.1",
+  "seller": "0xAGENT_WALLET",
+  "duration": 0,
+  "bountyAmount": "0.01"
+}
+
+→ Returns:
+  - typedData: EIP-712 data to sign with agent's wallet
+  - bazaarSubmit: order parameters for Bazaar.submit() call
+  - approvalNeeded: setApprovalForAll tx if Seaport isn't approved yet
+  - bountyRegistration: registerBounty tx if bounty was set
+```
+
+Agent flow: call list-helper → sign typedData → call Bazaar.submit() with signature → optionally register bounty. All from the agent's own wallet.
+
 ### Marketplace API Endpoints
 
 | Endpoint | Description |
 |----------|-------------|
+| `POST /api/marketplace/list-helper` | Build Seaport listing data for agent signing |
 | `GET /api/marketplace/listings` | Active hazza name listings (ETH + USDC) |
 | `GET /api/marketplace/offers` | Active collection offers |
 | `GET /api/marketplace/sales` | Recent sales |

--- a/hazza/SKILL.md
+++ b/hazza/SKILL.md
@@ -136,13 +136,27 @@ Base URL: `https://hazza.name`
 | `GET /api/share` | Square share image (1200x1200 PNG) — for Farcaster/social |
 | `GET /api/icon` | App icon (1200x1200 PNG) |
 
+### Agent Identity (ERC-8004)
+
+Agents register directly on the ERC-8004 registry (`0x8004A169FB4a3325136EB29fA0ceB6D2e539a432`), then link to their hazza name via text records:
+
+1. `POST /api/agent/register` with `{name, agentURI}` — returns unsigned 8004 register tx
+2. Agent signs and submits the tx, gets agentId from receipt
+3. `POST /api/agent/confirm` with `{name, agentId, txHash}` — verifies ownership, sets text records
+
+Or pass `agentURI` and `agentWallet` in the `POST /x402/register` body at registration time.
+
+Agent text records: `agent.8004id`, `agent.wallet`, `agent.uri`, `agent.endpoint`, `agent.model`, `agent.status`
+
 ### Write Endpoints
 
 | Endpoint | Description |
 |----------|-------------|
-| `POST /x402/register` | Register a name (x402 payment flow) |
+| `POST /x402/register` | Register a name (x402, optional: `agentURI`, `agentWallet`) |
 | `POST /x402/text/:name` | Set text record via x402 ($0.02 USDC, no API key) |
 | `POST /x402/text/:name/batch` | Batch set text records via x402 ($0.02 USDC, no API key) |
+| `POST /api/agent/register` | Get unsigned 8004 register tx for a name |
+| `POST /api/agent/confirm` | Verify 8004 registration + link to hazza name |
 | `POST /api/text/:name` | Set text record (API key auth, returns unsigned tx) |
 | `POST /api/text/:name/batch` | Batch set text records (API key auth, returns unsigned txs) |
 

--- a/hazza/SKILL.md
+++ b/hazza/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: hazza
+description: Register and manage hazza.name — immediately useful onchain names on Base. Check availability, register names, set profile records.
+---
+
+# hazza — Onchain Names on Base
+
+Register immediately useful names on Base for your users. Each name is an ERC-721 NFT at `name.hazza.name` with a profile page, text records, and multi-chain addresses. Powered by x402, XMTP and Net Protocol.
+
+## Command Format
+
+Users request names using the full domain:
+
+```
+register brian.hazza.name
+```
+
+Parse the name by stripping `.hazza.name` from the end. The registerable name is the part before the first dot. Names must be lowercase ASCII: a-z, 0-9, hyphens. 3-63 characters. No leading/trailing hyphens, no consecutive hyphens. No spaces, no emojis, no uppercase.
+
+## Quick Start
+
+### 1. Check Availability
+
+```bash
+curl -s https://hazza.name/api/available/brian
+```
+
+Returns `{"available": true}` or `{"available": false, "owner": "0x..."}`.
+
+### 2. Check Price
+
+```bash
+curl -s "https://hazza.name/api/quote/brian?wallet=USER_WALLET_ADDRESS"
+```
+
+Returns `{"totalCost": "5000000", "registrationFee": "5000000"}` (USDC, 6 decimals). A `totalCost` of `"0"` means the name is free for this wallet.
+
+### 3. Check Free Claim Eligibility
+
+```bash
+curl -s https://hazza.name/api/free-claim/USER_WALLET_ADDRESS
+```
+
+Returns whether the user qualifies for a free registration (first name per wallet, or Unlimited Pass holder's bonus free name).
+
+### 4. Register via x402
+
+```bash
+curl -s -X POST https://hazza.name/x402/register \
+  -H "Content-Type: application/json" \
+  -d '{"name": "brian", "owner": "USER_WALLET_ADDRESS"}'
+```
+
+**If the name is free** for this wallet → returns success immediately with `{name, owner, tokenId, registrationTx, profileUrl}`.
+
+**If payment is required** → returns HTTP 402 with payment details:
+
+```json
+{
+  "accepts": [{
+    "scheme": "exact",
+    "maxAmountRequired": "5000000",
+    "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "payTo": "RELAYER_ADDRESS",
+    "network": "base-mainnet"
+  }]
+}
+```
+
+To complete payment:
+
+1. Transfer the exact USDC amount to the `payTo` address on Base
+2. Retry the same POST with the payment header:
+
+```bash
+curl -s -X POST https://hazza.name/x402/register \
+  -H "Content-Type: application/json" \
+  -H "X-PAYMENT: BASE64_ENCODED_PAYMENT" \
+  -d '{"name": "brian", "owner": "USER_WALLET_ADDRESS"}'
+```
+
+The `X-PAYMENT` header is Base64-encoded JSON: `{"scheme":"exact","txHash":"0x...","from":"USER_WALLET_ADDRESS"}`
+
+### 5. Set Profile Records (Optional)
+
+After registration, help the user set up their profile:
+
+```bash
+curl -s -X POST https://hazza.name/api/text/brian \
+  -H "Content-Type: application/json" \
+  -d '{"key": "description", "value": "Builder on Base", "signature": "SIGNED_MESSAGE"}'
+```
+
+The signature is an EIP-191 personal sign of `setText:brian:description:Builder on Base` by the name owner.
+
+## Pricing
+
+| Situation | Cost |
+|-----------|------|
+| First name per wallet | **FREE** (gas only) |
+| Unlimited Pass holder — 2nd name | **FREE** (gas only) |
+| Paid names 1-3 (per wallet, 90-day window) | $5 USDC |
+| Paid names 4-5 | $12.50 USDC |
+| Paid names 6-7 | $25 USDC |
+| Paid names 8+ | $50 USDC |
+| Unlimited Pass discount | 20% off all paid tiers |
+
+Free registrations do not count toward the progressive pricing tiers. If a user gets 2 free names, their next 3 paid names are still at the $5 tier.
+
+Names are permanent — no renewals, no expiry. Pay once, own forever.
+
+## API Reference
+
+Base URL: `https://hazza.name`
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/available/:name` | GET | Check name availability |
+| `/api/quote/:name?wallet=ADDR` | GET | Get exact price for this wallet |
+| `/api/free-claim/:address` | GET | Free claim eligibility |
+| `/api/profile/:name` | GET | Full profile with text records |
+| `/api/names/:address` | GET | All names owned by a wallet |
+| `/api/resolve/:name` | GET | Resolve name to owner |
+| `/api/reverse/:address` | GET | Reverse resolve address to name |
+| `/api/stats` | GET | Registry stats (total names) |
+| `/x402/register` | POST | Register a name (x402 flow) |
+| `/api/text/:name` | POST | Set a text record |
+
+## Key Addresses (Base Mainnet)
+
+| Item | Address |
+|------|---------|
+| Registry | `0xaA27d926F057B72D006883785FC03DB1d9d6E3AC` |
+| USDC | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+| Chain ID | 8453 |
+
+## Name Rules
+
+- Lowercase only: a-z, 0-9, hyphens
+- 3 to 63 characters
+- No leading or trailing hyphens
+- No consecutive hyphens (--)
+- No spaces, emojis, or special characters
+- Each name becomes a real web page — names must work as DNS labels
+
+If a user requests a name with invalid characters, explain that names need to work as web addresses, so only letters, numbers, and hyphens are allowed.
+
+## Profile Records
+
+After registration, users can set these text records on their name:
+
+| Key | Purpose | Example |
+|-----|---------|---------|
+| `avatar` | Profile image URL | `https://example.com/pfp.png` |
+| `description` | Bio | `Builder on Base` |
+| `url` | Website | `https://alice.dev` |
+| `com.twitter` | Twitter/X handle | `alice` |
+| `com.github` | GitHub username | `alice` |
+| `org.telegram` | Telegram handle | `alice` |
+| `com.discord` | Discord username | `alice#1234` |
+| `xmtp` | XMTP address | `0x...` |
+
+## Post-Registration
+
+After a successful registration, share these with the user:
+
+- **Profile page:** `https://brian.hazza.name`
+- **Marketplace:** `https://hazza.name/marketplace`
+- **Set up profile:** Visit `https://hazza.name/dashboard` to manage records
+
+## Guidelines
+
+- It's "hazza" or "hazza.name" — never "HAZZA" or "Hazza Names"
+- Names are "immediately useful" — they come with a working profile page from day one
+- Powered by x402, XMTP and Net Protocol
+- Never promise price appreciation or investment value
+- If a name is taken, suggest alternatives (add numbers, try different names)


### PR DESCRIPTION
## Summary

- Adds `hazza/SKILL.md` — teaches Bankr how to register and manage hazza.name domains
- Covers the full x402 registration flow (check availability → quote price → pay → register)
- Documents progressive anti-squat pricing tiers and Unlimited Pass discounts
- Includes profile text record management and API reference

## What is hazza

[hazza.name](https://hazza.name) is an onchain name registry on Base. Users register `name.hazza.name` as ERC-721 NFTs with built-in profile pages, text records, and agent integration. First name is free per wallet, then $5 USDC — pay once, own forever.

## What this skill enables

Bankr users can say things like:
- "register brian.hazza.name"
- "check if alice.hazza.name is available"
- "how much does a hazza name cost?"

And Bankr will handle the registration using the user's own wallet via the x402 payment flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)