### PR TITLE
Add World Chain, Arbitrum, and BNB Chain to bankr skill docs

### DIFF
--- a/bankr/SKILL.md
+++ b/bankr/SKILL.md
@@ -555,13 +555,16 @@ For full details — setup paths, model list, provider config, SDK examples, key
 
 ## Supported Chains
 
-| Chain    | Native Token | Best For                      | Gas Cost |
-| -------- | ------------ | ----------------------------- | -------- |
-| Base     | ETH          | Memecoins, general trading    | Very Low |
-| Polygon  | MATIC        | Gaming, NFTs, frequent trades | Very Low |
-| Ethereum | ETH          | Blue chips, high liquidity    | High     |
-| Solana   | SOL          | High-speed trading            | Minimal  |
-| Unichain | ETH          | Newer L2 option               | Very Low |
+| Chain       | Native Token | Best For                      | Gas Cost |
+| ----------- | ------------ | ----------------------------- | -------- |
+| Base        | ETH          | Memecoins, general trading    | Very Low |
+| Polygon     | POL          | Gaming, NFTs, frequent trades | Very Low |
+| Ethereum    | ETH          | Blue chips, high liquidity    | High     |
+| Solana      | SOL          | High-speed trading            | Minimal  |
+| Unichain    | ETH          | Newer L2 option               | Very Low |
+| World Chain | ETH          | Uniswap V3/V4 swaps          | Very Low |
+| Arbitrum    | ETH          | DeFi, low-cost transactions   | Very Low |
+| BNB Chain   | BNB          | BSC ecosystem trading         | Low      |
 
 ## Safety & Access Control
 

--- a/bankr/references/agent-profiles.md
+++ b/bankr/references/agent-profiles.md
@@ -12,7 +12,7 @@ Create and manage public profile pages at [bankr.bot/agents](https://bankr.bot/a
 | **description** | No | Project description | Max 2000 chars |
 | **profileImageUrl** | No | Logo/avatar URL (auto-populated from Twitter if linked) | Valid URL |
 | **tokenAddress** | Yes | Token contract address — must be a token deployed through Bankr (Doppler or Clanker) | - |
-| **tokenChainId** | No | Chain: base, ethereum, polygon, solana (default: base) | - |
+| **tokenChainId** | No | Chain: base, ethereum, polygon, solana, worldchain, arbitrum, bnb (default: base) | - |
 | **tokenSymbol** | No | Token ticker symbol | Max 20 chars |
 | **tokenName** | No | Full token name | Max 100 chars |
 | **twitterUsername** | No | Twitter handle (auto-populated from linked account) | Max 50 chars |

--- a/bankr/references/portfolio.md
+++ b/bankr/references/portfolio.md
@@ -36,7 +36,7 @@ The `/wallet/portfolio` endpoint is a read endpoint — any valid API key with a
 
 ## Supported Chains
 
-All chains: Base, Polygon, Ethereum, Unichain, Solana
+All chains: Base, Polygon, Ethereum, Unichain, Solana, World Chain, Arbitrum, BNB Chain
 
 ## Prompt Examples
 

--- a/bankr/references/transfers.md
+++ b/bankr/references/transfers.md
@@ -31,8 +31,8 @@ The `/wallet/transfer` endpoint is a write endpoint — requires `walletApiEnabl
 
 ## Supported Transfers
 
-- **EVM Chains**: Base, Polygon, Ethereum (mainnet), Unichain
-  - Native tokens: ETH, MATIC
+- **EVM Chains**: Base, Polygon, Ethereum (mainnet), Unichain, World Chain, Arbitrum, BNB Chain
+  - Native tokens: ETH, POL, BNB
   - ERC20 tokens: USDC, USDT, WETH, etc.
 - **Solana**: SOL and SPL tokens
 


### PR DESCRIPTION
## Summary

- Add World Chain, Arbitrum, and BNB Chain to the supported chains table in `bankr/SKILL.md`
- Update chain lists in `references/portfolio.md`, `references/transfers.md`, and `references/agent-profiles.md`
- Fix Polygon native token from MATIC to POL to match CLI config

These chains are already fully configured in the bankr CLI and agent — the skills docs were the only place missing them.

## Test plan

- [ ] Verify the supported chains table in SKILL.md renders correctly
- [ ] Confirm chain slugs in agent-profiles.md match the CLI's `VALID_CHAINS` set

https://claude.ai/code/session_014gCG9F2L3Vqa12da32X4e4