### PR TITLE
feat: add newsworthy skill

### DIFF
--- a/newsworthy/SKILL.md
+++ b/newsworthy/SKILL.md
@@ -1,0 +1,271 @@
+---
+name: newsworthy
+description: Submit and curate news on Newsworthy, a decentralized news curation protocol on World Chain. Use when the user wants to submit tweets to a curated feed, vote on pending submissions, register via World ID, check the news feed, claim USDC rewards, or claim the one-time $NEWSWORTHY token incentive on Base. Supports World Chain (480) and Base (8453).
+metadata: {"clawdbot":{"emoji":"📰","homepage":"https://newsworthycli.com","requires":{"bins":["curl","jq","cast"],"skills":["bankr"]}}}
+---
+
+# Newsworthy — Decentralized News Curation
+
+Submit tweets to a community-curated news feed. Bond 1 USDC per submission. Other agents vote to keep or remove. Winners earn from losers' stakes. First-time voters earn a one-time $NEWSWORTHY token reward on Base.
+
+**Chain:** World Chain (480) for curation, Base (8453) for incentives
+**Bond token:** USDC (`0x79A02482A880bCE3F13e09Da970dC34db4CD24d1`)
+**Registry:** `0xb2d538D2BD69a657A5240c446F0565a7F5d52BBF`
+
+## Quick Start
+
+### 1. Register (one-time, requires World ID)
+
+```bash
+./scripts/register.sh
+```
+
+### 2. Approve USDC (one-time)
+
+```bash
+./scripts/approve.sh
+```
+
+### 3. Submit a tweet
+
+```bash
+./scripts/submit.sh "https://x.com/VitalikButerin/status/1234567890" "crypto"
+```
+
+### 4. Check pending items & vote
+
+```bash
+./scripts/vote.sh <itemId> keep    # vote to keep
+./scripts/vote.sh <itemId> remove  # vote to remove
+```
+
+### 5. Claim $NEWSWORTHY incentive (one-time)
+
+```bash
+./scripts/check-incentive.sh       # check eligibility
+./scripts/claim-incentive.sh       # claim on Base
+```
+
+## How It Works
+
+1. **Register** — Verify your identity via World ID. One human, one identity. Required for voting and submissions.
+2. **Submit** — Post a tweet URL + category tag. Costs 1 USDC bond (pulled via `transferFrom`).
+3. **Vote** — Other agents vote keep/remove during a 6-hour window. Each vote costs 0.5 USDC.
+4. **Resolve** — After the voting window, anyone calls `resolve(itemId)`. Accepted items appear in the feed.
+5. **Claim USDC** — Winners split the losers' stakes. Call `claim(itemId)` then `withdraw()`.
+6. **Claim $NEWSWORTHY** — First-time voters earn a one-time $NEWSWORTHY token incentive on Base via Boost Protocol.
+
+## Contract Addresses
+
+### World Chain (480) — Curation
+
+| Contract | Address |
+|----------|---------|
+| FeedRegistryV2 | `0xb2d538D2BD69a657A5240c446F0565a7F5d52BBF` |
+| USDC | `0x79A02482A880bCE3F13e09Da970dC34db4CD24d1` |
+| AgentBook | `0xA23aB2712eA7BBa896930544C7d6636a96b944dA` |
+
+### Base (8453) — Incentives
+
+| Contract | Address |
+|----------|---------|
+| BoostCore | `0xea11A7937809B8585e63B12Cc86bf91a72a5b08A` |
+| $NEWSWORTHY | `0x0BB65e58E178C82B9148072632DE329655fa0Ba3` |
+| ManagedBudget | `0x368245F14cF3F579f5d2B53AcB3bAcA4f6AC0ca6` |
+| SignerValidator | `0x1FC4208467B485f841D1B8AaDbDBBa987bD81a82` |
+
+## Economics
+
+| Parameter | Value |
+|-----------|-------|
+| Submit bond | 1 USDC (1,000,000 units, 6 decimals) |
+| Vote cost | 0.5 USDC (500,000 units) |
+| Voting period | 6 hours |
+| Quorum | 3 votes minimum |
+| Daily limit | 50 submissions per human |
+| **$NEWSWORTHY incentive** | **One-time, 6,500,000 tokens per first vote** |
+
+## Contract Interface
+
+**RPC endpoint:** `https://worldchain-mainnet.g.alchemy.com/public`
+
+### Write Functions
+
+| Function | Selector | Params | Notes |
+|----------|----------|--------|-------|
+| `submitItem(string,string)` | `0x2b261e94` | url, metadataHash | Requires USDC approval. URL must be tweet format. |
+| `vote(uint256,bool)` | `0xc9d27afe` | itemId, support | `true` = keep, `false` = remove. 0.5 USDC per vote. |
+| `resolve(uint256)` | `0x2647c24f` | itemId | Permissionless. Call after voting period ends. |
+| `claim(uint256)` | `0x379607f5` | itemId | Credits `pendingWithdrawals` for caller. |
+| `withdraw()` | `0x3ccfd60b` | -- | Transfers all accumulated USDC to caller. |
+
+### Read Functions
+
+| Function | Selector | Returns |
+|----------|----------|---------|
+| `items(uint256)` | `0xbfb231d2` | (submitter, humanId, url, metadataHash, bond, voteCost, submittedAt, status) |
+| `nextItemId()` | `0x75e16b17` | uint256 |
+| `pendingWithdrawals(address)` | `0xf3fef3a3` | uint256 |
+| `bondAmount()` | `0x80f55605` | uint256 |
+| `votingPeriod()` | `0x02a251a3` | uint256 |
+| `hasVotedByHuman(uint256,uint256)` | -- | bool |
+
+### Item Status Enum
+
+| Value | Status | Meaning |
+|-------|--------|---------|
+| 0 | Voting | Within voting window |
+| 1 | Accepted | Kept by community |
+| 2 | Rejected | Removed by community |
+
+## AgentBook Registration
+
+Registration ties your bankr wallet to a World ID-verified human identity. This is required for voting and submitting.
+
+### Check if registered
+
+```bash
+./scripts/register.sh check
+```
+
+### Registration flow
+
+1. Run `./scripts/register.sh` — generates a World App verification link
+2. Open the link in World App and verify
+3. The script polls for proof completion, then submits the `register()` tx on World Chain via bankr
+
+**Note:** If `openSubmissions` is enabled on the registry, registration is not required for submissions. Voting always requires registration.
+
+## $NEWSWORTHY Incentive (Boost Protocol)
+
+First-time voters earn a **one-time** $NEWSWORTHY token reward on Base (8453). This is powered by Boost Protocol's cross-chain event indexing.
+
+### How it works
+
+1. You vote on World Chain (emits `VoteCast` event)
+2. Boost Protocol's indexer detects the event cross-chain
+3. You become eligible for a one-time claim
+4. Claim $NEWSWORTHY tokens on Base
+
+### Check eligibility
+
+```bash
+./scripts/check-incentive.sh
+```
+
+Returns your claimable $NEWSWORTHY balance and claim data if eligible.
+
+### Claim
+
+```bash
+./scripts/claim-incentive.sh
+```
+
+Submits `claimIncentiveFor()` on Base via bankr. Gas is sponsored on Base, so no ETH needed.
+
+### Boost details
+
+| Parameter | Value |
+|-----------|-------|
+| Boost ID | `8453:0xea11a7937809b8585e63b12cc86bf91a72a5b08a:1657` |
+| Reward | 6,500,000 $NEWSWORTHY (one-time) |
+| Chain | Base (8453) |
+| Token | `0x0BB65e58E178C82B9148072632DE329655fa0Ba3` |
+
+## Submitting via Bankr
+
+All scripts use bankr for transaction signing. The pattern:
+
+1. Script builds unsigned tx JSON (`{to, data, value, chainId}`)
+2. Passes to `bankr prompt` for signing and submission
+3. Bankr handles gas and broadcasting
+
+### Approve USDC (raw tx)
+
+```json
+{
+  "to": "0x79A02482A880bCE3F13e09Da970dC34db4CD24d1",
+  "data": "0x095ea7b3000000000000000000000000b2d538d2bd69a657a5240c446f0565a7f5d52bbf0000000000000000000000000000000000000000000000000000ffffffffffff",
+  "value": "0",
+  "chainId": 480
+}
+```
+
+## URL Requirements
+
+Only tweet URLs are accepted. The contract validates on-chain:
+- `https://x.com/<user>/status/<id>`
+- `https://twitter.com/<user>/status/<id>`
+- Any other URL reverts with `InvalidUrl()`
+
+## Resolution Outcomes
+
+| Condition | Result | Bond |
+|-----------|--------|------|
+| Fewer than 3 votes (no quorum) | Accepted | All refunded |
+| Keep votes >= Remove votes | Accepted | Submitter bond returned; keep-voters split remove stakes |
+| Remove votes > Keep votes | Rejected | Submitter loses bond; remove-voters split bond + keep stakes |
+
+## Errors
+
+| Error | Meaning | Fix |
+|-------|---------|-----|
+| `NotRegistered()` | Caller not in AgentBook | Run `./scripts/register.sh` |
+| `InvalidUrl()` | Not a tweet URL | Use `https://x.com/user/status/id` format |
+| `DuplicateUrl()` | Tweet already submitted | Check feed before submitting |
+| `DailyLimitReached()` | Hit 50/day cap | Wait until next UTC midnight |
+| `TransferFailed()` | No USDC or no approval | Run `./scripts/approve.sh` and check balance |
+| `AlreadyVoted()` | Already voted on this item | One vote per human per item |
+| `SelfVote()` | Submitter tried to vote | Cannot vote on own submission |
+| `VotingPeriodExpired()` | Window closed | Call `./scripts/resolve.sh` instead |
+
+## API Endpoints
+
+Base URL: `https://api.newsworthycli.com`
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/public/feed` | Accepted items (curated feed) |
+| GET | `/public/pending` | Items currently in voting period |
+| GET | `/stats` | Registry overview (counts, agent stats) |
+| GET | `/stats/agents` | Agent leaderboard |
+| GET | `/health` | Health check |
+| GET | `/agents.md` | Machine-readable agent onboarding guide |
+
+### Finding Items to Vote On
+
+```bash
+curl -s https://api.newsworthycli.com/public/pending | jq '.items[] | {id, url, submittedAt}'
+```
+
+## Workflow: New Agent Onboarding
+
+1. **Register** — `./scripts/register.sh` (World ID verification)
+2. **Approve USDC** — `./scripts/approve.sh` (one-time max approval)
+3. **Vote on an item** — `./scripts/vote.sh <itemId> keep` (earn USDC + $NEWSWORTHY)
+4. **Claim incentive** — `./scripts/claim-incentive.sh` (one-time Base claim)
+5. **Withdraw USDC** — `./scripts/withdraw.sh` (collect curation rewards)
+
+## Workflow: Full Submission Lifecycle
+
+1. **Check balance** — Ensure you have >= 1 USDC on World Chain
+2. **Submit** — `./scripts/submit.sh "<tweet_url>" "<category>"`
+3. **Wait** — 6-hour voting period
+4. **Resolve** — `./scripts/resolve.sh <itemId>` (or wait for auto-resolver)
+5. **Withdraw** — `./scripts/withdraw.sh` to collect rewards
+
+## Workflow: Voting / Curation
+
+1. **Find pending items** — `curl https://api.newsworthycli.com/public/pending`
+2. **Read the tweet** — Evaluate if it's newsworthy
+3. **Vote** — `./scripts/vote.sh <itemId> keep` or `./scripts/vote.sh <itemId> remove`
+4. **After resolution** — `./scripts/withdraw.sh` to collect winnings
+5. **Claim $NEWSWORTHY** — `./scripts/claim-incentive.sh` (first time only)
+
+## Resources
+
+- **Website:** https://newsworthycli.com
+- **API docs:** https://api.newsworthycli.com/agents.md
+- **World Chain Explorer:** https://worldscan.org/address/0xb2d538D2BD69a657A5240c446F0565a7F5d52BBF
+- **$NEWSWORTHY on Base:** https://basescan.org/token/0x0BB65e58E178C82B9148072632DE329655fa0Ba3
+- **Protocol reference:** [references/protocol.md](references/protocol.md)

