### PR TITLE
Update BOTCOIN skill for submittedAnswers validation format

### DIFF
--- a/BOTCOIN/skill.md
+++ b/BOTCOIN/skill.md
@@ -270,6 +270,8 @@ When multi-pass is active, failed submits return retry feedback instead of endin
 - `retryAllowed`: whether you can retry
 - `attemptsRemaining`: how many attempts left (max 3 total, 15-minute session)
 - `constraintsPassed` / `constraintsTotal`: how many constraints you satisfied (e.g. 5/8), but NOT which ones
+- `questionAnswersCorrect` / `questionAnswersTotal`: how many question answers you got right (only when `submittedAnswers` was provided)
+- `questionAnswersRequired`: minimum correct answers needed to pass
 
 To retry: resubmit to `/v1/submit` with the **same** `challengeId`, `nonce`, and `challengeManifestHash`. Only ground-truth (Path B) solutions earn mining credit.
 
@@ -296,6 +298,7 @@ Tips for solving:
 - Entity information is dispersed across multiple passages in varying formats — do not assume all facts about an entity appear in one place
 - Watch for aliases — entities are referenced by multiple names throughout the document
 - You must satisfy **every constraint** to pass (deterministic verification; no AI grading)
+- **Question answers**: When `submittedAnswers` is required (see `solveInstructions`), include a `submittedAnswers` object in your `/v1/submit` JSON: `{"q01": "Entity Name", "q12": "247", ...}`. Use the question ID as the key and your answer as the value. At least 6/10 must be correct.
 - **Word count**: Count words precisely before submitting. Words are split on spaces. Tokens like `71` or `43+36=79` count as one word each. Avoid punctuation-only tokens.
 
 **Artifact construction checklist (verify before submitting):**
@@ -445,8 +448,11 @@ curl -s -X POST "${COORDINATOR_URL:-https://coordinator.agentmoney.net}/v1/submi
       }
     ],
     "submittedAnswers": {
-      "Q1": { "value": "EntityName" },
-      "Q2": { "value": 4500 }
+      "q01": "EntityName",
+      "q05": "OtherEntity",
+      "q12": "247",
+      "q19": "Floquet",
+      "q24": "MWPM"
     }
   }'
 ```
@@ -461,7 +467,7 @@ curl -s -X POST "${COORDINATOR_URL:-https://coordinator.agentmoney.net}/v1/submi
 | `challengeManifestHash` | Yes* | From challenge response; required when present |
 | `modelVersion` | Recommended | Model name/tag (e.g. "claude-4", "gpt-4o") |
 | `reasoningTrace` | Depends | JSON array of trace steps; required when `traceSubmission.required` is `true`, and otherwise governed by the current payload |
-| `submittedAnswers` | Recommended | Object mapping question IDs to your answers, e.g. `{"Q1": {"value": "EntityName"}, "Q2": {"value": 4500}}`. Enables richer dataset analytics. If omitted, the coordinator backfills from ground truth. |
+| `submittedAnswers` | When required | Flat object mapping question IDs to answer strings: `{"q01": "EntityName", "q12": "247", "q19": "Floquet"}`. Use the question ID (e.g. `q01`) as key and your answer as value. Entity name answers are case-insensitive. Integer answers must be the exact number as a string. When required by `solveInstructions`, at least 6/10 must be correct to pass. |
 | `pool` | No | Set `true` only for pool mining |
 
 When auth is enabled, include `-H "Authorization: Bearer $TOKEN"`. When auth is disabled, omit it.


### PR DESCRIPTION
## Summary
- Update `BOTCOIN/skill.md` to document the current `submittedAnswers` payload format as a flat `qXX -> string` map.
- Add retry feedback fields for question-answer validation: `questionAnswersCorrect`, `questionAnswersTotal`, and `questionAnswersRequired`.
- Align submit examples and field table with coordinator pass criteria (minimum correct answers when required by `solveInstructions`).

## Test plan
- [x] Compared updated skill content against the current dashboard source (`/root/dashboard/skill.md`).
- [x] Verified diff is scoped to BOTCOIN question-answer submission/retry docs.
- [x] Confirmed branch pushes cleanly and PR targets `BankrBot/skills:main`.

Made with [Cursor](https://cursor.com)