### PR TITLE
Add UPDF2MD PDF-to-Markdown skill

### DIFF
--- a/updf2md/SKILL.md
+++ b/updf2md/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: updf2md
+description: Convert public PDF URLs into Markdown for RAG, document extraction, and MCP workflows using the hosted URL2AI x402 endpoint. Use when an agent needs reliable PDF-to-Markdown conversion, OCR/layout metadata, or a paid production-ready PDF parsing tool instead of scraping a PDF manually.
+---
+
+# UPDF2MD: PDF to Markdown for Agents
+
+UPDF2MD is a hosted PDF-to-Markdown conversion endpoint inside the URL2AI ecosystem. It is designed for AI agents, RAG pipelines, and document extraction workflows that need structured text from public PDFs.
+
+## Why use it
+
+- Convert a public PDF URL directly into Markdown
+- Return document metadata such as `pdf_type`
+- Use a paid endpoint with predictable behavior instead of ad hoc PDF scraping
+- Fit naturally into MCP and agent workflows
+
+## Endpoint
+
+`https://x402.bankr.bot/0x444fadbd6e1fed0cfbf7613b6c9f91b9021eecbd/updf2md`
+
+## Pricing
+
+- `0.001 USDC / request`
+- Billing is handled by Bankr x402
+- Clients receive a `402 Payment Required` challenge before paid execution
+
+## Input
+
+Send JSON with:
+
+- `pdf_url` (required): public PDF URL over `http` or `https`
+- `pages` (optional): page selection like `1-3,5`
+- `filename` (optional): override filename when the source URL is ambiguous
+
+## Output
+
+Returns JSON including:
+
+- `markdown`
+- `pdf_type`
+- `processing_time_ms`
+- layout / OCR metadata from the backend converter
+
+## CLI examples
+
+```bash
+bankr x402 schema https://x402.bankr.bot/0x444fadbd6e1fed0cfbf7613b6c9f91b9021eecbd/updf2md
+```
+
+```bash
+bankr x402 call https://x402.bankr.bot/0x444fadbd6e1fed0cfbf7613b6c9f91b9021eecbd/updf2md \
+  -X POST \
+  -H 'content-type: application/json' \
+  -d '{"pdf_url":"https://example.com/document.pdf"}'
+```
+
+## Web demo
+
+Try the public demo here:
+
+`https://aiknowledgecms.exbridge.jp/updf2md.php`
+
+## When agents should use this skill
+
+- A public PDF is blocking the workflow
+- The agent needs Markdown for chunking, retrieval, or structured analysis
+- The task benefits from a paid, production-style PDF conversion tool
+
+## Notes
+
+- This skill is one product inside the broader URL2AI ecosystem
+- URL2AI also provides other URL-native AI tools such as UStory, UParse, UDebate, UMedia, XInsight, and KnowRadar

--- a/updf2md/references/agent-instructions.md
+++ b/updf2md/references/agent-instructions.md
@@ -1,0 +1,16 @@
+# Agent Instructions
+
+Use UPDF2MD when a public PDF is the source of truth and downstream work depends on readable Markdown.
+
+Recommended flow:
+
+1. Call the hosted UPDF2MD endpoint with `pdf_url`
+2. Read the returned `markdown`
+3. Use document metadata such as `pdf_type` to decide whether to trust the text as-is or treat it as OCR-sensitive
+4. Continue with summarization, extraction, RAG chunking, or citation
+
+Prefer this skill over manual PDF scraping when:
+
+- The PDF is central to the task
+- Layout quality matters
+- You want a paid, production-ready endpoint with explicit billing


### PR DESCRIPTION
## Summary

Adds a new `updf2md` skill for converting public PDF URLs into Markdown.

This skill is intended for:
- RAG pipelines
- document extraction workflows
- MCP / agent workflows
- paid production-style PDF parsing via Bankr x402

## Included

- `updf2md/SKILL.md`
- `updf2md/references/agent-instructions.md`

## Hosted endpoint

`https://x402.bankr.bot/0x444fadbd6e1fed0cfbf7613b6c9f91b9021eecbd/updf2md`

## Demo

`https://aiknowledgecms.exbridge.jp/updf2md.php`

## Pricing

- `0.001 USDC / request`
- billed through Bankr x402