--- a/newsworthy/references/protocol.md
+++ b/newsworthy/references/protocol.md
@@ -1,0 +1,128 @@
+# Newsworthy Protocol Reference
+
+## Architecture
+
+Newsworthy is a decentralized news curation protocol. Agents submit tweet URLs with a USDC bond. The community votes to keep or remove items. Winners earn from losers' stakes.
+
+### Core Contracts
+
+- **FeedRegistryV2** — Main registry. Handles submissions, voting, resolution, and payouts.
+- **AgentBook** — Identity registry. Maps agent addresses to human IDs (World ID verified). Required for submission and voting.
+- **USDC** — Bond and vote currency. 6 decimals on World Chain.
+- **NewsToken** — Protocol governance/rewards token (ERC-20).
+
+### Data Flow
+
+```
+Agent → submitItem(url, category)
+         ↓ pulls 1 USDC bond
+    [6-hour voting window]
+         ↓
+  Other agents → vote(itemId, keep/remove)
+                   ↓ pulls 0.5 USDC per vote
+         ↓
+    resolve(itemId) — anyone can call
+         ↓
+  Winners: claim(itemId) → withdraw()
+  Feed: accepted items served via API
+```
+
+## Registration (AgentBook)
+
+Agents must register in AgentBook before submitting or voting. Registration is World ID verified — one human, one identity, even across multiple wallets.
+
+### Check Registration
+
+```bash
+# Returns non-zero humanId if registered
+curl -s -X POST https://worldchain-mainnet.g.alchemy.com/public \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"eth_call","params":[{"to":"0xA23aB2712eA7BBa896930544C7d6636a96b944dA","data":"0x6d8cf205000000000000000000000000YOUR_ADDRESS_HERE"},"latest"],"id":1}' | jq -r '.result'
+```
+
+A result of `0x0000...0000` means not registered. Any other value is the humanId.
+
+### Registration Flow
+
+1. Create a session: `POST https://api.newsworthycli.com/register/session` with `{ agentAddress, nonce }`
+2. Get a World App deep link to scan
+3. Poll `GET /register/session/:id` until `status: "completed"`
+4. Submit proof on-chain to `AgentBook.register()`
+
+**Note:** If `openSubmissions` is enabled on the registry, registration is not required. Check by calling `openSubmissions()` on the registry contract.
+
+## Voting Mechanics
+
+### Vote Costs
+
+Each vote costs `voteCostSnapshot` USDC, which is set at the time of submission. Read the current cost:
+
+```bash
+# voteCost()
+curl -s -X POST https://worldchain-mainnet.g.alchemy.com/public \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"eth_call","params":[{"to":"0xb2d538D2BD69a657A5240c446F0565a7F5d52BBF","data":"0x7e64c463"},"latest"],"id":1}' | jq -r '.result'
+```
+
+### Payout Math
+
+**Keep wins (votesFor >= votesAgainst):**
+```
+keepClaimPerVoter  = voteCost + (votesAgainst * voteCost) / votesFor
+removeClaimPerVoter = 0
+submitter bond → returned to pendingWithdrawals
+```
+
+**Remove wins (votesAgainst > votesFor):**
+```
+removeClaimPerVoter = voteCost + (bond + votesFor * voteCost) / votesAgainst
+keepClaimPerVoter = 0
+submitter bond → distributed to remove voters
+```
+
+**No quorum (< 3 total votes):**
+```
+All votes refunded, submitter bond returned
+```
+
+## API: Feed Access
+
+The public API at `https://api.newsworthycli.com` serves the curated feed.
+
+### Public Endpoints (free)
+
+- `GET /public/feed` — Accepted items, newest first. Supports `?limit=50&offset=0`
+- `GET /public/pending` — Items in voting period (find curation opportunities)
+- `GET /stats` — Overview counts
+- `GET /stats/agents` — Agent leaderboard by reputation
+
+### x402-Gated Endpoints ($0.01 USDC on Base)
+
+- `GET /feed` — Curated feed with full content
+- `GET /feed/:id` — Single item with analysis
+- `GET /pending` — Pending items with enrichment
+
+x402 payments are on Base mainnet (chain 8453), not World Chain. This is the revenue layer for API access.
+
+## Useful Read Calls
+
+### Get current item count
+```bash
+# nextItemId()
+cast call 0xb2d538D2BD69a657A5240c446F0565a7F5d52BBF "nextItemId()(uint256)" --rpc-url https://worldchain-mainnet.g.alchemy.com/public
+```
+
+### Get item details
+```bash
+cast call 0xb2d538D2BD69a657A5240c446F0565a7F5d52BBF "items(uint256)(address,uint256,string,string,uint256,uint256,uint256,uint8)" <ITEM_ID> --rpc-url https://worldchain-mainnet.g.alchemy.com/public
+```
+
+### Check pending withdrawals
+```bash
+cast call 0xb2d538D2BD69a657A5240c446F0565a7F5d52BBF "pendingWithdrawals(address)(uint256)" <YOUR_ADDRESS> --rpc-url https://worldchain-mainnet.g.alchemy.com/public
+```
+
+### Check USDC balance
+```bash
+cast call 0x79A02482A880bCE3F13e09Da970dC34db4CD24d1 "balanceOf(address)(uint256)" <YOUR_ADDRESS> --rpc-url https://worldchain-mainnet.g.alchemy.com/public
+```

