### PR TITLE
feat(bankr): weekly skill update — x402 client tools, Hyperliquid primary leverage, CIDR allowlists, GLM models

### DIFF
--- a/bankr/SKILL.md
+++ b/bankr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bankr
-description: AI-powered crypto trading agent, wallet API, and LLM gateway via natural language. Use when the user wants to trade crypto, check portfolio balances (with PnL and NFTs), view token prices, search tokens, transfer crypto, manage NFTs, use leverage, bet on Polymarket, deploy tokens, set up automated trading, sign and submit raw transactions, or access LLM models through the Bankr LLM gateway funded by your Bankr wallet. Supports Base, Ethereum, Polygon, Solana, and Unichain.
+description: AI-powered crypto trading agent, wallet API, and LLM gateway via natural language. Use when the user wants to trade crypto, check portfolio balances (with PnL and NFTs), view token prices, search tokens, transfer crypto, manage NFTs, use leverage (Hyperliquid or Avantis), bet on Polymarket, deploy tokens, set up automated trading, sign and submit raw transactions, call x402 paid API endpoints, or access LLM models through the Bankr LLM gateway funded by your Bankr wallet. Supports Base, Ethereum, Polygon, Solana, and Unichain.
 metadata:
   {
     "clawdbot":
@@ -118,7 +118,7 @@ bankr login email <user-email> --code <otp> --accept-terms --key-name "LLM Clien
 | `--read-write` | Disable read-only mode (allow transactions). Without this, enabled APIs are read-only |
 | `--no-token-launch` | Disable Token Launch API (enabled by default) |
 | `--llm` | Enable [LLM gateway](https://docs.bankr.bot/llm-gateway/overview) access (multi-model API at `llm.bankr.bot`). Currently limited to beta testers |
-| `--allowed-ips <ips>` | Comma-separated IP allowlist for the API key |
+| `--allowed-ips <ips>` | Comma-separated IP/CIDR allowlist for the API key (e.g., `1.2.3.4,10.0.0.0/24`) |
 | `--allowed-recipients <addresses>` | Comma-separated EVM/Solana addresses the key can send to (auto-classified by 0x prefix) |
 
 **New key defaults** (when no flags are passed):
@@ -520,12 +520,11 @@ For full details — setup paths, model list, provider config, SDK examples, key
 
 ### Leverage Trading
 
-- Long/short positions (up to 50x crypto, 100x forex/commodities)
-- Crypto, forex, and commodities
-- Stop loss and take profit
-- Position management via Avantis on Base
+- **Hyperliquid** (primary) — Perpetual futures on Hyperliquid L1 with on-chain order book. Crypto, stocks (TSLA, AAPL, NVDA via HIP-3), spot trading. Up to 50x leverage.
+- **Avantis** (secondary) — Perpetuals on Base for crypto (up to 50x), forex and commodities (up to 100x)
+- Stop loss, take profit, and position management on both platforms
 
-**Reference**: [references/leverage-trading.md](references/leverage-trading.md)
+**Reference**: [references/leverage-trading.md](references/leverage-trading.md) | [references/hyperliquid.md](references/hyperliquid.md)
 
 ### Token Deployment
 
@@ -549,6 +548,17 @@ For full details — setup paths, model list, provider config, SDK examples, key
 - Scheduled commands
 
 **Reference**: [references/automation.md](references/automation.md)
+
+### x402 Paid API Calls
+
+The agent can discover and call x402-protected API endpoints, automatically handling USDC payments on Base:
+
+- **Discover** endpoints in the Bankr registry or via web search
+- **Inspect** endpoint pricing, methods, and input/output schemas
+- **Call** endpoints with automatic payment signing (max $10/request)
+- Works with any x402-compatible endpoint (Bankr-hosted or external)
+
+**Reference**: [references/x402-cloud.md](references/x402-cloud.md)
 
 ### Arbitrary Transactions
 
@@ -580,7 +590,7 @@ For full details — setup paths, model list, provider config, SDK examples, key
 
 **Read-Only API Keys**: New keys default to `readOnly: true`. This filters all write tools (swaps, transfers, staking, token launches, etc.) from agent sessions. The `/wallet/sign`, `/wallet/submit`, and `/wallet/transfer` write endpoints return 403. Use `--read-write` during login or toggle in the web settings to disable. Ideal for monitoring bots and research agents.
 
-**IP Whitelisting**: Set `allowedIps` on your API key to restrict usage to specific IPs. Requests from non-whitelisted IPs are rejected with 403 at the auth layer.
+**IP Whitelisting**: Set `allowedIps` on your API key to restrict usage to specific IPs or CIDR ranges (e.g., `10.0.0.0/24`). Requests from non-whitelisted IPs are rejected with 403 at the auth layer.
 
 **Rate Limits**: 100 messages/day (standard), 1,000/day (Bankr Club), or custom per key. Resets 24h from first message (rolling window). LLM Gateway uses a credit-based system.
 
@@ -589,7 +599,7 @@ For full details — setup paths, model list, provider config, SDK examples, key
 - Add `~/.bankr/` and `.env` to `.gitignore` — the CLI stores credentials in `~/.bankr/config.json`
 - Test with small amounts on low-cost chains (Base, Polygon) before production use
 - Use `waitForConfirmation: true` with `/wallet/submit` — transactions execute immediately with no confirmation prompt
-- Rotate keys periodically and revoke immediately if compromised at [bankr.bot/api](https://bankr.bot/api)
+- Rotate keys periodically via the dashboard or API key rotation endpoint, and revoke immediately if compromised at [bankr.bot/api](https://bankr.bot/api)
 
 **Reference**: [references/safety.md](references/safety.md)
 
@@ -801,8 +811,11 @@ See [references/safety.md](references/safety.md) for comprehensive safety guidan
 
 ### Leverage
 
+- "Long $100 of BTC on hyperliquid with 10x"
+- "Short ETH with 5x on hyperliquid"
 - "Open 5x long on ETH with $100"
 - "Short BTC 10x with stop loss at $45k"
+- "Show my hyperliquid positions"
 - "Show my Avantis positions"
 
 ### Automation
@@ -829,6 +842,12 @@ See [references/safety.md](references/safety.md) for comprehensive safety guidan
 
 - "Deploy a token called BankrFan with symbol BFAN on Base"
 - "Claim fees for my token MTK"
+
+### x402 Paid API Calls
+
+- "Find x402 endpoints for sentiment analysis"
+- "Call the weather endpoint on x402"
+- "What x402 endpoints are available for price data?"
 
 ### Arbitrary Transactions
 

--- a/bankr/references/leverage-trading.md
+++ b/bankr/references/leverage-trading.md
@@ -1,10 +1,15 @@
 # Leverage Trading Reference
 
-Trade with leverage using Avantis perpetuals on Base.
+Trade with leverage on Hyperliquid (primary) or Avantis on Base (secondary).
 
 ## Overview
 
-Avantis offers long/short positions on crypto, forex, and commodities via perpetuals on Base.
+Two leverage platforms are available:
+
+- **Hyperliquid** (primary) — High-performance L1 DEX with on-chain order book. Supports perpetual futures for crypto, stocks (via HIP-3), and spot trading. See [hyperliquid.md](hyperliquid.md) for the full Hyperliquid reference.
+- **Avantis** (secondary) — Perpetuals on Base for crypto, forex, and commodities.
+
+### Avantis Details
 
 **Chain**: Base
 **Protocol**: [Avantis](https://docs.avantisfi.com/)

--- a/bankr/references/llm-gateway.md
+++ b/bankr/references/llm-gateway.md
@@ -56,6 +56,8 @@ bankr config get llmKey
 | `minimax-m2.7` | MiniMax | Balanced performance (204.8K context) |
 | `kimi-k2.5` | Moonshot AI | Long-context reasoning |
 | `qwen3-coder` | Alibaba | Code generation, debugging |
+| `glm-5` | Z.ai | General purpose reasoning |
+| `glm-5-turbo` | Z.ai | Fast, cost-effective |
 
 ```bash
 # Fetch live model list from the gateway

--- a/bankr/references/safety.md
+++ b/bankr/references/safety.md
@@ -99,10 +99,11 @@ The agent receives a system directive and will explain the restriction if a user
 
 ### IP Whitelisting
 
-API keys support an `allowedIps` whitelist. When configured, requests from non-whitelisted IPs are rejected at the authentication layer before reaching any endpoint.
+API keys support an `allowedIps` whitelist with both individual IPs and CIDR ranges. When configured, requests from non-whitelisted IPs are rejected at the authentication layer before reaching any endpoint.
 
 - **Empty array** (`[]`) = all IPs allowed (default)
-- **Non-empty array** = only listed IPs can use the key
+- **Non-empty array** = only listed IPs/ranges can use the key
+- **CIDR notation** supported (e.g., `10.0.0.0/24`, `192.168.1.0/16`)
 
 **403 error response:**
 ```json
@@ -119,7 +120,7 @@ Manage API key settings at [bankr.bot/api](https://bankr.bot/api):
 | Field | Type | Description |
 |-------|------|-------------|
 | `readOnly` | boolean | When true, only read tools are available |
-| `allowedIps` | string[] | IP whitelist (empty = all allowed) |
+| `allowedIps` | string[] | IP/CIDR whitelist (e.g., `["1.2.3.4", "10.0.0.0/24"]`, empty = all allowed) |
 | `walletApiEnabled` | boolean | Whether `/wallet/*` write endpoints are accessible |
 | `agentApiEnabled` | boolean | Whether `/agent/*` AI endpoints are accessible |
 | `tokenLaunchApiEnabled` | boolean | Whether token deployment is accessible |
@@ -273,7 +274,7 @@ Blockchain transactions are **irreversible** once confirmed. Key safety rules:
 
 ### Rotation & Revocation
 
-- **Rotate periodically** — Generate new keys and deactivate old ones at [bankr.bot/api](https://bankr.bot/api). After rotating, update both env vars and CLI config (`bankr login --api-key NEW_KEY`)
+- **Rotate periodically** — Rotate keys via the dashboard at [bankr.bot/api](https://bankr.bot/api) or programmatically via the API key rotation endpoint. Rotation atomically generates a new key and deactivates the old one. After rotating, update both env vars and CLI config (`bankr login --api-key NEW_KEY`)
 - **Revoke immediately** — If any key (API or LLM) is leaked, deactivate it immediately at the dashboard
 - **One key per purpose** — Use separate keys for different agents, environments, and services (Agent API vs LLM Gateway) so you can revoke individually without disrupting unrelated systems
 

--- a/bankr/references/x402-cloud.md
+++ b/bankr/references/x402-cloud.md
@@ -148,7 +148,24 @@ Service config lives in `bankr.x402.json` at the project root:
 
 ## Calling x402 Endpoints
 
-### With x402-fetch (recommended)
+### Via Bankr Agent (recommended for agent users)
+
+The Bankr agent has built-in tools to discover and call x402 endpoints with automatic payment handling:
+
+```bash
+# Discover endpoints in the Bankr registry
+bankr agent prompt "Find x402 endpoints for sentiment analysis"
+
+# Call an endpoint — agent handles payment signing automatically
+bankr agent prompt "Call the sentiment analysis endpoint on x402 with text 'Bitcoin is pumping'"
+
+# Inspect an endpoint's pricing and schema before calling
+bankr agent prompt "What does the x402 weather endpoint cost?"
+```
+
+The agent uses USDC on Base for all x402 payments. Maximum payment per request is $10. The agent will always confirm payment amount before calling.
+
+### With x402-fetch (for developers)
 
 ```typescript
 import { createWalletClient, http } from "viem";


### PR DESCRIPTION
## Summary

- Add x402 paid API call capabilities — agent can now discover, inspect, and call x402-protected endpoints with automatic USDC payment handling
- Position Hyperliquid as primary leverage trading platform, Avantis as secondary (Base only)
- Add CIDR notation support for IP allowlists in API key security configuration
- Document API key rotation endpoint for programmatic key management
- Add GLM-5 and GLM-5 Turbo models to LLM gateway reference
- Add Hyperliquid prompt examples to leverage trading section

## Changed Files

- `bankr/SKILL.md` — Updated description, leverage section, safety docs, added x402 client capability section and prompt examples
- `bankr/references/leverage-trading.md` — Reframed with Hyperliquid as primary, Avantis as secondary
- `bankr/references/llm-gateway.md` — Added GLM-5 and GLM-5 Turbo models
- `bankr/references/safety.md` — Added CIDR support docs, API key rotation details
- `bankr/references/x402-cloud.md` — Added agent-based x402 endpoint calling section

## Test plan

- [ ] Verify all markdown renders correctly
- [ ] Confirm no private repository details are exposed
- [ ] Review prompt examples for accuracy

https://claude.ai/code/session_01T3GTxuqe9cFgXacA2g5gNP