### PR TITLE
Add Quorum and Capture the Bag skills - onchain games by 1999 Labs

### DIFF
--- a/capturethebag/SKILL.md
+++ b/capturethebag/SKILL.md
@@ -1,0 +1,141 @@
+# Capture the Bag Agent Skill
+
+## What this game is
+An onchain game on Base. One bag. One holder. Pay ETH to capture it.
+Hold it for 24 hours with no other captures to win 95% of the pot.
+
+## Contract
+- Address: 0xCc4D523206b0d4C11fc96dcb7173a3A7fcC38428
+- Network: Base Mainnet (chainId: 8453)
+- RPC: https://mainnet.base.org
+- ABI: GET https://capturethebag.wtf/api/abi
+
+## How to play
+
+### Step 1 — Read game state
+GET https://capturethebag.wtf/api/state
+
+Returns:
+- holder: current bag holder address
+- capturePrice: current capture cost in wei
+- pot: total pot in wei
+- lastCaptureTime: unix timestamp of last capture
+- windowExpiresAt: unix timestamp when current holder wins
+- roundNumber: current round
+- captureCount: captures this round
+- canClaim: true if 24h window has passed and claimWinnings() can be called
+- roundActive: false if waiting for first capture of new round
+
+Alternatively, call getGameState() directly on the contract:
+```json
+{
+  "name": "getGameState",
+  "type": "function",
+  "stateMutability": "view",
+  "inputs": [],
+  "outputs": [
+    { "name": "holder", "type": "address" },
+    { "name": "capturePrice", "type": "uint256" },
+    { "name": "potAmount", "type": "uint256" },
+    { "name": "lastCapture", "type": "uint256" },
+    { "name": "windowExpiresAt", "type": "uint256" },
+    { "name": "round", "type": "uint256" },
+    { "name": "captures", "type": "uint256" },
+    { "name": "canClaim", "type": "bool" }
+  ]
+}
+```
+
+### Step 2 — Decide whether to capture
+Capture is rational when:
+- capturePrice is within your budget
+- pot * 0.95 > capturePrice (positive EV if you hold to win)
+- You believe you can hold for 24 hours (or outlast current competition)
+
+### Step 3 — Capture the bag
+Call capture(address referrer) on the contract.
+- referrer: pass any active player address from recent BagCaptured events, or address(0)
+- msg.value: must be >= capturePrice (exact or slight overage — excess is refunded)
+- Self-referral is blocked at contract level
+
+ABI for capture:
+```json
+{
+  "name": "capture",
+  "type": "function",
+  "inputs": [{"name": "referrer", "type": "address"}],
+  "outputs": [],
+  "stateMutability": "payable"
+}
+```
+
+### Step 4 — Monitor your position
+Poll GET /api/state every 60 seconds.
+If holder changes to a different address, you have been captured.
+Re-evaluate whether to recapture.
+
+### Step 5 — Claim winnings
+If canClaim is true and you are the holder, call claimWinnings().
+This pays out 95% of pot to you and holds 5% rollover for the next round.
+Anyone can call claimWinnings() — it is permissionless.
+
+ABI for claimWinnings:
+```json
+{
+  "name": "claimWinnings",
+  "type": "function",
+  "inputs": [],
+  "outputs": [],
+  "stateMutability": "nonpayable"
+}
+```
+
+## Events to monitor
+Subscribe to BagCaptured events for live game state without polling.
+Each event contains: newHolder, previousHolder, pricePaid, nextCapturePrice,
+captureCount, referrer, referralPaid, protocolPaid, addedToPot.
+
+```json
+{
+  "name": "BagCaptured",
+  "type": "event",
+  "inputs": [
+    { "name": "roundNumber", "type": "uint256", "indexed": true },
+    { "name": "newHolder", "type": "address", "indexed": true },
+    { "name": "previousHolder", "type": "address", "indexed": true },
+    { "name": "pricePaid", "type": "uint256", "indexed": false },
+    { "name": "nextCapturePrice", "type": "uint256", "indexed": false },
+    { "name": "captureCount", "type": "uint256", "indexed": false },
+    { "name": "referrer", "type": "address", "indexed": false },
+    { "name": "referralPaid", "type": "uint256", "indexed": false },
+    { "name": "protocolPaid", "type": "uint256", "indexed": false },
+    { "name": "addedToPot", "type": "uint256", "indexed": false }
+  ]
+}
+```
+
+## Referral strategy
+Pass the address of the most recent capturer as your referrer parameter.
+This gives them 5% of your capture fee and costs you nothing —
+the fee comes from your capture payment, not on top of it.
+The referral relationship is permanent — you will only pay this referrer once.
+
+## Fee structure
+- Protocol fee: 5% of capture price (every capture)
+- Referral fee: 5% of capture price (first capture by referred wallet only)
+- To pot: 90% with referral, 95% without
+- Winner payout: 95% of pot
+- Rollover to next round: 5% of pot
+
+## Price escalation
+Starting price is 0.01 ETH. Each capture multiplies the price by 1.15x.
+By capture #10 the price is ~0.035 ETH. By capture #20 it is ~0.142 ETH.
+By capture #30 it is ~0.579 ETH. The pot grows with each capture.
+
+## Quick reference
+| Action | Function | Value |
+|---|---|---|
+| Read state | getGameState() | — |
+| Capture | capture(address referrer) | >= capturePrice |
+| Claim win | claimWinnings() | — |
+| Check referrer | referredBy(address) | — |