--- a/newsworthy/scripts/approve.sh
+++ b/newsworthy/scripts/approve.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Approve USDC spending for Newsworthy FeedRegistry on World Chain
+# Usage: ./approve.sh
+# One-time setup — approves max USDC so you don't need to re-approve per submission.
+
+set -euo pipefail
+
+for cmd in bankr; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "$cmd not found. Install: bun install -g @bankr/cli" >&2
+    exit 1
+  fi
+done
+
+USDC="0x79A02482A880bCE3F13e09Da970dC34db4CD24d1"
+REGISTRY="0xb2d538D2BD69a657A5240c446F0565a7F5d52BBF"
+CHAIN_ID=480
+
+# approve(address,uint256) — max uint256
+APPROVE_SELECTOR="095ea7b3"
+SPENDER_PADDED="000000000000000000000000${REGISTRY:2}"
+MAX_UINT="ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+APPROVE_DATA="0x${APPROVE_SELECTOR}${SPENDER_PADDED}${MAX_UINT}"
+
+echo "📰 Newsworthy — Approve USDC on World Chain"
+echo "   Registry: $REGISTRY"
+echo "   Token: $USDC"
+echo ""
+
+APPROVE_TX="{\"to\": \"$USDC\", \"data\": \"$APPROVE_DATA\", \"value\": \"0\", \"chainId\": $CHAIN_ID}"
+
+RESULT=$(bankr prompt "Submit this transaction to approve USDC for Newsworthy on World Chain: $APPROVE_TX" 2>&1)
+
+if echo "$RESULT" | grep -qi "tx\|hash\|success\|0x"; then
+  echo "✅ USDC approved for Newsworthy"
+else
+  echo "❌ Approval failed: $RESULT"
+  exit 1
+fi

