### PR TITLE
docs: add Trails by Polygon to available skills table

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Bankr Skills equip builders with plug-and-play tools to build more powerful agen
 | [Quicknode](https://www.quicknode.com) | [quicknode](quicknode/) | Blockchain RPC and data access for all supported chains. Native/token balances, gas estimation, transaction status, and onchain queries for Base, Ethereum, Polygon, Solana, and Unichain. Supports API key and x402 pay-per-request access. |
 | [Hydrex](https://hydrex.fi) | [hydrex](hydrex/) | Liquidity pools on Base. Lock HYDX for voting power, vote on pool strategies, deposit single-sided liquidity into auto-managed vaults, and claim oHYDX rewards. |
 | [Helixa](https://helixa.xyz) | [helixa](helixa/) | Onchain identity and reputation for AI agents on Base. Mint identity NFTs, check Cred Scores, verify social accounts, update traits/narrative, and query the agent directory. Supports SIWA auth and x402 micropayments. |
+| [Polygon](https://polygon.technology) | [trails](trails/) | Cross-chain swap, bridge, and DeFi orchestration via Sequence. Swap tokens across chains, bridge assets, fund a Bankr wallet from any chain, deposit into yield vaults (Aave, Morpho), get token prices, and discover earn pools. Integrates with Bankr submit() for on-chain execution. |
 
 ## Adding a Skill
 


### PR DESCRIPTION
## Summary

- Adds [Trails](https://github.com/BankrBot/skills/tree/main/trails) by Polygon to the README available skills table
- Follows the existing table format used for other skills

## Test plan

- [ ] Verify the row renders correctly in the README
- [ ] Confirm the link to `trails/` directory works

🤖 Generated with [Claude Code](https://claude.com/claude-code)