--- a/capturethebag/references/strategy.md
+++ b/capturethebag/references/strategy.md
@@ -1,0 +1,115 @@
+# Capture the Bag — Strategy Reference
+
+## Core Game Theory
+
+CTB is a war of attrition with escalating stakes. Every capture makes the pot larger but makes the next capture more expensive. The winner is whoever is willing to pay a price nobody else will match — and then survive 24 hours unchallenged.
+
+The fundamental tension: the pot is most valuable when many players have contributed, but capturing when the price is high means you've spent the most to acquire a position everyone else wants to take from you.
+
+## Price Escalation Math
+
+Starting price: 0.01 ETH. Multiplier: 1.15x per capture.
+
+| Capture # | Price (ETH) | Cumulative pot (approx, 90% to pot) |
+|-----------|------------|--------------------------------------|
+| 1         | 0.010      | 0.009                                |
+| 5         | 0.017      | 0.061                                |
+| 10        | 0.035      | 0.175                                |
+| 15        | 0.071      | 0.424                                |
+| 20        | 0.142      | 0.914                                |
+| 25        | 0.289      | 1.832                                |
+| 30        | 0.579      | 3.532                                |
+
+The pot grows geometrically. By capture #30, the pot is ~3.5 ETH but the next capture costs ~0.58 ETH. The ratio of pot-to-capture-price stays roughly constant after the first few captures because both are growing at the same exponential rate.
+
+## EV Framework
+
+Simple EV at any moment:
+
+```
+EV = P(hold for 24h) × pot × 0.95 - capturePrice
+```
+
+The hard variable is P(hold for 24h) — the probability that nobody else captures within the next 24 hours after you.
+
+### Estimating P(hold)
+
+Factors that increase your hold probability:
+- **High capture price** — fewer agents/humans willing to pay the next increment
+- **Low game activity** — long gaps between recent captures suggest players are exhausted
+- **Time of day** — captures tend to cluster when humans are awake; a capture at 3am in the dominant timezone may face less competition
+- **Round age** — the longer a round has gone, the more sunk cost all players have. Late-round captures face opponents who've already spent and may be tapped out
+
+Factors that decrease your hold probability:
+- **Large pot relative to capture price** — a 3 ETH pot with a 0.1 ETH capture price is a screaming deal for anyone watching
+- **Many active wallets** — check `captureCount` and BagCaptured events to count unique players this round
+- **Short time between recent captures** — rapid capture velocity means the game is hot
+
+### Heuristic: The Exhaustion Threshold
+
+The game naturally reaches a point where the capture price exceeds most players' appetite. This is the exhaustion threshold — the price at which capture velocity drops sharply.
+
+Monitor capture timestamps via BagCaptured events. If the gap between captures is growing (e.g., 2 min → 10 min → 45 min → 3 hours), the game is approaching exhaustion. A capture just past the exhaustion threshold has the highest EV: the pot is large, and fewer opponents remain willing to pay the next price.
+
+## Strategies
+
+### Strategy 1: Sniper
+Wait until the game approaches exhaustion. Monitor capture velocity. When gaps between captures exceed several hours, capture once and hold. This minimizes your spend (one capture) and maximizes P(hold).
+
+**Risk:** Someone else snipes at the same moment. Two agents running this strategy will leapfrog each other, driving the price up further.
+
+**Best for:** Patient agents with limited budgets.
+
+### Strategy 2: Rapid Recapture
+If captured, immediately recapture at the new (higher) price. This signals aggression and may discourage opponents. The cost is high — you're paying escalating prices each time — but if it causes opponents to quit, you win the pot.
+
+**Risk:** An opponent running the same strategy creates a price spiral that benefits nobody except the eventual winner's wallet drain.
+
+**Best for:** Agents with larger budgets in low-competition rounds.
+
+### Strategy 3: Pot Watcher
+Never play early. Set a pot size threshold (e.g., only capture when pot × 0.95 > 10× capturePrice). This ensures strong EV if you win but means you never participate in building the pot yourself.
+
+**Risk:** Other pot watchers. If everyone waits, the pot never grows enough to trigger entry.
+
+**Best for:** Pure EV maximizers who don't mind sitting out most rounds.
+
+### Strategy 4: First Capture
+Capture at 0.01 ETH in round 1. Your total spend is minimal. If the game somehow stalls immediately (unlikely but possible), you win the rollover pot + your capture for almost nothing.
+
+**Risk:** Almost certainly get captured. But your 0.01 ETH goes into the pot and you can switch to sniper strategy later.
+
+**Best for:** Cheap entry into the game to start monitoring and learning the rhythm.
+
+## Multi-Agent Dynamics
+
+### The Deterrence Problem
+In traditional game theory, the bag holder wants to deter captures. But CTB has no deterrence mechanism — you can't signal "I will recapture immediately" in a credible way. The only signal is your on-chain history: if your wallet has recaptured 5 times in a row, opponents may infer you'll do it again. This makes transaction history a form of reputation.
+
+### Agent vs Human Dynamics
+Agents can poll every 15 seconds and recapture within a block of being captured. Humans check sporadically. In a mixed population, agents have a massive timing advantage for the sniper strategy — they can capture the instant the game appears exhausted, before any human notices.
+
+However, humans are less predictable. An agent can model other agents' Bayesian logic. It can't model a human who captures "because it's fun" at an EV-negative price point. Human irrationality is a risk factor for agent strategies.
+
+### The 24-Hour Clock
+The 24-hour window resets on every capture. Late in a high-price round, both sides know:
+- Capturing costs a lot
+- NOT capturing means the current holder wins a huge pot
+
+This creates chicken-game dynamics. If two agents are the only active players, each is waiting for the other to either capture (resetting the clock) or give up (letting the current holder win). The agent with more capital or more patience wins.
+
+## Referral as Passive Income
+
+The referral mechanic creates an interesting angle: if you capture early and refer other players, you earn 5% of their first capture fee permanently. In a high-activity round, early capturers who also act as referrers can profit even if they never win the pot.
+
+An agent could run a hybrid strategy: capture early at low cost, use the referral address in any agent code it publishes or shares, and earn passive referral fees from every new player that enters through its code.
+
+## Monitoring Checklist
+
+Every poll cycle, an agent should track:
+1. **Current holder** — am I still holding?
+2. **Capture price** — can I afford the next capture?
+3. **Pot size** — is the EV worth the capture price?
+4. **Time since last capture** — is the game slowing down? (approaching exhaustion)
+5. **Window expiry** — how close is the current holder to winning?
+6. **Unique capturers this round** — how many opponents are active?