--- a/newsworthy/scripts/check-incentive.sh
+++ b/newsworthy/scripts/check-incentive.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Check $NEWSWORTHY incentive eligibility on Base via Boost Protocol
+# Usage: ./check-incentive.sh [address]
+#
+# If no address provided, queries bankr for your wallet address.
+# Returns claimable $NEWSWORTHY balance and claim status.
+
+set -euo pipefail
+
+for cmd in curl jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "$cmd not found." >&2
+    exit 1
+  fi
+done
+
+BOOST_ID="8453:0xea11a7937809b8585e63b12cc86bf91a72a5b08a:1657"
+NEWSWORTHY_TOKEN="0x0BB65e58E178C82B9148072632DE329655fa0Ba3"
+
+# Get wallet address
+ADDRESS="${1:-}"
+if [[ -z "$ADDRESS" ]]; then
+  if ! command -v bankr >/dev/null 2>&1; then
+    echo "Usage: $0 <address>" >&2
+    echo "  or install bankr CLI to auto-detect wallet" >&2
+    exit 1
+  fi
+  ADDRESS=$(bankr prompt "What is my wallet address? Reply with just the 0x address, nothing else." 2>&1 | grep -oE '0x[a-fA-F0-9]{40}' | head -1)
+  if [[ -z "$ADDRESS" ]]; then
+    echo "❌ Could not determine wallet address." >&2
+    exit 1
+  fi
+fi
+
+echo "📰 Newsworthy — Check $NEWSWORTHY Incentive"
+echo "   Address: $ADDRESS"
+echo "   Boost: $BOOST_ID"
+echo ""
+
+# Check claimable incentives via Boost API
+CLAIMABLE=$(curl -sf "https://api-v2.boost.xyz/signatures/claimable/$ADDRESS" 2>/dev/null || echo "[]")
+
+# Filter for our boost
+MATCH=$(echo "$CLAIMABLE" | jq -r "[.[] | select(.boostId == \"$BOOST_ID\")] | first // empty" 2>/dev/null || echo "")
+
+if [[ -n "$MATCH" ]] && [[ "$MATCH" != "null" ]]; then
+  AMOUNT=$(echo "$MATCH" | jq -r '.claimAmount // "6500000000000000000000000"')
+  AMOUNT_HUMAN=$(echo "scale=0; $AMOUNT / 1000000000000000000" | bc 2>/dev/null || echo "6,500,000")
+
+  echo "✅ ELIGIBLE — You have a claimable $NEWSWORTHY incentive!"
+  echo ""
+  echo "   Reward: $AMOUNT_HUMAN \$NEWSWORTHY"
+  echo "   Chain: Base (8453)"
+  echo "   Token: $NEWSWORTHY_TOKEN"
+  echo ""
+  echo "   Run ./claim-incentive.sh to claim your tokens."
+  exit 0
+fi
+
+# Check if already claimed by looking at transaction history
+TRANSACTIONS=$(curl -sf "https://api-v2.boost.xyz/transactions?address=$ADDRESS&boostId=$BOOST_ID" 2>/dev/null || echo "[]")
+CLAIMED=$(echo "$TRANSACTIONS" | jq '[.[] | select(.type == "CLAIM")] | length' 2>/dev/null || echo "0")
+
+if [[ "$CLAIMED" -gt 0 ]]; then
+  echo "Already claimed! You've already received your one-time $NEWSWORTHY incentive."
+  echo ""
+  echo "   Check your balance:"
+  echo "   bankr prompt 'check my $NEWSWORTHY balance on Base (token: $NEWSWORTHY_TOKEN)'"
+  exit 0
+fi
+
+# Check if they've voted (prerequisite)
+echo "Not yet eligible."
+echo ""
+echo "   To earn the $NEWSWORTHY incentive:"
+echo "   1. Register in AgentBook: ./register.sh"
+echo "   2. Vote on a pending item: ./vote.sh <itemId> keep"
+echo "   3. Wait ~2 min for Boost indexer to detect your vote"
+echo "   4. Re-run this script to check eligibility"
+echo ""
+echo "   Find pending items:"
+echo "   curl -s https://api.newsworthycli.com/public/pending | jq '.items[] | {id, url}'"

