### PR TITLE
docs: weekly update — Hyperliquid, rehype pools, new chains & models

### DIFF
--- a/bankr/SKILL.md
+++ b/bankr/SKILL.md
@@ -546,7 +546,7 @@ For full details — setup paths, model list, provider config, SDK examples, key
 
 - **EVM (Base)**: Deploy ERC20 tokens via Clanker with customizable metadata and social links
 - **Solana**: Launch SPL tokens via Raydium LaunchLab with bonding curve and auto-migration to CPMM
-- Rehype (decay) pools: 95% creator fees on standard deploys, 57% on partner deploys
+- Rehype (decay) pools: 95% creator fees, 5% protocol fee
 - Creator fee claiming on both chains
 - Fee Key NFTs for Solana (50% LP trading fees post-migration)
 - Optional fee recipient designation with 99.9%/0.1% split (Solana)
@@ -676,20 +676,6 @@ bankr agent prompt "What tokens are trending on Base?"
 # Compare tokens
 bankr agent prompt "Compare ETH vs SOL"
 ```
-
-## Partner API
-
-The Partner API enables programmatic wallet provisioning for platforms integrating Bankr. Partners authenticate via `x-partner-key` header with keys in the format `bk_ptr_{keyId}_{secret}`.
-
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/partner/wallets` | POST | Provision a new Bankr wallet for an end-user |
-| `/partner/wallets` | GET | List all wallets provisioned by this partner |
-| `/partner/wallets/:identifier` | GET | Look up wallet by public ID, EVM, or Solana address |
-| `/partner/wallets/:identifier/api-key` | POST | Generate a user API key for a provisioned wallet |
-| `/partner/wallets/:identifier/api-key` | DELETE | Revoke a wallet's API key |
-
-Partner capabilities are scoped per organization: `walletApi`, `agentApi`, `llmGatewayApi`, `tokenLaunchApi`. All partner keys are SHA-256 hashed at rest.
 
 ## API Workflow
 

