### PR TITLE
feat: add blueagent-rewards skill

### DIFF
--- a/blueagent-rewards/SKILL.md
+++ b/blueagent-rewards/SKILL.md
@@ -89,8 +89,15 @@ const claim = await rewards.claim(userId, walletAddress)
 ## Fee Model
 
 Every claim is split automatically onchain:
+
+**Without `creatorAddress`:**
 - **95%** → user wallet
-- **5%** → Blue Agent treasury (burn + ecosystem)
+- **5%** → Blue Agent treasury
+
+**With `creatorAddress`:**
+- **92%** → user wallet
+- **3%** → agent creator (you earn this)
+- **5%** → Blue Agent treasury
 
 ## Links
 


### PR DESCRIPTION
## Blue Agent Rewards Skill 🟦

Plug-and-play $BLUEAGENT token rewards for any Telegram bot or AI agent on Base.

**What it does:**
- Award points for check-in, trivia, referral, project submission
- Claim $BLUEAGENT onchain with auto fee split
- Activity tier system: Builder → Shipper → Founder → Legend (×1.0 to ×2.0)
- Agent builders earn 3% of every claim via `creatorAddress`
- TypeScript + ethers.js v6 + JSON storage

**Fee split:**
- Without creator: 95% user / 5% treasury
- With `creatorAddress`: 92% user / 3% creator / 5% treasury

**Install:**
```bash
npm install github:madebyshun/blue-agent-rewards-skill
```

**Token:** `0xf895783b2931c919955e18b5e3343e7c7c456ba3` on Base · Uniswap v4

**Repo:** https://github.com/madebyshun/blue-agent-rewards-skill
**Live bot using this skill:** @Blockyagent_beta_bot
**Community:** t.me/blueagent_hub