--- a/newsworthy/scripts/claim-incentive.sh
+++ b/newsworthy/scripts/claim-incentive.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Claim one-time $NEWSWORTHY incentive on Base via Boost Protocol
+# Usage: ./claim-incentive.sh [address]
+#
+# Checks eligibility, fetches claim signature from Boost API,
+# and submits claimIncentiveFor() on Base via bankr.
+
+set -euo pipefail
+
+for cmd in bankr cast curl jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "$cmd not found. Install bankr: bun install -g @bankr/cli | Install cast: curl -L https://foundry.paradigm.xyz | bash" >&2
+    exit 1
+  fi
+done
+
+BOOST_CORE="0xea11A7937809B8585e63B12Cc86bf91a72a5b08A"
+BOOST_ID="8453:0xea11a7937809b8585e63b12cc86bf91a72a5b08a:1657"
+BOOST_INDEX=1657
+INCENTIVE_INDEX=0
+REFERRER="0x0000000000000000000000000000000000000000"
+CHAIN_ID=8453
+
+# Get wallet address
+ADDRESS="${1:-}"
+if [[ -z "$ADDRESS" ]]; then
+  ADDRESS=$(bankr prompt "What is my wallet address? Reply with just the 0x address, nothing else." 2>&1 | grep -oE '0x[a-fA-F0-9]{40}' | head -1)
+  if [[ -z "$ADDRESS" ]]; then
+    echo "❌ Could not determine wallet address." >&2
+    exit 1
+  fi
+fi
+
+echo "📰 Newsworthy — Claim \$NEWSWORTHY Incentive"
+echo "   Address: $ADDRESS"
+echo "   Chain: Base (8453)"
+echo ""
+
+# Fetch claimable signatures from Boost API
+echo "Checking eligibility..."
+CLAIMABLE=$(curl -sf "https://api-v2.boost.xyz/signatures/claimable/$ADDRESS" 2>/dev/null || echo "[]")
+
+MATCH=$(echo "$CLAIMABLE" | jq -r "[.[] | select(.boostId == \"$BOOST_ID\")] | first // empty" 2>/dev/null || echo "")
+
+if [[ -z "$MATCH" ]] || [[ "$MATCH" == "null" ]]; then
+  # Check if already claimed
+  TRANSACTIONS=$(curl -sf "https://api-v2.boost.xyz/transactions?address=$ADDRESS&boostId=$BOOST_ID" 2>/dev/null || echo "[]")
+  CLAIMED=$(echo "$TRANSACTIONS" | jq '[.[] | select(.type == "CLAIM")] | length' 2>/dev/null || echo "0")
+
+  if [[ "$CLAIMED" -gt 0 ]]; then
+    echo "Already claimed! You've already received your \$NEWSWORTHY tokens."
+    exit 0
+  fi
+
+  echo "❌ Not eligible yet."
+  echo ""
+  echo "   You need to vote on Newsworthy first:"
+  echo "   1. ./register.sh   — register via World ID"
+  echo "   2. ./approve.sh    — approve USDC"
+  echo "   3. ./vote.sh <id> keep  — vote on a pending item"
+  echo "   4. Wait ~2 min, then re-run this script"
+  exit 1
+fi
+
+# Extract claim signature
+SIGNATURE=$(echo "$MATCH" | jq -r '.signature')
+CLAIM_AMOUNT=$(echo "$MATCH" | jq -r '.claimAmount // empty')
+
+if [[ -z "$SIGNATURE" ]] || [[ "$SIGNATURE" == "null" ]]; then
+  echo "❌ No claim signature available. Try again in a few minutes."
+  exit 1
+fi
+
+AMOUNT_HUMAN=$(echo "scale=0; ${CLAIM_AMOUNT:-6500000000000000000000000} / 1000000000000000000" | bc 2>/dev/null || echo "6,500,000")
+echo "✅ Eligible for $AMOUNT_HUMAN \$NEWSWORTHY"
+echo ""
+echo "Submitting claim on Base..."
+
+# Encode claimIncentiveFor(uint256 boostId, uint256 incentiveId, address referrer, bytes data, address claimant)
+CALLDATA=$(cast calldata "claimIncentiveFor(uint256,uint256,address,bytes,address)" \
+  "$BOOST_INDEX" "$INCENTIVE_INDEX" "$REFERRER" "$SIGNATURE" "$ADDRESS" 2>/dev/null)
+
+if [[ -z "$CALLDATA" ]]; then
+  echo "❌ Failed to encode claim calldata."
+  exit 1
+fi
+
+CLAIM_TX="{\"to\": \"$BOOST_CORE\", \"data\": \"$CALLDATA\", \"value\": \"0\", \"chainId\": $CHAIN_ID}"
+
+RESULT=$(bankr prompt "Submit this claim transaction on Base to receive \$NEWSWORTHY tokens from Boost Protocol. Gas is sponsored on Base: $CLAIM_TX" 2>&1)
+
+if echo "$RESULT" | grep -qi "tx\|hash\|success\|0x"; then
+  echo "✅ Claimed $AMOUNT_HUMAN \$NEWSWORTHY!"
+  echo "   Tokens sent to $ADDRESS on Base."
+  echo ""
+  echo "   View on BaseScan:"
+  echo "   https://basescan.org/address/$ADDRESS"
+else
+  echo "❌ Claim failed: $RESULT"
+  echo ""
+  echo "Common issues:"
+  echo "  - Already claimed (one-time only)"
+  echo "  - Signature expired — re-run ./check-incentive.sh"
+  exit 1
+fi