--- a/bankr/SKILL.md
+++ b/bankr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bankr
-description: AI-powered crypto trading agent, wallet API, and LLM gateway via natural language. Use when the user wants to trade crypto, check portfolio balances (with PnL and NFTs), view token prices, search tokens, transfer crypto, manage NFTs, use leverage, bet on Polymarket, deploy tokens, set up automated trading, sign and submit raw transactions, or access LLM models through the Bankr LLM gateway funded by your Bankr wallet. Supports Base, Ethereum, Polygon, Solana, and Unichain.
+description: AI-powered crypto trading agent, wallet API, and LLM gateway via natural language. Use when the user wants to trade crypto, check portfolio balances (with PnL and NFTs), view token prices, search tokens, transfer crypto, manage NFTs, use leverage, trade perpetuals on Hyperliquid, bet on Polymarket, deploy tokens, set up automated trading, sign and submit raw transactions, or access LLM models through the Bankr LLM gateway funded by your Bankr wallet. Supports Base, Ethereum, Polygon, Solana, Unichain, World Chain, Arbitrum, BNB Chain, and Hyperliquid.
 metadata:
   {
     "clawdbot":
@@ -310,6 +310,8 @@ CLI 0.2.0 organizes commands into three namespaces: `wallet`, `agent`, and `toke
 | `bankr config get [key]` | Get config value(s) |
 | `bankr config set <key> <value>` | Set a config value |
 | `bankr --config <path> <command>` | Use a custom config file path |
+| `bankr update` | Check for and install CLI updates from npm |
+| `bankr update --check` | Check for available updates without installing |
 
 Valid config keys: `apiKey`, `apiUrl`, `llmKey`, `llmUrl`
 
@@ -527,16 +529,30 @@ For full details — setup paths, model list, provider config, SDK examples, key
 
 **Reference**: [references/leverage-trading.md](references/leverage-trading.md)
 
+### Hyperliquid Trading
+
+- Perpetual futures on 200+ crypto assets, stocks (TSLA, AAPL, NVDA), and commodities
+- Spot trading on Hyperliquid-native tokens (HYPE, PURR, etc.)
+- Up to 50x leverage with isolated or cross margin
+- Take profit / stop loss on new and existing positions
+- Limit orders on perps and spot
+- Bridge USDC from Arbitrum (and other EVM chains) to Hyperliquid
+- Internal transfers between spot and perps accounts
+- Order management: modify, cancel, update leverage/margin
+
+**Reference**: [references/hyperliquid.md](references/hyperliquid.md)
+
 ### Token Deployment
 
 - **EVM (Base)**: Deploy ERC20 tokens via Clanker with customizable metadata and social links
 - **Solana**: Launch SPL tokens via Raydium LaunchLab with bonding curve and auto-migration to CPMM
+- Rehype (decay) pools: 95% creator fees on standard deploys, 57% on partner deploys
 - Creator fee claiming on both chains
 - Fee Key NFTs for Solana (50% LP trading fees post-migration)
 - Optional fee recipient designation with 99.9%/0.1% split (Solana)
 - Both creator AND fee recipient can claim bonding curve fees (gas sponsored)
 - Optional vesting parameters (Solana)
-- Rate limits: 1/day standard, 10/day Bankr Club (gas sponsored within limits)
+- Rate limits: 50/day standard, 100/day Bankr Club (gas sponsored within daily limits)
 
 **Reference**: [references/token-deployment.md](references/token-deployment.md)
 
@@ -569,8 +585,9 @@ For full details — setup paths, model list, provider config, SDK examples, key
 | Solana      | SOL          | High-speed trading            | Minimal  |
 | Unichain    | ETH          | Newer L2 option               | Very Low |
 | World Chain | ETH          | Uniswap V3/V4 swaps          | Very Low |
-| Arbitrum    | ETH          | DeFi, low-cost transactions   | Very Low |
+| Arbitrum    | ETH          | DeFi, low-cost transactions   | Very Low (gas sponsored) |
 | BNB Chain   | BNB          | BSC ecosystem trading         | Low      |
+| Hyperliquid | USDC         | Perps, spot, stocks (HIP-3)   | Minimal  |
 
 ## Safety & Access Control
 
@@ -660,6 +677,20 @@ bankr agent prompt "What tokens are trending on Base?"
 bankr agent prompt "Compare ETH vs SOL"
 ```
 
+## Partner API
+
+The Partner API enables programmatic wallet provisioning for platforms integrating Bankr. Partners authenticate via `x-partner-key` header with keys in the format `bk_ptr_{keyId}_{secret}`.
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/partner/wallets` | POST | Provision a new Bankr wallet for an end-user |
+| `/partner/wallets` | GET | List all wallets provisioned by this partner |
+| `/partner/wallets/:identifier` | GET | Look up wallet by public ID, EVM, or Solana address |
+| `/partner/wallets/:identifier/api-key` | POST | Generate a user API key for a provisioned wallet |
+| `/partner/wallets/:identifier/api-key` | DELETE | Revoke a wallet's API key |
+
+Partner capabilities are scoped per organization: `walletApi`, `agentApi`, `llmGatewayApi`, `tokenLaunchApi`. All partner keys are SHA-256 hashed at rest.
+
 ## API Workflow
 
 Bankr uses an asynchronous job-based API:
@@ -698,8 +729,9 @@ Common issues and fixes:
 - **Authentication errors** → Run `bankr login` or check `bankr whoami` (CLI), or verify your `X-API-Key` header (REST API)
 - **Insufficient balance** → Add funds or reduce amount
 - **Token not found** → Verify symbol and chain
-- **Transaction reverted** → Check parameters and balances
+- **Transaction reverted** → Check parameters and balances; swap failures now return descriptive error messages (gas insufficiency, on-chain reverts)
 - **Rate limiting** → Wait and retry
+- **Gas insufficient** → Add native tokens to cover gas fees; gas is sponsored on Base, Polygon, Unichain, and Arbitrum (up to 10 tx/day)
 
 For comprehensive error troubleshooting, setup instructions, and debugging steps, see:
 
@@ -804,6 +836,17 @@ See [references/safety.md](references/safety.md) for comprehensive safety guidan
 - "Open 5x long on ETH with $100"
 - "Short BTC 10x with stop loss at $45k"
 - "Show my Avantis positions"
+
+### Hyperliquid
+
+- "Long $100 of BTC on hyperliquid with 10x"
+- "Short ETH on hyperliquid with 5x leverage"
+- "Buy $50 of HYPE on hyperliquid"
+- "Show my hyperliquid positions"
+- "Close my BTC position on hyperliquid"
+- "Set take profit at $70000 on my BTC position"
+- "Deposit $500 USDC to hyperliquid"
+- "What's the funding rate for SOL on hyperliquid?"
 
 ### Automation
 

--- a/bankr/references/llm-gateway.md
+++ b/bankr/references/llm-gateway.md
@@ -53,9 +53,11 @@ bankr config get llmKey
 | `gpt-5.2-codex` | OpenAI | Code generation |
 | `gpt-5.4-mini` | OpenAI | Fast, economical (400K context, image input) |
 | `gpt-5.4-nano` | OpenAI | Ultra-fast, lowest cost (400K context, image input) |
+| `minimax-m2.5` | MiniMax | Cost-effective (204.8K context) |
 | `minimax-m2.7` | MiniMax | Balanced performance (204.8K context) |
 | `kimi-k2.5` | Moonshot AI | Long-context reasoning |
 | `qwen3-coder` | Alibaba | Code generation, debugging |
+| `glm-5-turbo` | Z.ai | Fast, large context (202K tokens) |
 
 ```bash
 # Fetch live model list from the gateway

--- a/bankr/references/safety.md
+++ b/bankr/references/safety.md
@@ -120,6 +120,7 @@ Manage API key settings at [bankr.bot/api](https://bankr.bot/api):
 |-------|------|-------------|
 | `readOnly` | boolean | When true, only read tools are available |
 | `allowedIps` | string[] | IP whitelist (empty = all allowed) |
+| `allowedRecipients` | string[] | Restrict transfer recipients to specific EVM/Solana addresses |
 | `walletApiEnabled` | boolean | Whether `/wallet/*` write endpoints are accessible |
 | `agentApiEnabled` | boolean | Whether `/agent/*` AI endpoints are accessible |
 | `tokenLaunchApiEnabled` | boolean | Whether token deployment is accessible |
@@ -197,12 +198,15 @@ When building autonomous agents that execute transactions, use a **separate Bank
 
 Fund the agent wallet with enough for gas and intended operations, not more:
 
-| Chain | Gas Buffer | Trading Capital |
-|-------|-----------|-----------------|
-| Base | 0.01 - 0.05 ETH | As needed for trades |
-| Polygon | 5 - 10 MATIC | As needed for trades |
-| Ethereum | 0.05 - 0.1 ETH | As needed for trades |
-| Solana | 0.1 - 0.5 SOL | As needed for trades |
+| Chain | Gas Buffer | Trading Capital | Gas Sponsored |
+|-------|-----------|-----------------|---------------|
+| Base | 0.01 - 0.05 ETH | As needed for trades | Yes |
+| Polygon | 5 - 10 MATIC | As needed for trades | Yes |
+| Ethereum | 0.05 - 0.1 ETH | As needed for trades | No |
+| Solana | 0.1 - 0.5 SOL | As needed for trades | No |
+| Arbitrum | 0.01 - 0.05 ETH | As needed for trades | Yes |
+| World Chain | 0.01 - 0.05 ETH | As needed for trades | No |
+| BNB Chain | 0.01 - 0.05 BNB | As needed for trades | No |
 
 Replenish periodically rather than pre-loading large amounts.
 

--- a/bankr/references/token-deployment.md
+++ b/bankr/references/token-deployment.md
@@ -229,25 +229,12 @@ Deploy ERC20 tokens on Base and Unichain using Clanker or Doppler (rehype pools)
 
 ### Fee Structure (Doppler Rehype Pools)
 
-**Standard deploys (non-partner):**
-
 | Share | Recipient | Description |
 |-------|-----------|-------------|
 | 95% | Creator | Creator trading fees |
 | 5% | Protocol | Protocol fee |
 
 Rehype pools route the Bankr share to a buyback mechanism instead of direct beneficiary splits. Pool fee is 0.7%.
-
-**Partner deploys (without custom split):**
-
-| Share | Recipient | Description |
-|-------|-----------|-------------|
-| 57% | Creator | Creator trading fees |
-| 36.1% | Bankr | Platform fee |
-| 1.9% | Bankr Ecosystem | Ecosystem fund |
-| 5% | Protocol | Protocol fee |
-
-**Partner deploys (with custom split):** Fully custom fee splits override all defaults.
 
 ### Fee Structure (Clanker)
 

--- a/bankr/references/token-deployment.md
+++ b/bankr/references/token-deployment.md
@@ -6,7 +6,7 @@ Deploy and manage tokens on EVM chains (via Clanker) and Solana (via Raydium Lau
 
 | Chain | Protocol | Token Standard | Best For |
 |-------|----------|----------------|----------|
-| **Base** | Clanker | ERC20 | Memecoins, social tokens |
+| **Base** | Clanker / Doppler (rehype) | ERC20 | Memecoins, social tokens |
 | **Unichain** | Clanker | ERC20 | Lower fees, newer ecosystem |
 | **Solana** | Raydium LaunchLab | SPL | High-speed trading, bonding curves |
 
@@ -178,16 +178,16 @@ Shared fee claims are always sponsored to ensure atomic claim+transfer.
 
 | User Type | Daily Limit | Gas Sponsored |
 |-----------|-------------|---------------|
-| Standard Users | Unlimited | 1 token/day |
-| Bankr Club Members | Unlimited | 10 tokens/day |
+| Standard Users | 50 tokens/day | Yes (within limits) |
+| Bankr Club Members | 100 tokens/day | Yes (within limits) |
 
 Users can launch additional tokens beyond sponsored limits by paying ~0.01 SOL gas.
 
 ---
 
-## EVM Token Launches (Clanker)
+## EVM Token Launches (Clanker / Doppler)
 
-Deploy ERC20 tokens on Base and Unichain using Clanker.
+Deploy ERC20 tokens on Base and Unichain using Clanker or Doppler (rehype pools).
 
 ### Deployment Parameters
 
@@ -224,14 +224,37 @@ Deploy ERC20 tokens on Base and Unichain using Clanker.
 
 | User Type | Daily Limit |
 |-----------|-------------|
-| Standard Users | 1 token/day |
-| Bankr Club Members | 10 tokens/day |
+| Standard Users | 50 tokens/day |
+| Bankr Club Members | 100 tokens/day |
 
-### Fee Structure
+### Fee Structure (Doppler Rehype Pools)
+
+**Standard deploys (non-partner):**
+
+| Share | Recipient | Description |
+|-------|-----------|-------------|
+| 95% | Creator | Creator trading fees |
+| 5% | Protocol | Protocol fee |
+
+Rehype pools route the Bankr share to a buyback mechanism instead of direct beneficiary splits. Pool fee is 0.7%.
+
+**Partner deploys (without custom split):**
+
+| Share | Recipient | Description |
+|-------|-----------|-------------|
+| 57% | Creator | Creator trading fees |
+| 36.1% | Bankr | Platform fee |
+| 1.9% | Bankr Ecosystem | Ecosystem fund |
+| 5% | Protocol | Protocol fee |
+
+**Partner deploys (with custom split):** Fully custom fee splits override all defaults.
+
+### Fee Structure (Clanker)
 
 - Small fee on each trade, accumulated for token creator
 - Claimable anytime via "Claim fees for my token"
 - Legacy fees (older Clanker versions) claimed separately
+- `transfer_fee_recipient` tool works for both Clanker and Doppler tokens
 
 ### Chain Selection
 


### PR DESCRIPTION
## Summary

Weekly skill update for Bankr (Mar 22–29, 2026).

### Key changes:

- **Hyperliquid trading** — New capabilities section, supported chain entry, and prompt examples for perps/spot/stocks trading on Hyperliquid L1
- **Rehype (decay) pools** — Updated token deployment fee structure: 95% creator / 5% protocol
- **New LLM models** — Added `glm-5-turbo` (Z.ai, 202K context) and `minimax-m2.5` to gateway model list
- **Gas sponsorship** — Arbitrum now gas-sponsored; added sponsorship column to safety funding table
- **New chains in funding table** — Arbitrum, World Chain, BNB Chain added to safety reference
- **CLI updates** — Added `bankr update` / `bankr update --check` self-update command
- **Token deploy limits** — Updated to 50/day standard, 100/day Bankr Club
- **Error handling** — Added descriptive swap failure messages and gas insufficiency guidance
- **Access control** — Added `allowedRecipients` field to safety reference

### Files changed:
- `bankr/SKILL.md` — Description, capabilities, supported chains, CLI commands, prompt examples, error handling
- `bankr/references/llm-gateway.md` — New models (glm-5-turbo, minimax-m2.5)
- `bankr/references/token-deployment.md` — Rehype fee structure, updated rate limits, Doppler support
- `bankr/references/safety.md` — Funding table with new chains + gas sponsorship, allowedRecipients

## Test plan
- [ ] Verify SKILL.md renders correctly with new sections
- [ ] Confirm model list matches live `bankr llm models` output
- [ ] Validate fee percentages

https://claude.ai/code/session_011v9y1Lk4NqQC3NWHxgkbwe