### PR TITLE
docs: update deprecated CLI commands to new namespaced equivalents

### DIFF
--- a/bankr/SKILL.md
+++ b/bankr/SKILL.md
@@ -321,11 +321,13 @@ Old flat commands still work but prefer the namespaced versions:
 
 | Deprecated | Use Instead |
 |-----------|-------------|
-| `bankr prompt` | `bankr agent prompt` |
+| `bankr prompt` | `bankr agent` |
 | `bankr status` | `bankr agent status` |
 | `bankr cancel` | `bankr agent cancel` |
 | `bankr balances` | `bankr wallet portfolio` |
 | `bankr profile` | `bankr agent profile` |
+| `bankr sign` | `bankr wallet sign` |
+| `bankr submit` | `bankr wallet submit` |
 | `bankr skills` | `bankr agent skills` |
 
 ### Environment Variables

--- a/bankr/references/agent-profiles.md
+++ b/bankr/references/agent-profiles.md
@@ -25,18 +25,18 @@ Create and manage public profile pages at [bankr.bot/agents](https://bankr.bot/a
 ### View Profile
 
 ```bash
-bankr profile              # Pretty-printed view
-bankr profile --json       # JSON output
+bankr agent profile              # Pretty-printed view
+bankr agent profile --json       # JSON output
 ```
 
 ### Create Profile
 
 ```bash
 # Interactive wizard
-bankr profile create
+bankr agent profile create
 
 # Non-interactive with flags
-bankr profile create \
+bankr agent profile create \
   --name "My Agent" \
   --description "AI-powered trading agent on Base" \
   --token 0x1234...abcd \
@@ -46,8 +46,8 @@ bankr profile create \
 ### Update Profile
 
 ```bash
-bankr profile update --description "Updated description"
-bankr profile update --token 0xNEW...ADDR
+bankr agent profile update --description "Updated description"
+bankr agent profile update --token 0xNEW...ADDR
 ```
 
 ### Add Project Updates
@@ -56,16 +56,16 @@ Project updates appear in a timeline on the profile detail page. Capped at 50 en
 
 ```bash
 # Interactive
-bankr profile add-update
+bankr agent profile add-update
 
 # Non-interactive
-bankr profile add-update --title "v2 Launch" --content "Shipped new swap engine and portfolio dashboard"
+bankr agent profile add-update --title "v2 Launch" --content "Shipped new swap engine and portfolio dashboard"
 ```
 
 ### Delete Profile
 
 ```bash
-bankr profile delete   # Requires confirmation
+bankr agent profile delete   # Requires confirmation
 ```
 
 ## REST API Endpoints

--- a/bankr/references/error-handling.md
+++ b/bankr/references/error-handling.md
@@ -29,7 +29,7 @@ bankr config set apiKey bk_your_actual_key_here
 **3. Verify Setup**
 ```bash
 bankr whoami
-bankr prompt "What is my balance?"
+bankr agent "What is my balance?"
 ```
 
 ### Common API Key Issues
@@ -267,7 +267,7 @@ Before reporting an issue, check:
 bankr whoami
 
 # Test with a simple query
-bankr prompt "What is my balance?"
+bankr agent "What is my balance?"
 ```
 
 ### Gather Information

--- a/bankr/references/safety.md
+++ b/bankr/references/safety.md
@@ -28,7 +28,7 @@ For most users, **one key works for both** the Agent API and LLM Gateway. Howeve
 |--------|--------------|-----------------|
 | Environment variable | `BANKR_API_KEY` | `BANKR_LLM_KEY` (falls back to `BANKR_API_KEY`) |
 | CLI config key | `apiKey` | `llmKey` (falls back to `apiKey`) |
-| Used by | `bankr prompt`, `/agent/*` endpoints | `bankr llm claude`, `llm.bankr.bot` |
+| Used by | `bankr agent`, `/agent/*` endpoints | `bankr llm claude`, `llm.bankr.bot` |
 
 **When to use separate keys:**
 - Your agent API key is read-only but your LLM key needs no such restriction (LLM calls are inherently read-only)
@@ -169,7 +169,7 @@ Access controls (read-only, IP whitelist) apply identically whether you use the 
 
 ```bash
 # These two are equivalent — same access controls apply
-bankr prompt "What is my balance?"
+bankr agent "What is my balance?"
 curl -X POST "https://api.bankr.bot/agent/prompt" \
   -H "X-API-Key: bk_YOUR_KEY" \
   -d '{"prompt": "What is my balance?"}'

--- a/endaoment/scripts/donate.sh
+++ b/endaoment/scripts/donate.sh
@@ -81,7 +81,7 @@ if [[ "$CODE" != "0x" ]] && [[ -n "$CODE" ]]; then
   echo "📝 Step 1: Approving USDC..."
   APPROVE_TX="{\"to\": \"$USDC\", \"data\": \"$APPROVE_DATA\", \"value\": \"0\", \"chainId\": $CHAIN_ID}"
   
-  APPROVE_RESULT=$(bankr prompt "Submit this transaction: $APPROVE_TX" 2>&1)
+  APPROVE_RESULT=$(bankr agent "Submit this transaction: $APPROVE_TX" 2>&1)
   if echo "$APPROVE_RESULT" | grep -q "basescan.org/tx"; then
     APPROVE_HASH=$(echo "$APPROVE_RESULT" | grep -o 'https://basescan.org/tx/[^ "]*' | head -1)
     echo "   ✅ Approved: $APPROVE_HASH"
@@ -95,7 +95,7 @@ if [[ "$CODE" != "0x" ]] && [[ -n "$CODE" ]]; then
   echo "📝 Step 2: Donating..."
   DONATE_TX="{\"to\": \"$ENTITY_ADDRESS\", \"data\": \"$DONATE_DATA\", \"value\": \"0\", \"chainId\": $CHAIN_ID}"
   
-  DONATE_RESULT=$(bankr prompt "Submit this transaction: $DONATE_TX" 2>&1)
+  DONATE_RESULT=$(bankr agent "Submit this transaction: $DONATE_TX" 2>&1)
   if echo "$DONATE_RESULT" | grep -q "basescan.org/tx"; then
     DONATE_HASH=$(echo "$DONATE_RESULT" | grep -o 'https://basescan.org/tx/[^ "]*' | head -1)
     echo "   ✅ Donated: $DONATE_HASH"
@@ -112,7 +112,7 @@ else
   echo "📝 Step 1: Approving USDC to factory..."
   APPROVE_TX="{\"to\": \"$USDC\", \"data\": \"$APPROVE_DATA\", \"value\": \"0\", \"chainId\": $CHAIN_ID}"
   
-  APPROVE_RESULT=$(bankr prompt "Submit this transaction: $APPROVE_TX" 2>&1)
+  APPROVE_RESULT=$(bankr agent "Submit this transaction: $APPROVE_TX" 2>&1)
   if echo "$APPROVE_RESULT" | grep -q "basescan.org/tx"; then
     APPROVE_HASH=$(echo "$APPROVE_RESULT" | grep -o 'https://basescan.org/tx/[^ "]*' | head -1)
     echo "   ✅ Approved: $APPROVE_HASH"
@@ -126,7 +126,7 @@ else
   echo "📝 Step 2: Deploying & donating..."
   DEPLOY_TX="{\"to\": \"$FACTORY\", \"data\": \"$DEPLOY_DATA\", \"value\": \"0\", \"chainId\": $CHAIN_ID}"
   
-  DEPLOY_RESULT=$(bankr prompt "Submit this transaction: $DEPLOY_TX" 2>&1)
+  DEPLOY_RESULT=$(bankr agent "Submit this transaction: $DEPLOY_TX" 2>&1)
   if echo "$DEPLOY_RESULT" | grep -q "basescan.org/tx"; then
     DEPLOY_HASH=$(echo "$DEPLOY_RESULT" | grep -o 'https://basescan.org/tx/[^ "]*' | head -1)
     echo "   ✅ Deployed & Donated: $DEPLOY_HASH"

--- a/ens-primary-name/SKILL.md
+++ b/ens-primary-name/SKILL.md
@@ -22,7 +22,7 @@ bun install -g @bankr/cli
 bankr login
 ```
 
-The scripts use `bankr prompt` to submit transactions like:
+The scripts use `bankr agent` to submit transactions like:
 ```
 Submit this transaction: {"to": "0x...", "data": "0x...", "value": "0", "chainId": 8453}
 ```

--- a/ens-primary-name/scripts/set-avatar.sh
+++ b/ens-primary-name/scripts/set-avatar.sh
@@ -85,7 +85,7 @@ echo "Submitting to resolver on Ethereum mainnet..." >&2
 echo "⚠️  Note: This requires ETH on mainnet for gas" >&2
 
 # Submit transaction via Bankr
-RESULT=$(bankr prompt "Submit this transaction: {\"to\": \"$RESOLVER\", \"data\": \"$CALLDATA\", \"value\": \"0\", \"chainId\": $CHAIN_ID}" 2>/dev/null)
+RESULT=$(bankr agent "Submit this transaction: {\"to\": \"$RESOLVER\", \"data\": \"$CALLDATA\", \"value\": \"0\", \"chainId\": $CHAIN_ID}" 2>/dev/null)
 
 if echo "$RESULT" | grep -q "$EXPLORER"; then
   TX_HASH=$(echo "$RESULT" | grep -oE "$EXPLORER/tx/0x[a-fA-F0-9]{64}" | grep -oE '0x[a-fA-F0-9]{64}')

--- a/ens-primary-name/scripts/set-primary.sh
+++ b/ens-primary-name/scripts/set-primary.sh
@@ -124,7 +124,7 @@ console.log(selector + offset + len + data);
 echo "Calldata: $CALLDATA" >&2
 echo "Submitting transaction..." >&2
 
-RESULT=$(bankr prompt "Submit this transaction: {\"to\": \"$REVERSE_REGISTRAR\", \"data\": \"$CALLDATA\", \"value\": \"0\", \"chainId\": $CHAIN_ID}" 2>/dev/null)
+RESULT=$(bankr agent "Submit this transaction: {\"to\": \"$REVERSE_REGISTRAR\", \"data\": \"$CALLDATA\", \"value\": \"0\", \"chainId\": $CHAIN_ID}" 2>/dev/null)
 
 if echo "$RESULT" | grep -q "$EXPLORER"; then
   TX_HASH=$(echo "$RESULT" | grep -oE "$EXPLORER/tx/0x[a-fA-F0-9]{64}" | grep -oE '0x[a-fA-F0-9]{64}')

--- a/erc-8004/scripts/bridge-to-mainnet.sh
+++ b/erc-8004/scripts/bridge-to-mainnet.sh
@@ -19,7 +19,7 @@ echo "From: Base" >&2
 echo "To: Ethereum Mainnet" >&2
 
 # Use Bankr to bridge
-RESULT=$(bankr prompt "Bridge $AMOUNT ETH from Base to Ethereum mainnet" 2>/dev/null)
+RESULT=$(bankr agent "Bridge $AMOUNT ETH from Base to Ethereum mainnet" 2>/dev/null)
 
 if echo "$RESULT" | grep -qi "success\|bridge\|complete\|transaction"; then
   echo "=== SUCCESS ===" >&2

--- a/erc-8004/scripts/register-http.sh
+++ b/erc-8004/scripts/register-http.sh
@@ -48,7 +48,7 @@ console.log(selector + offset + len + data);
 echo "Registering on-chain..." >&2
 
 # Submit via Bankr
-RESULT=$(bankr prompt "Submit this transaction on $CHAIN: {\"to\": \"$IDENTITY_REGISTRY\", \"data\": \"$CALLDATA\", \"value\": \"0\", \"chainId\": $CHAIN_ID}" 2>/dev/null)
+RESULT=$(bankr agent "Submit this transaction on $CHAIN: {\"to\": \"$IDENTITY_REGISTRY\", \"data\": \"$CALLDATA\", \"value\": \"0\", \"chainId\": $CHAIN_ID}" 2>/dev/null)
 
 if echo "$RESULT" | grep -qE "$EXPLORER/tx/0x[a-fA-F0-9]{64}"; then
   TX_HASH=$(echo "$RESULT" | grep -oE "$EXPLORER/tx/0x[a-fA-F0-9]{64}" | grep -oE '0x[a-fA-F0-9]{64}' | head -1)

--- a/erc-8004/scripts/register-onchain.sh
+++ b/erc-8004/scripts/register-onchain.sh
@@ -62,7 +62,7 @@ echo "Registering on-chain (data URI)..." >&2
 echo "Note: This will cost more gas than IPFS/HTTP due to larger calldata" >&2
 
 # Submit via Bankr
-RESULT=$(bankr prompt "Submit this transaction on $CHAIN: {\"to\": \"$IDENTITY_REGISTRY\", \"data\": \"$CALLDATA\", \"value\": \"0\", \"chainId\": $CHAIN_ID}" 2>/dev/null)
+RESULT=$(bankr agent "Submit this transaction on $CHAIN: {\"to\": \"$IDENTITY_REGISTRY\", \"data\": \"$CALLDATA\", \"value\": \"0\", \"chainId\": $CHAIN_ID}" 2>/dev/null)
 
 if echo "$RESULT" | grep -qE "$EXPLORER/tx/0x[a-fA-F0-9]{64}"; then
   TX_HASH=$(echo "$RESULT" | grep -oE "$EXPLORER/tx/0x[a-fA-F0-9]{64}" | grep -oE '0x[a-fA-F0-9]{64}' | head -1)

--- a/erc-8004/scripts/register.sh
+++ b/erc-8004/scripts/register.sh
@@ -89,7 +89,7 @@ console.log(selector + offset + len + data);
 echo "Calldata: $CALLDATA" >&2
 
 # Submit via Bankr
-RESULT=$(bankr prompt "Submit this transaction on $CHAIN: {\"to\": \"$IDENTITY_REGISTRY\", \"data\": \"$CALLDATA\", \"value\": \"0\", \"chainId\": $CHAIN_ID}" 2>/dev/null)
+RESULT=$(bankr agent "Submit this transaction on $CHAIN: {\"to\": \"$IDENTITY_REGISTRY\", \"data\": \"$CALLDATA\", \"value\": \"0\", \"chainId\": $CHAIN_ID}" 2>/dev/null)
 
 if echo "$RESULT" | grep -qE "$EXPLORER/tx/0x[a-fA-F0-9]{64}"; then
   TX_HASH=$(echo "$RESULT" | grep -oE "$EXPLORER/tx/0x[a-fA-F0-9]{64}" | grep -oE '0x[a-fA-F0-9]{64}' | head -1)

--- a/erc-8004/scripts/update-profile.sh
+++ b/erc-8004/scripts/update-profile.sh
@@ -61,7 +61,7 @@ console.log(selector + id + offset + len + data);
 echo "Calldata: $CALLDATA" >&2
 
 # Submit via Bankr
-RESULT=$(bankr prompt "Submit this transaction on $CHAIN: {\"to\": \"$IDENTITY_REGISTRY\", \"data\": \"$CALLDATA\", \"value\": \"0\", \"chainId\": $CHAIN_ID}" 2>/dev/null)
+RESULT=$(bankr agent "Submit this transaction on $CHAIN: {\"to\": \"$IDENTITY_REGISTRY\", \"data\": \"$CALLDATA\", \"value\": \"0\", \"chainId\": $CHAIN_ID}" 2>/dev/null)
 
 if echo "$RESULT" | grep -qE "$EXPLORER/tx/0x[a-fA-F0-9]{64}"; then
   TX_HASH=$(echo "$RESULT" | grep -oE "$EXPLORER/tx/0x[a-fA-F0-9]{64}" | grep -oE '0x[a-fA-F0-9]{64}' | head -1)

--- a/hydrex/SKILL.md
+++ b/hydrex/SKILL.md
@@ -123,8 +123,8 @@ Convert my oHYDX to veHYDX on Hydrex
 Get current liquidity pool data:
 
 ```bash
-bankr prompt "What are the top Hydrex pools by projected fees?"
-bankr prompt "Show me all Hydrex liquidity pools with their voting weights"
+bankr agent "What are the top Hydrex pools by projected fees?"
+bankr agent "Show me all Hydrex liquidity pools with their voting weights"
 ```
 
 **Key fields for voting optimization:**
@@ -251,16 +251,16 @@ Vote on Hydrex pools weighted by their fee efficiency
 
 ```bash
 # Check voting power
-bankr prompt "What's my Hydrex voting power?"
+bankr agent "What's my Hydrex voting power?"
 
 # Check earning power (1.3x voting power)
-bankr prompt "What's my Hydrex earning power?"
+bankr agent "What's my Hydrex earning power?"
 
 # Check veHYDX NFT balance
-bankr prompt "Show my veHYDX NFT balance"
+bankr agent "Show my veHYDX NFT balance"
 
 # Check a specific NFT's earning power
-bankr prompt "How much earning power does my veHYDX NFT #5 have?"
+bankr agent "How much earning power does my veHYDX NFT #5 have?"
 ```
 
 **Display to users**: Show earning power (voting power × 1.3) when discussing fee earnings, as this is what determines your share of distributions.

--- a/hydrex/references/locking.md
+++ b/hydrex/references/locking.md
@@ -92,8 +92,8 @@ Query information about a locked position:
 **Contract**: `0x25B2ED7149fb8A05f6eF9407d9c8F878f59cd1e1` (Base)
 
 ```bash
-bankr prompt "Show my veHYDX lock details for NFT #1"
-bankr prompt "What are the lock details for veHYDX NFT #5?"
+bankr agent "Show my veHYDX lock details for NFT #1"
+bankr agent "What are the lock details for veHYDX NFT #5?"
 ```
 
 To read directly — encode `tokenId` as a 32-byte hex value and call `eth_call` on the veHYDX contract. Example for token ID 1: data = `0x2c79db11` + `0000000000000000000000000000000000000000000000000000000000000001`
@@ -113,8 +113,8 @@ Get the voting power of a specific veHYDX NFT:
 **Contract**: `0x25B2ED7149fb8A05f6eF9407d9c8F878f59cd1e1` (Base)
 
 ```bash
-bankr prompt "What's the voting power for my veHYDX NFT #1?"
-bankr prompt "What's the earning power for my veHYDX NFT #1?"
+bankr agent "What's the voting power for my veHYDX NFT #1?"
+bankr agent "What's the earning power for my veHYDX NFT #1?"
 ```
 
 To read directly — encode `tokenId` as a 32-byte hex value and call `eth_call` on the veHYDX contract. Returns a `uint256` in wei units.
@@ -144,7 +144,7 @@ Get the owner of a veHYDX NFT:
 **Function**: `ownerOf(uint256 _tokenId)` — selector `0x6352211e`
 
 ```bash
-bankr prompt "Who owns veHYDX NFT #1?"
+bankr agent "Who owns veHYDX NFT #1?"
 ```
 
 To read directly — encode `tokenId` as a 32-byte hex value and call `eth_call`. Returns the owner address.
@@ -156,8 +156,8 @@ Get number of veHYDX NFTs owned by an address:
 **Function**: `balanceOf(address _owner)` — selector `0x70a08231`
 
 ```bash
-bankr prompt "Show my veHYDX NFT balance"
-bankr prompt "How many veHYDX NFTs do I own?"
+bankr agent "Show my veHYDX NFT balance"
+bankr agent "How many veHYDX NFTs do I own?"
 ```
 
 To read directly — encode the owner address as a 32-byte padded hex value (strip `0x`, left-pad with 24 zeros) and call `eth_call`. Returns a `uint256` count.
@@ -207,16 +207,16 @@ After creating a lock, your voting power will be available for voting starting a
 
 ```bash
 # 1. Check HYDX balance
-bankr prompt "What's my HYDX balance on Base?"
+bankr agent "What's my HYDX balance on Base?"
 
 # 2. Approve HYDX
-bankr prompt "Approve 1000 HYDX to 0x25B2ED7149fb8A05f6eF9407d9c8F878f59cd1e1 on Base"
+bankr agent "Approve 1000 HYDX to 0x25B2ED7149fb8A05f6eF9407d9c8F878f59cd1e1 on Base"
 
 # 3. Create rolling lock
-bankr prompt "Lock 1000 HYDX on Hydrex with rolling lock"
+bankr agent "Lock 1000 HYDX on Hydrex with rolling lock"
 
 # 4. Check veHYDX NFT balance
-bankr prompt "Show my veHYDX NFT balance"
+bankr agent "Show my veHYDX NFT balance"
 ```
 
 ## Lock Type Details

--- a/hydrex/references/rewards.md
+++ b/hydrex/references/rewards.md
@@ -17,9 +17,9 @@ Hydrex distributes rewards as **oHYDX** (options HYDX) — a token that can be c
 ### Natural Language
 
 ```bash
-bankr prompt "Check my Hydrex rewards"
-bankr prompt "How much oHYDX have I earned on Hydrex?"
-bankr prompt "Show my unclaimed Hydrex incentives"
+bankr agent "Check my Hydrex rewards"
+bankr agent "How much oHYDX have I earned on Hydrex?"
+bankr agent "Show my unclaimed Hydrex incentives"
 ```
 
 ### Rewards API
@@ -54,8 +54,8 @@ If `unclaimed == 0`, skip — already fully claimed.
 ### Natural Language
 
 ```bash
-bankr prompt "Claim my Hydrex rewards"
-bankr prompt "Claim all my unclaimed Hydrex incentives"
+bankr agent "Claim my Hydrex rewards"
+bankr agent "Claim all my unclaimed Hydrex incentives"
 ```
 
 ### Steps Bankr Executes
@@ -96,9 +96,9 @@ oHYDX is an options token — exercising it converts it into a locked veHYDX pos
 ### Natural Language
 
 ```bash
-bankr prompt "Convert my oHYDX to veHYDX on Hydrex"
-bankr prompt "Exercise my Hydrex oHYDX rewards into veHYDX"
-bankr prompt "How much does it cost to exercise my oHYDX on Hydrex?"
+bankr agent "Convert my oHYDX to veHYDX on Hydrex"
+bankr agent "Exercise my Hydrex oHYDX rewards into veHYDX"
+bankr agent "How much does it cost to exercise my oHYDX on Hydrex?"
 ```
 
 ### `exerciseVe` Call
@@ -139,16 +139,16 @@ To read oHYDX balance directly — `balanceOf(address)` selector `0x70a08231`, e
 
 ```bash
 # 1. Check what rewards you've earned
-bankr prompt "Check my Hydrex rewards"
+bankr agent "Check my Hydrex rewards"
 
 # 2. Claim all unclaimed oHYDX
-bankr prompt "Claim my Hydrex oHYDX rewards"
+bankr agent "Claim my Hydrex oHYDX rewards"
 
 # 3. Check your oHYDX balance
-bankr prompt "What's my oHYDX balance on Base?"
+bankr agent "What's my oHYDX balance on Base?"
 
 # 4. Convert oHYDX into veHYDX (locking for voting power + fee earnings)
-bankr prompt "Exercise my oHYDX into veHYDX on Hydrex"
+bankr agent "Exercise my oHYDX into veHYDX on Hydrex"
 ```
 
 ## Implementation Guide for Bankr

--- a/hydrex/references/single-sided-liquidity.md
+++ b/hydrex/references/single-sided-liquidity.md
@@ -32,7 +32,7 @@ https://api.hydrex.fi/strategies?strategist=ichi&depositTokens=TOKEN_ADDRESS,TOK
 **Example — find BNKR deposit opportunities:**
 
 ```bash
-bankr prompt "What single-sided liquidity vaults can I deposit BNKR into on Hydrex?"
+bankr agent "What single-sided liquidity vaults can I deposit BNKR into on Hydrex?"
 ```
 
 The API fetches from: `https://api.hydrex.fi/strategies?strategist=ichi&depositTokens=0x22af33fe49fd1fa80c7149773dde5890d3c76f3b`
@@ -57,9 +57,9 @@ The API fetches from: `https://api.hydrex.fi/strategies?strategist=ichi&depositT
 Always specify the strategy by title (e.g., `"BNKR/WETH"`) or vault address so Bankr can unambiguously resolve which vault to use.
 
 ```bash
-bankr prompt "Deposit 100 BNKR into the BNKR/WETH strategy on Hydrex"
-bankr prompt "Deposit 500 USDC into the USDC/HYDX strategy on Hydrex"
-bankr prompt "Deposit 1000 HYDX into vault 0xABC...123 on Hydrex"
+bankr agent "Deposit 100 BNKR into the BNKR/WETH strategy on Hydrex"
+bankr agent "Deposit 500 USDC into the USDC/HYDX strategy on Hydrex"
+bankr agent "Deposit 1000 HYDX into vault 0xABC...123 on Hydrex"
 ```
 
 ### Steps Bankr Executes
@@ -95,9 +95,9 @@ Send transaction to 0x9A0EBEc47c85fD30F1fdc90F57d2b178e84DC8d8 on Base calling f
 ### Natural Language
 
 ```bash
-bankr prompt "Withdraw my BNKR/WETH single-sided position on Hydrex"
-bankr prompt "Remove 50% of my BNKR single-sided liquidity on Hydrex"
-bankr prompt "Exit my Hydrex BNKR vault position"
+bankr agent "Withdraw my BNKR/WETH single-sided position on Hydrex"
+bankr agent "Remove 50% of my BNKR single-sided liquidity on Hydrex"
+bankr agent "Exit my Hydrex BNKR vault position"
 ```
 
 ### Steps Bankr Executes
@@ -133,9 +133,9 @@ Send transaction to 0x9A0EBEc47c85fD30F1fdc90F57d2b178e84DC8d8 on Base calling f
 ### Natural Language
 
 ```bash
-bankr prompt "Show my Hydrex single-sided liquidity positions"
-bankr prompt "What's my BNKR/WETH vault balance on Hydrex?"
-bankr prompt "How much is my Hydrex BNKR single-sided position worth?"
+bankr agent "Show my Hydrex single-sided liquidity positions"
+bankr agent "What's my BNKR/WETH vault balance on Hydrex?"
+bankr agent "How much is my Hydrex BNKR single-sided position worth?"
 ```
 
 ### Calculating Underlying Tokens
@@ -188,29 +188,29 @@ Vault addresses are per-pair — always retrieve from `https://api.hydrex.fi/str
 
 ```bash
 # 1. Find available BNKR vaults
-bankr prompt "What single-sided liquidity vaults can I deposit BNKR into on Hydrex?"
+bankr agent "What single-sided liquidity vaults can I deposit BNKR into on Hydrex?"
 
 # 2. Check BNKR balance
-bankr prompt "What's my BNKR balance on Base?"
+bankr agent "What's my BNKR balance on Base?"
 
 # 3. Deposit
-bankr prompt "Deposit 500 BNKR into the BNKR/WETH single-sided vault on Hydrex"
+bankr agent "Deposit 500 BNKR into the BNKR/WETH single-sided vault on Hydrex"
 
 # 4. Confirm position
-bankr prompt "Show my Hydrex single-sided liquidity positions"
+bankr agent "Show my Hydrex single-sided liquidity positions"
 ```
 
 ### Withdraw from BNKR/WETH Vault
 
 ```bash
 # 1. Check current position
-bankr prompt "What's my BNKR/WETH vault balance on Hydrex?"
+bankr agent "What's my BNKR/WETH vault balance on Hydrex?"
 
 # 2. Full withdrawal
-bankr prompt "Withdraw my full BNKR/WETH single-sided position on Hydrex"
+bankr agent "Withdraw my full BNKR/WETH single-sided position on Hydrex"
 
 # 3. Partial withdrawal
-bankr prompt "Withdraw 25% of my BNKR single-sided position on Hydrex"
+bankr agent "Withdraw 25% of my BNKR single-sided position on Hydrex"
 ```
 
 ## Implementation Guide for Bankr

--- a/hydrex/references/voting.md
+++ b/hydrex/references/voting.md
@@ -35,7 +35,7 @@ Query your voting power (amount of veHYDX you can allocate for governance votes)
 **Contract**: `0xc69E3eF39E3fFBcE2A1c570f8d3ADF76909ef17b` (Base)
 
 ```bash
-bankr prompt "What's my Hydrex voting power?"
+bankr agent "What's my Hydrex voting power?"
 ```
 
 To read directly — encode the voter address as a 32-byte padded hex value (strip `0x`, left-pad with 24 zeros) and call `eth_call` on the Voter contract. Returns a `uint256` voting power in wei units.
@@ -47,7 +47,7 @@ To read directly — encode the voter address as a 32-byte padded hex value (str
 **Function**: Same `votingPower(address)` read — selector `0x90a40d0a` — then multiply result by 1.3.
 
 ```bash
-bankr prompt "What's my Hydrex earning power?"
+bankr agent "What's my Hydrex earning power?"
 ```
 
 ```
@@ -68,7 +68,7 @@ Check how an address has allocated votes across pools:
 **Function**: `poolVoteLength(address)` — selector `0x29199aa4`
 
 ```bash
-bankr prompt "How many pools am I currently voting on in Hydrex?"
+bankr agent "How many pools am I currently voting on in Hydrex?"
 ```
 
 To read directly — encode voter address as 32-byte padded hex and call `eth_call`. Returns `uint256` count of pools voted for.
@@ -78,7 +78,7 @@ To read directly — encode voter address as 32-byte padded hex and call `eth_ca
 **Function**: `poolVote(address, uint256)` — selector `0xd73d1f9b`
 
 ```bash
-bankr prompt "Show which pools I'm voting on in Hydrex"
+bankr agent "Show which pools I'm voting on in Hydrex"
 ```
 
 To read directly — encode voter address + index (both 32-byte padded) and call `eth_call`. Returns the pool address at that index. Iterate from 0 to `poolVoteLength - 1`.
@@ -88,7 +88,7 @@ To read directly — encode voter address + index (both 32-byte padded) and call
 **Function**: `votes(address voter, address pool)` — selector `0xd23254b4`
 
 ```bash
-bankr prompt "How many votes do I have on the HYDX/USDC pool in Hydrex?"
+bankr agent "How many votes do I have on the HYDX/USDC pool in Hydrex?"
 ```
 
 To read directly — encode voter address + pool address (both 32-byte padded) and call `eth_call`. Returns `uint256` vote weight allocated to that pool.
@@ -101,8 +101,8 @@ Get current voting weight for any pool:
 **Contract**: `0xc69E3eF39E3fFBcE2A1c570f8d3ADF76909ef17b` (Base)
 
 ```bash
-bankr prompt "What's the current voting weight for the HYDX/USDC pool on Hydrex?"
-bankr prompt "Show voting weights for all Hydrex pools"
+bankr agent "What's the current voting weight for the HYDX/USDC pool on Hydrex?"
+bankr agent "Show voting weights for all Hydrex pools"
 ```
 
 To read directly — encode pool address as 32-byte padded hex and call `eth_call`. Returns `uint256` total votes allocated to that pool. Use pool addresses from `https://api.hydrex.fi/strategies` (`address` field).
@@ -196,7 +196,7 @@ Be aware of voting constraints:
 **Function**: `lastVoted(address)` — selector `0x77b887b9`
 
 ```bash
-bankr prompt "When did I last vote on Hydrex?"
+bankr agent "When did I last vote on Hydrex?"
 ```
 
 To read directly — encode voter address as 32-byte padded hex and call `eth_call`. Returns `uint256` Unix timestamp of last vote. Compare against current time + `VOTE_DELAY` to determine if a new vote is allowed.
@@ -236,7 +236,7 @@ When choosing pools to vote for, consider:
 When the user requests optimized voting, follow this process:
 
 1. **Fetch all pools** from `https://api.hydrex.fi/strategies`
-2. **Get user's earning power**: Use `bankr prompt "What's my Hydrex earning power?"`, or query voting power via Bankr and multiply by 1.3
+2. **Get user's earning power**: Use `bankr agent "What's my Hydrex earning power?"`, or query voting power via Bankr and multiply by 1.3
 3. **Calculate fee efficiency** for each pool:
 
    ```
@@ -367,13 +367,13 @@ curl -s https://api.hydrex.fi/strategies | jq '.[] | {
 } | select(.projectedFees != null)' | jq -s 'sort_by(-.efficiency)'
 
 # 2. Check your voting power
-bankr prompt "What's my Hydrex voting power?"
+bankr agent "What's my Hydrex voting power?"
 
 # 3. Vote via Bankr natural language
-bankr prompt "Vote 60% on HYDX/USDC and 40% on cbBTC/WETH on Hydrex"
+bankr agent "Vote 60% on HYDX/USDC and 40% on cbBTC/WETH on Hydrex"
 
 # 4. Verify vote
-bankr prompt "Show which pools I'm voting on in Hydrex"
+bankr agent "Show which pools I'm voting on in Hydrex"
 ```
 
 ### Optimization Example for Bankr

--- a/veil/scripts/veil-bankr-prompt.sh
+++ b/veil/scripts/veil-bankr-prompt.sh
@@ -16,7 +16,7 @@ fi
 
 # CLI path (preferred) — need_bankr already verified one of these is available
 if command -v bankr >/dev/null 2>&1; then
-  exec bankr prompt "$PROMPT"
+  exec bankr agent "$PROMPT"
 fi
 
 # Curl fallback — config file was validated by need_bankr


### PR DESCRIPTION
## Summary

- Replace deprecated `bankr prompt` → `bankr agent` across 19 files (scripts, SKILL.md docs, and reference docs)
- Replace deprecated `bankr profile` → `bankr agent profile` in agent-profiles reference
- Fix deprecation table in `bankr/SKILL.md`: correct `bankr agent prompt` to `bankr agent`, add missing `bankr sign` → `bankr wallet sign` and `bankr submit` → `bankr wallet submit` entries

Mirrors the CLI deprecation changes from BankrBot/bankr#1135.

## Test plan

- [ ] Verify all `bankr prompt` references in skills are updated (only the deprecation table should mention it)
- [ ] Verify shell scripts in `erc-8004/`, `ens-primary-name/`, `endaoment/`, `veil/` use `bankr agent` instead of `bankr prompt`
- [ ] Verify `hydrex/` example commands use `bankr agent`
- [ ] Verify `bankr/references/agent-profiles.md` uses `bankr agent profile`

https://claude.ai/code/session_01QR4Mad879dKsYjV9CaE1vi