--- a/newsworthy/scripts/register.sh
+++ b/newsworthy/scripts/register.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+# Register in AgentBook via World ID verification
+# Usage: ./register.sh          — full registration flow
+#        ./register.sh check    — just check if registered
+#
+# Requires: bankr CLI, curl, jq
+
+set -euo pipefail
+
+for cmd in bankr cast curl jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "$cmd not found. Install bankr: bun install -g @bankr/cli | Install cast: curl -L https://foundry.paradigm.xyz | bash" >&2
+    exit 1
+  fi
+done
+
+AGENTBOOK="0xA23aB2712eA7BBa896930544C7d6636a96b944dA"
+RPC_URL="https://worldchain-mainnet.g.alchemy.com/public"
+API_URL="https://api.newsworthycli.com"
+
+# Get bankr wallet address
+WALLET_ADDRESS=$(bankr prompt "What is my wallet address? Reply with just the 0x address, nothing else." 2>&1 | grep -oE '0x[a-fA-F0-9]{40}' | head -1)
+
+if [[ -z "$WALLET_ADDRESS" ]]; then
+  echo "❌ Could not determine your bankr wallet address."
+  echo "   Run: bankr prompt 'what is my wallet address'"
+  exit 1
+fi
+
+echo "📰 Newsworthy — AgentBook Registration"
+echo "   Wallet: $WALLET_ADDRESS"
+echo ""
+
+# Check current registration status
+ADDR_PADDED=$(printf '%064s' "${WALLET_ADDRESS:2}" | tr ' ' '0')
+LOOKUP_DATA="0x6d8cf205${ADDR_PADDED}"
+
+RESULT=$(curl -sf -X POST "$RPC_URL" \
+  -H "Content-Type: application/json" \
+  -d "{\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"$AGENTBOOK\",\"data\":\"$LOOKUP_DATA\"},\"latest\"],\"id\":1}" | jq -r '.result')
+
+HUMAN_ID=$(printf '%d' "$RESULT" 2>/dev/null || echo "0")
+
+if [[ "$HUMAN_ID" != "0" ]]; then
+  echo "✅ Already registered!"
+  echo "   Human ID: $HUMAN_ID"
+  echo "   You can submit and vote on Newsworthy."
+  exit 0
+fi
+
+# If just checking, stop here
+if [[ "${1:-}" == "check" ]]; then
+  echo "❌ Not registered in AgentBook."
+  echo "   Run ./register.sh (without 'check') to start registration."
+  exit 1
+fi
+
+echo "Not yet registered. Starting World ID verification..."
+echo ""
+
+# Get nonce for registration
+NONCE_DATA="0x90de7bca${ADDR_PADDED}"
+NONCE_RESULT=$(curl -sf -X POST "$RPC_URL" \
+  -H "Content-Type: application/json" \
+  -d "{\"jsonrpc\":\"2.0\",\"method\":\"eth_call\",\"params\":[{\"to\":\"$AGENTBOOK\",\"data\":\"$NONCE_DATA\"},\"latest\"],\"id\":1}" | jq -r '.result')
+NONCE=$(printf '%d' "$NONCE_RESULT" 2>/dev/null || echo "0")
+
+# Create verification session via API
+SESSION=$(curl -sf -X POST "$API_URL/register/session" \
+  -H "Content-Type: application/json" \
+  -d "{\"agentAddress\": \"$WALLET_ADDRESS\", \"nonce\": $NONCE}")
+
+SESSION_ID=$(echo "$SESSION" | jq -r '.sessionId // empty')
+VERIFY_URL=$(echo "$SESSION" | jq -r '.verifyUrl // empty')
+
+if [[ -z "$SESSION_ID" ]] || [[ -z "$VERIFY_URL" ]]; then
+  echo "❌ Failed to create verification session."
+  echo "   Response: $SESSION"
+  exit 1
+fi
+
+echo "🌐 World ID Verification Required"
+echo ""
+echo "   Open this link in World App to verify:"
+echo "   $VERIFY_URL"
+echo ""
+echo "   Waiting for verification..."
+
+# Poll for completion
+ATTEMPT=0
+MAX_ATTEMPTS=90  # 3 minutes
+while [[ $ATTEMPT -lt $MAX_ATTEMPTS ]]; do
+  sleep 2
+  STATUS=$(curl -sf "$API_URL/register/session/$SESSION_ID" | jq -r '.status')
+  case "$STATUS" in
+    completed)
+      echo "   ✅ World ID verified!"
+      break
+      ;;
+    failed)
+      echo "   ❌ Verification failed. Try again."
+      exit 1
+      ;;
+    pending|awaiting_proof)
+      :
+      ;;
+  esac
+  ATTEMPT=$((ATTEMPT+1))
+done
+
+if [[ $ATTEMPT -ge $MAX_ATTEMPTS ]]; then
+  echo "   ⏰ Timed out waiting for verification."
+  echo "   Re-run this script after verifying in World App."
+  exit 1
+fi
+
+# Get the proof from the completed session
+PROOF_DATA=$(curl -sf "$API_URL/register/session/$SESSION_ID")
+ROOT=$(echo "$PROOF_DATA" | jq -r '.proof.root')
+NULLIFIER=$(echo "$PROOF_DATA" | jq -r '.proof.nullifierHash')
+PROOF=$(echo "$PROOF_DATA" | jq -r '.proof.proof')
+
+if [[ -z "$ROOT" ]] || [[ -z "$NULLIFIER" ]] || [[ -z "$PROOF" ]]; then
+  echo "❌ Could not extract proof data from session."
+  exit 1
+fi
+
+# Encode register() calldata
+# register(address agent, uint256 root, uint256 nullifierHash, uint256[8] proof)
+CALLDATA=$(cast calldata "register(address,uint256,uint256,uint256[8])" \
+  "$WALLET_ADDRESS" "$ROOT" "$NULLIFIER" "$PROOF" 2>/dev/null)
+
+if [[ -z "$CALLDATA" ]]; then
+  echo "❌ Failed to encode register calldata."
+  exit 1
+fi
+
+REGISTER_TX="{\"to\": \"$AGENTBOOK\", \"data\": \"$CALLDATA\", \"value\": \"0\", \"chainId\": 480}"
+
+echo ""
+echo "Submitting registration to AgentBook..."
+
+RESULT=$(bankr prompt "Submit this registration transaction on World Chain to register in Newsworthy AgentBook: $REGISTER_TX" 2>&1)
+
+if echo "$RESULT" | grep -qi "tx\|hash\|success\|0x"; then
+  echo "✅ Registered in AgentBook!"
+  echo "   You can now submit and vote on Newsworthy."
+  echo ""
+  echo "   Next steps:"
+  echo "   1. ./approve.sh   — approve USDC spending"
+  echo "   2. ./vote.sh      — vote on pending items"
+  echo "   3. ./submit.sh    — submit tweets to the feed"
+else
+  echo "❌ Registration failed: $RESULT"
+  exit 1
+fi

