### PR TITLE
fix: update GitHub URLs from openclaw-skills to skills

### DIFF
--- a/bankr-signals/SKILL.md
+++ b/bankr-signals/SKILL.md
@@ -115,10 +115,10 @@ curl -X POST https://bankrsignals.com/api/providers/register \
 
 #### Bankr References
 
-- [Bankr Skill](https://github.com/BankrBot/openclaw-skills/tree/main/bankr) - full skill docs
-- [Sign & Submit API](https://github.com/BankrBot/openclaw-skills/blob/main/bankr/references/sign-submit-api.md) - signing endpoint details
-- [API Workflow](https://github.com/BankrBot/openclaw-skills/blob/main/bankr/references/api-workflow.md) - async job polling
-- [Leverage Trading](https://github.com/BankrBot/openclaw-skills/blob/main/bankr/references/leverage-trading.md) - Avantis positions (for LONG/SHORT signals)
+- [Bankr Skill](https://github.com/BankrBot/skills/tree/main/bankr) - full skill docs
+- [Sign & Submit API](https://github.com/BankrBot/skills/blob/main/bankr/references/sign-submit-api.md) - signing endpoint details
+- [API Workflow](https://github.com/BankrBot/skills/blob/main/bankr/references/api-workflow.md) - async job polling
+- [Leverage Trading](https://github.com/BankrBot/skills/blob/main/bankr/references/leverage-trading.md) - Avantis positions (for LONG/SHORT signals)
 - [Agent API Docs](https://docs.bankr.bot/agent-api/overview) - full API reference
 
 ### Step 1: Provider Registration

--- a/botchan/SKILL.md
+++ b/botchan/SKILL.md
@@ -79,7 +79,7 @@ Or pass it directly with `--private-key KEY` on any write command.
 
 Use `--encode-only` to generate transactions, then submit through [Bankr](https://bankr.bot). This is the recommended approach for AI agents as Bankr handles gas, signing, and transaction management.
 
-Need help setting up Bankr? See the [Bankr Skill](https://github.com/BankrBot/openclaw-skills/tree/main/bankr) for installation and setup.
+Need help setting up Bankr? See the [Bankr Skill](https://github.com/BankrBot/skills/tree/main/bankr) for installation and setup.
 
 **How to submit with Bankr:**
 
@@ -94,8 +94,8 @@ botchan post general "Hello agents!" --encode-only
 ```
 
 For details, see:
-- [Bankr Arbitrary Transaction Reference](https://github.com/BankrBot/openclaw-skills/blob/main/bankr/references/arbitrary-transaction.md)
-- [Bankr API Workflow Reference](https://github.com/BankrBot/openclaw-skills/blob/main/bankr/references/api-workflow.md)
+- [Bankr Arbitrary Transaction Reference](https://github.com/BankrBot/skills/blob/main/bankr/references/arbitrary-transaction.md)
+- [Bankr API Workflow Reference](https://github.com/BankrBot/skills/blob/main/bankr/references/api-workflow.md)
 
 ### Gas Fees
 

--- a/siwa/references/bankr-signer.md
+++ b/siwa/references/bankr-signer.md
@@ -26,7 +26,7 @@ The wallet address is fetched automatically from Bankr's `/agent/me` endpoint.
 
 ## Register as ERC-8004 Agent
 
-Bankr wallets are smart contract accounts (ERC-4337). To register on the ERC-8004 Identity Registry, submit the registration as an [arbitrary transaction](https://github.com/BankrBot/openclaw-skills/blob/main/bankr/references/arbitrary-transaction.md) via Bankr's `/agent/submit` endpoint.
+Bankr wallets are smart contract accounts (ERC-4337). To register on the ERC-8004 Identity Registry, submit the registration as an [arbitrary transaction](https://github.com/BankrBot/skills/blob/main/bankr/references/arbitrary-transaction.md) via Bankr's `/agent/submit` endpoint.
 
 ### Supported Networks
 


### PR DESCRIPTION
## Summary
- Updated all GitHub URLs referencing `BankrBot/openclaw-skills` to `BankrBot/skills` after repo rename
- Affected files: `bankr-signals/SKILL.md`, `botchan/SKILL.md`, `siwa/references/bankr-signer.md`

## Test plan
- [x] Verify all updated links resolve correctly on GitHub