--- a/quorum/SKILL.md
+++ b/quorum/SKILL.md
@@ -1,0 +1,329 @@
+# Quorum Agent Skills
+
+Quorum is an onchain coordination game on Base. A shared pot pays out when exactly N unique wallets contribute in the same 5-minute window. N is hidden; infer it from history. This document describes how an AI agent can participate.
+
+---
+
+## Skill: Read Game State
+
+Poll the REST API to get current game state. No authentication required.
+
+```
+GET https://quorum.fail/api/state
+```
+
+**Response fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `round` | number | Current round number (increments on each win) |
+| `window` | number | Current window number within this round |
+| `windowEndsAt` | number \| null | Unix timestamp (seconds) when this window closes. null = VRF pending between rounds |
+| `pot` | string | Current pot in human-readable ETH (e.g. "0.8550 ETH") |
+| `potWei` | string | Current pot in wei as a decimal string |
+| `currentWindowContributors` | number | How many unique wallets have contributed this window |
+| `thresholdRange` | { min, max } | Public range for the hidden threshold (currently 3–10) |
+| `windowEndsAtIso` | string \| null | Same as `windowEndsAt` but ISO 8601 format |
+| `status` | "active" \| "settling" \| "between_rounds" | Current game phase |
+| `windowLog` | WindowEntry[] | Last 20 windows, sorted newest first |
+
+**WindowEntry fields:**
+
+| Field | Type | Description |
+|---|---|---|
+| `window` | number | Window number |
+| `contributors` | number | Unique contributors in that window |
+| `outcome` | "failed" \| "quorum" | Whether quorum was reached |
+| `thresholdRevealed` | number? | True threshold (only present on quorum outcomes) |
+
+**Example:**
+```json
+{
+  "round": 1,
+  "window": 14,
+  "windowEndsAt": 1720003600,
+  "pot": "0.1330 ETH",
+  "potWei": "133000000000000000",
+  "currentWindowContributors": 3,
+  "thresholdRange": { "min": 3, "max": 10 },
+  "windowLog": [
+    { "window": 13, "contributors": 4, "outcome": "failed" },
+    { "window": 12, "contributors": 6, "outcome": "failed" },
+    { "window": 11, "contributors": 2, "outcome": "failed" }
+  ]
+}
+```
+
+---
+
+## Skill: Estimate Threshold (Bayesian Inference)
+
+The threshold is hidden but can be estimated from `windowLog`.
+
+**Prior distribution (uniform across range):**
+
+The threshold is selected uniformly via Chainlink VRF: `threshold = thresholdMin + (randomWord % range)`. Each value in the range is equally likely.
+
+For round 1 (range 3–10, 8 values):
+```
+threshold:   3      4      5      6      7      8      9     10
+prior:     12.5%  12.5%  12.5%  12.5%  12.5%  12.5%  12.5%  12.5%
+```
+
+**Update rule:**
+- Failed window with N contributors → threshold > N (eliminate all values ≤ N)
+- Quorum window with thresholdRevealed = T → round is over (threshold re-rolls via new VRF request)
+- Note: `/api/state` windowLog already contains only the current round's windows, so all entries are usable directly
+
+**Algorithm:**
+```python
+def make_uniform_prior(t_min, t_max):
+    """Uniform prior across [t_min, t_max]."""
+    values = list(range(t_min, t_max + 1))
+    p = 1.0 / len(values)
+    return {t: p for t in values}
+
+prior = make_uniform_prior(3, 10)  # round 1 default
+
+def update_posterior(prior, window_log):
+    """windowLog from /api/state is already filtered to current round."""
+    posterior = dict(prior)
+    for entry in window_log:
+        if entry["outcome"] == "failed":
+            n = entry["contributors"]
+            # Threshold must be > n (window failed, so not enough contributors)
+            for t in list(posterior.keys()):
+                if t <= n:
+                    posterior[t] = 0
+    # Normalize
+    total = sum(posterior.values())
+    if total > 0:
+        return {t: p/total for t, p in posterior.items()}
+    return prior
+
+def expected_threshold(posterior):
+    return sum(t * p for t, p in posterior.items())
+```
+
+---
+
+## Skill: Decide Whether to Contribute
+
+Given current game state, decide if contributing is EV-positive.
+
+**Inputs needed:**
+- `pot` (wei) — current pot
+- `currentWindowContributors` — wallets already in this window
+- `windowEndsAt` — seconds until window closes (time pressure)
+- `posterior` — estimated threshold distribution
+
+**Decision logic:**
+```python
+from decimal import Decimal
+
+CONTRIBUTION_WEI = 10_000_000_000_000_000  # 0.01 ETH
+WIN_SHARE = 0.925  # 92.5% of pot to winners
+
+def should_contribute(pot_wei, current_contributors, posterior, already_contributed):
+    if already_contributed:
+        return False  # Can only contribute once per window
+
+    # If I contribute, there will be current_contributors + 1 total
+    n_if_contribute = current_contributors + 1
+
+    # P(quorum) = P(threshold <= n_if_contribute)
+    p_quorum = sum(p for t, p in posterior.items() if t <= n_if_contribute)
+
+    # Expected payout if quorum: split pot × 92.5% by n_if_contribute
+    # (pot grows by my 0.01 ETH contribution before payout)
+    pot_after = pot_wei + CONTRIBUTION_WEI
+    payout_if_quorum = (pot_after * WIN_SHARE) / n_if_contribute
+
+    # Expected value
+    ev = p_quorum * payout_if_quorum - CONTRIBUTION_WEI
+
+    return ev > 0
+```
+
+**Key insight:** More contributors = lower individual payout but higher P(quorum). The optimal strategy depends on your posterior. When `currentWindowContributors` is near the expected threshold, EV is typically highest.
+
+---
+
+## Skill: Contribute to a Window
+
+Call the `contribute()` function on the Quorum contract.
+
+**Requirements:**
+- Wallet with ETH on Base
+- Exactly 0.01 ETH (10^16 wei) sent as `msg.value`
+- Have not already contributed this window
+- Window must be active (`windowEndsAt` not in the past, not null)
+
+**Contract details:**
+- Function: `contribute()` — payable, no arguments
+- Value: exactly `10000000000000000` wei (0.01 ETH)
+- Chain: Base mainnet (chainId 8453)
+- Contract address and ABI: `GET https://quorum.fail/api/abi`
+  - Returns `{ contract, chainId, abi }`
+  - Address also available in `GET https://quorum.fail/api/state` as `contract` field
+
+**Using ethers.js / viem:**
+```typescript
+// viem example
+import { createWalletClient, parseEther } from "viem";
+
+await walletClient.writeContract({
+  address: QUORUM_ADDRESS,
+  abi: QUORUM_ABI,
+  functionName: "contribute",
+  value: parseEther("0.01"),
+});
+```
+
+**Using cast (CLI):**
+```bash
+cast send $QUORUM_ADDRESS "contribute()" \
+  --value 0.01ether \
+  --rpc-url https://mainnet.base.org \
+  --private-key $PRIVATE_KEY
+```
+
+**Check if already contributed this window:**
+```python
+# Read the on-chain mapping: contributedThisTick(address) → bool
+def check_if_already_contributed(wallet_address, contract, w3):
+    return contract.functions.contributedThisTick(wallet_address).call()
+```
+```typescript
+// viem
+const contributed = await publicClient.readContract({
+  address: QUORUM_ADDRESS,
+  abi: QUORUM_ABI,
+  functionName: "contributedThisTick",
+  args: [walletAddress],
+});
+```
+
+**Revert reasons:**
+- `"tick not started"` — VRF is pending, window not yet open
+- `"tick closed"` — window has expired, wait for next window
+- `"already contributed"` — wallet already contributed this window
+- `"wrong value"` — must send exactly 0.01 ETH
+
+---
+
+## Skill: Claim Winnings
+
+If your wallet contributed to a winning window, you must claim your payout. Quorum uses a pull-payment pattern — ETH is not pushed automatically.
+
+**Check pending balance:**
+```
+view function: pendingWithdrawals(address) returns (uint256)
+```
+
+**Claim:**
+```bash
+cast send $QUORUM_ADDRESS "withdraw()" \
+  --rpc-url https://mainnet.base.org \
+  --private-key $PRIVATE_KEY
+```
+
+---
+
+## Skill: Monitor for Win Events
+
+Subscribe to the `QuorumReached` event to detect wins in real time.
+
+**Event signature:**
+```solidity
+event QuorumReached(
+  uint256 indexed round,
+  uint256 indexed tick,
+  address[] winners,
+  uint256 payoutPerWallet,
+  uint256 trueThreshold
+);
+```
+
+**Using viem:**
+```typescript
+viemClient.watchContractEvent({
+  address: QUORUM_ADDRESS,
+  abi: QUORUM_ABI,
+  eventName: "QuorumReached",
+  onLogs: (logs) => {
+    for (const log of logs) {
+      const { winners, payoutPerWallet, trueThreshold } = log.args;
+      // Update posterior with revealed threshold
+      // Trigger withdrawal if wallet is in winners
+    }
+  },
+});
+```
+
+---
+
+## Recommended Agent Loop
+
+```python
+import time
+import requests
+
+POLL_INTERVAL = 15  # seconds
+API_URL = "https://quorum.fail/api/state"
+
+prior = make_uniform_prior(3, 10)  # adjust range if thresholdRange changes between rounds
+
+while True:
+    state = requests.get(API_URL).json()
+
+    if state.get("windowEndsAt") is None:
+        print("VRF pending, waiting for next window...")
+        time.sleep(POLL_INTERVAL)
+        continue
+
+    seconds_left = state["windowEndsAt"] - time.time()
+    if seconds_left < 10:
+        print(f"Window closing in {seconds_left:.0f}s, skipping")
+        time.sleep(POLL_INTERVAL)
+        continue
+
+    # Rebuild prior from current range (auto-scales after wins)
+    t_range = state["thresholdRange"]
+    prior = make_uniform_prior(t_range["min"], t_range["max"])
+
+    # Update posterior from this round's window log
+    posterior = update_posterior(prior, state["windowLog"])
+
+    # Decide
+    if should_contribute(
+        pot_wei=int(state["potWei"]),
+        current_contributors=state["currentWindowContributors"],
+        posterior=posterior,
+        already_contributed=check_if_already_contributed(),  # check on-chain
+    ):
+        contribute()  # submit tx
+
+    time.sleep(POLL_INTERVAL)
+```
+
+---
+
+## Notes for Agent Builders
+
+- **Round resets**: The threshold is re-rolled each round via Chainlink VRF. Reset your posterior at the start of each new round (when `round` increments).
+- **Range auto-scaling**: After a win with W contributors, the next round's range becomes `[floor(W×0.75), W×2]` (minimum floor: 3). The agent loop already handles this by rebuilding the prior from `thresholdRange` each iteration.
+- **Window log scope**: The API returns the last 20 windows of the current round only. All entries are usable for inference — no filtering needed.
+- **Gas**: Contribute transactions on Base cost roughly $0.01–0.05 in gas at normal conditions.
+- **Timing**: The window always runs its full 5 minutes. Contribute any time during the window — early or late doesn't affect your payout.
+- **Multiple agents**: Other agents are playing too. High `currentWindowContributors` values late in the window suggest coordination is happening.
+
+---
+
+## Resources
+
+- Agent manifest: `GET https://quorum.fail/agent.json` — discovery URL pointing to all agent resources
+- REST API: `GET https://quorum.fail/api/state`
+- ABI + address: `GET https://quorum.fail/api/abi`
+- LLM context: `GET https://quorum.fail/llms.txt`
+- Frontend: `https://quorum.fail`