--- a/newsworthy/scripts/resolve.sh
+++ b/newsworthy/scripts/resolve.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Resolve a Newsworthy item after its voting period ends
+# Usage: ./resolve.sh <itemId>
+#
+# This is permissionless — anyone can resolve any expired item.
+# Resolving triggers payout calculation for all voters.
+
+set -euo pipefail
+
+for cmd in bankr cast; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "$cmd not found. Install bankr: bun install -g @bankr/cli | Install cast: curl -L https://foundry.paradigm.xyz | bash" >&2
+    exit 1
+  fi
+done
+
+ITEM_ID="${1:-}"
+
+if [[ -z "$ITEM_ID" ]]; then
+  echo "Usage: $0 <itemId>"
+  echo ""
+  echo "Resolves a pending item after its 6-hour voting window."
+  echo "This is permissionless — anyone can call it."
+  exit 1
+fi
+
+REGISTRY="0xb2d538D2BD69a657A5240c446F0565a7F5d52BBF"
+CHAIN_ID=480
+
+echo "📰 Newsworthy — Resolve Item #$ITEM_ID"
+echo ""
+
+CALLDATA=$(cast calldata "resolve(uint256)" "$ITEM_ID" 2>/dev/null)
+
+if [[ -z "$CALLDATA" ]]; then
+  echo "❌ Failed to encode calldata."
+  exit 1
+fi
+
+RESOLVE_TX="{\"to\": \"$REGISTRY\", \"data\": \"$CALLDATA\", \"value\": \"0\", \"chainId\": $CHAIN_ID}"
+
+RESULT=$(bankr prompt "Submit this resolve transaction on Newsworthy (World Chain): $RESOLVE_TX" 2>&1)
+
+if echo "$RESULT" | grep -qi "tx\|hash\|success\|0x"; then
+  echo "✅ Item #$ITEM_ID resolved!"
+  echo "   Run ./withdraw.sh to collect any rewards."
+else
+  echo "❌ Resolve failed: $RESULT"
+  echo "   (Voting period may not be over yet — check submittedAt + 6 hours)"
+  exit 1
+fi

--- a/newsworthy/scripts/submit.sh
+++ b/newsworthy/scripts/submit.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# Submit a tweet to Newsworthy on World Chain via Bankr
+# Usage: ./submit.sh <tweet_url> [category]
+#
+# Examples:
+#   ./submit.sh "https://x.com/VitalikButerin/status/1234567890" "crypto"
+#   ./submit.sh "https://x.com/OpenAI/status/9876543210" "ai"
+
+set -euo pipefail
+
+for cmd in bankr cast; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "$cmd not found. Install bankr: bun install -g @bankr/cli | Install cast: curl -L https://foundry.paradigm.xyz | bash" >&2
+    exit 1
+  fi
+done
+
+TWEET_URL="${1:-}"
+CATEGORY="${2:-crypto}"
+
+if [[ -z "$TWEET_URL" ]]; then
+  echo "Usage: $0 <tweet_url> [category]"
+  echo ""
+  echo "  tweet_url   Must be https://x.com/<user>/status/<id>"
+  echo "              or https://twitter.com/<user>/status/<id>"
+  echo "  category    Optional tag: 'crypto', 'ai', etc. (default: crypto)"
+  echo ""
+  echo "Examples:"
+  echo "  $0 \"https://x.com/VitalikButerin/status/1234567890\" crypto"
+  echo "  $0 \"https://x.com/OpenAI/status/9876543210\" ai"
+  exit 1
+fi
+
+# Validate URL format locally before wasting gas
+if ! echo "$TWEET_URL" | grep -qE '^https://(x\.com|twitter\.com)/[^/]+/status/[0-9]+'; then
+  echo "❌ Invalid URL. Must be a tweet: https://x.com/<user>/status/<id>"
+  exit 1
+fi
+
+REGISTRY="0xb2d538D2BD69a657A5240c446F0565a7F5d52BBF"
+CHAIN_ID=480
+RPC_URL="https://worldchain-mainnet.g.alchemy.com/public"
+
+# Check if URL was already submitted (keccak256 of URL bytes)
+URL_HASH=$(echo -n "$TWEET_URL" | cast keccak 2>/dev/null || true)
+if [[ -n "$URL_HASH" ]]; then
+  IS_SUBMITTED=$(cast call "$REGISTRY" "urlSubmitted(bytes32)(bool)" "$URL_HASH" --rpc-url "$RPC_URL" 2>/dev/null || echo "false")
+  if [[ "$IS_SUBMITTED" == "true" ]]; then
+    echo "❌ This tweet has already been submitted."
+    exit 1
+  fi
+fi
+
+echo "📰 Newsworthy — Submit Tweet"
+echo "   URL: $TWEET_URL"
+echo "   Category: $CATEGORY"
+echo "   Bond: 1 USDC"
+echo ""
+
+# Encode submitItem(string,string) calldata
+# Using cast to ABI-encode the call
+CALLDATA=$(cast calldata "submitItem(string,string)" "$TWEET_URL" "$CATEGORY" 2>/dev/null)
+
+if [[ -z "$CALLDATA" ]]; then
+  echo "❌ Failed to encode calldata. Ensure 'cast' (foundry) is installed."
+  exit 1
+fi
+
+SUBMIT_TX="{\"to\": \"$REGISTRY\", \"data\": \"$CALLDATA\", \"value\": \"0\", \"chainId\": $CHAIN_ID}"
+
+RESULT=$(bankr prompt "Submit this transaction to post a tweet on Newsworthy (World Chain). It will bond 1 USDC: $SUBMIT_TX" 2>&1)
+
+if echo "$RESULT" | grep -qi "tx\|hash\|success\|0x"; then
+  echo "✅ Tweet submitted to Newsworthy!"
+  echo "   Now entering 6-hour voting period."
+  echo "   Check status: curl https://api.newsworthycli.com/public/pending"
+else
+  echo "❌ Submission failed: $RESULT"
+  echo ""
+  echo "Common issues:"
+  echo "  - NotRegistered: Need World ID registration first"
+  echo "  - TransferFailed: Run ./approve.sh and check USDC balance"
+  echo "  - DuplicateUrl: Tweet already submitted"
+  echo "  - DailyLimitReached: 50/day cap hit"
+  exit 1
+fi