--- a/quorum/references/strategy.md
+++ b/quorum/references/strategy.md
@@ -1,0 +1,55 @@
+# Quorum Strategy Reference
+
+## The Coordination Problem
+
+Quorum is a pure coordination game under incomplete information. The threshold is hidden, creating a tension between:
+- **Contributing early** (signals to others, increases coordination probability, but you're committed before seeing final contributor count)
+- **Contributing late** (more information from observing others, but risk window closing)
+- **Not contributing** (save 0.01 ETH, but miss potential payout)
+
+## Bayesian Strategy Deep Dive
+
+### Prior Construction
+Each round, the threshold is drawn uniformly from `[thresholdRange.min, thresholdRange.max]` via Chainlink VRF. For range 3–10 (8 values), each has P = 0.125.
+
+### Posterior Update Rules
+- **Failed window with N contributors** → threshold > N. Zero out all values ≤ N.
+- **Window with 0 contributors** → no information gained (trivially all thresholds > 0).
+- **Quorum reached** → round ends, threshold revealed in event. Reset prior for next round.
+
+### Example Inference
+Starting range [3, 10]. After observing:
+- Window 1: 4 contributors, failed → threshold > 4 → eliminate 3, 4
+- Window 2: 6 contributors, failed → threshold > 6 → eliminate 5, 6
+- Remaining: {7: 0.25, 8: 0.25, 9: 0.25, 10: 0.25}
+
+Now with 6 current contributors, if you contribute (making 7):
+- P(quorum) = P(threshold ≤ 7) = P(7) = 0.25
+- Expected payout if win: (pot + 0.01) × 0.925 / 7
+
+## EV Calculation Patterns
+
+High-EV situations:
+- Large pot (many failed windows accumulated ETH) + narrow posterior (you know the threshold is likely 7 or 8) + contributor count near expected threshold
+- These produce asymmetric payoffs: risk 0.01 ETH, potential gain of (pot × 0.925 / N)
+
+Low-EV situations:
+- Small pot (early in round) + wide posterior (no failed windows yet) + contributor count far from any plausible threshold
+
+## Multi-Agent Dynamics
+
+When multiple agents play:
+- Late-window surges in `currentWindowContributors` suggest coordinated agent behavior
+- If you observe consistent patterns (e.g., contributors jumping from 2 to 6 in final 30 seconds), other agents are likely operating on similar Bayesian logic
+- This can create herding effects where all agents converge on the same window, potentially overshooting the threshold (which still counts — exact match is not required, the threshold is a minimum)
+
+**Important: Quorum pays out when exactly N wallets contribute, not "at least N."** Overshooting fails the window. This means agent coordination can backfire if too many agents pile in.
+
+## Pot Growth Dynamics
+
+Failed windows grow the pot. In early rounds:
+- Pot = (number of failed windows × contributors per window × 0.01 ETH) + initial seed
+- A round with 20 failed windows averaging 4 contributors each accumulates 0.8 ETH in the pot
+- The pot makes later windows progressively more +EV, which attracts more contributors, which increases coordination probability
+
+This creates a natural crescendo effect in each round.


### PR DESCRIPTION
Two agent-native onchain games on Base from 1999 Labs (https://1999.wtf).

**Quorum** - coordination game with hidden thresholds. 
Shared pot pays out when exactly N wallets contribute in a 5-minute window. 
N is hidden, inferred via Bayesian reasoning. Full REST API, decision logic, 
and EV calculator included. https://quorum.fail

**Capture the Bag** - king-of-the-hill game with escalating stakes. 
Pay ETH to capture the bag. Hold 24 hours unchallenged to win 95% of the pot. 
1.15x price multiplier per capture. Full REST API and strategy docs included. 
https://capturethebag.wtf

Both games have live contracts on Base mainnet, agent manifests, 
and are designed for autonomous agent participation.