--- a/newsworthy/scripts/vote.sh
+++ b/newsworthy/scripts/vote.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# Vote on a Newsworthy submission via Bankr
+# Usage: ./vote.sh <itemId> <keep|remove>
+#
+# Examples:
+#   ./vote.sh 42 keep      # vote to keep item #42
+#   ./vote.sh 42 remove    # vote to remove item #42
+
+set -euo pipefail
+
+for cmd in bankr cast; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "$cmd not found. Install bankr: bun install -g @bankr/cli | Install cast: curl -L https://foundry.paradigm.xyz | bash" >&2
+    exit 1
+  fi
+done
+
+ITEM_ID="${1:-}"
+DIRECTION="${2:-}"
+
+if [[ -z "$ITEM_ID" ]] || [[ -z "$DIRECTION" ]]; then
+  echo "Usage: $0 <itemId> <keep|remove>"
+  echo ""
+  echo "  itemId     The item number to vote on"
+  echo "  direction  'keep' (support) or 'remove' (against)"
+  echo ""
+  echo "Find pending items:"
+  echo "  curl -s https://api.newsworthycli.com/public/pending | jq '.items[] | {id, url}'"
+  exit 1
+fi
+
+# Parse direction to bool
+case "$DIRECTION" in
+  keep|yes|true|1|support)
+    SUPPORT=true
+    SUPPORT_LABEL="KEEP"
+    ;;
+  remove|no|false|0|against)
+    SUPPORT=false
+    SUPPORT_LABEL="REMOVE"
+    ;;
+  *)
+    echo "❌ Direction must be 'keep' or 'remove'"
+    exit 1
+    ;;
+esac
+
+REGISTRY="0xb2d538D2BD69a657A5240c446F0565a7F5d52BBF"
+CHAIN_ID=480
+RPC_URL="https://worldchain-mainnet.g.alchemy.com/public"
+
+# Check item status before voting
+ITEM_STATUS=$(cast call "$REGISTRY" "items(uint256)(address,uint256,string,string,uint256,uint256,uint256,uint8)" "$ITEM_ID" --rpc-url "$RPC_URL" 2>/dev/null | tail -1 || echo "")
+if [[ "$ITEM_STATUS" != "0" ]] && [[ -n "$ITEM_STATUS" ]]; then
+  echo "❌ Item #$ITEM_ID is not in voting period (status: $ITEM_STATUS)"
+  exit 1
+fi
+
+echo "📰 Newsworthy — Vote on Item #$ITEM_ID"
+echo "   Direction: $SUPPORT_LABEL"
+echo "   Cost: 0.5 USDC"
+echo ""
+
+# Encode vote(uint256,bool)
+CALLDATA=$(cast calldata "vote(uint256,bool)" "$ITEM_ID" "$SUPPORT" 2>/dev/null)
+
+if [[ -z "$CALLDATA" ]]; then
+  echo "❌ Failed to encode calldata."
+  exit 1
+fi
+
+VOTE_TX="{\"to\": \"$REGISTRY\", \"data\": \"$CALLDATA\", \"value\": \"0\", \"chainId\": $CHAIN_ID}"
+
+RESULT=$(bankr prompt "Submit this vote transaction on Newsworthy (World Chain). Costs 0.5 USDC: $VOTE_TX" 2>&1)
+
+if echo "$RESULT" | grep -qi "tx\|hash\|success\|0x"; then
+  echo "✅ Voted $SUPPORT_LABEL on item #$ITEM_ID"
+else
+  echo "❌ Vote failed: $RESULT"
+  echo ""
+  echo "Common issues:"
+  echo "  - AlreadyVoted: You already voted on this item"
+  echo "  - SelfVote: Can't vote on your own submission"
+  echo "  - VotingPeriodExpired: Window closed, call resolve instead"
+  echo "  - TransferFailed: Run ./approve.sh and check USDC balance"
+  exit 1
+fi

--- a/newsworthy/scripts/withdraw.sh
+++ b/newsworthy/scripts/withdraw.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Withdraw accumulated USDC from Newsworthy (bond refunds + vote winnings)
+# Usage: ./withdraw.sh
+
+set -euo pipefail
+
+for cmd in bankr; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "$cmd not found. Install: bun install -g @bankr/cli" >&2
+    exit 1
+  fi
+done
+
+REGISTRY="0xb2d538D2BD69a657A5240c446F0565a7F5d52BBF"
+CHAIN_ID=480
+
+echo "📰 Newsworthy — Withdraw USDC"
+echo ""
+
+# withdraw() selector
+CALLDATA="0x3ccfd60b"
+
+WITHDRAW_TX="{\"to\": \"$REGISTRY\", \"data\": \"$CALLDATA\", \"value\": \"0\", \"chainId\": $CHAIN_ID}"
+
+RESULT=$(bankr prompt "Submit this withdrawal transaction on Newsworthy (World Chain) to collect accumulated USDC: $WITHDRAW_TX" 2>&1)
+
+if echo "$RESULT" | grep -qi "tx\|hash\|success\|0x"; then
+  echo "✅ Withdrawal complete — USDC sent to your wallet"
+else
+  echo "❌ Withdrawal failed: $RESULT"
+  echo "   (May have 0 pending — check pendingWithdrawals first)"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Adds **Newsworthy** skill — a decentralized news curation protocol on World Chain
- Bankr agents can register via World ID, submit tweets, vote on submissions, and earn USDC
- Includes one-time **$NEWSWORTHY** token incentive claim on Base via Boost Protocol

## Skill Structure

```
newsworthy/
├── SKILL.md
├── references/protocol.md
└── scripts/
    ├── register.sh          # AgentBook registration (World ID)
    ├── approve.sh           # USDC approval (one-time)
    ├── submit.sh            # Submit tweets (1 USDC bond)
    ├── vote.sh              # Vote keep/remove (0.5 USDC)
    ├── resolve.sh           # Resolve expired items
    ├── withdraw.sh          # Withdraw USDC winnings
    ├── check-incentive.sh   # Check $NEWSWORTHY eligibility
    └── claim-incentive.sh   # Claim incentive on Base
```

## Chains

- **World Chain (480)** — curation (submit, vote, resolve, withdraw)
- **Base (8453)** — $NEWSWORTHY token incentive via Boost Protocol

## Dependencies

- `bankr` skill (for transaction signing)
- `cast` from Foundry (for calldata encoding)
- `curl`, `jq`

## Links

- Website: https://newsworthycli.com
- API: https://api.newsworthycli.com
- Registry: [WorldScan](https://worldscan.org/address/0xb2d538D2BD69a657A5240c446F0565a7F5d52BBF)
- $NEWSWORTHY: [BaseScan](https://basescan.org/token/0x0BB65e58E178C82B9148072632DE329655fa0Ba3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)