### PR TITLE
fix: update stale bankr-signals references after rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Bankr Skills equip builders with plug-and-play tools to build more powerful agen
 | --- | --- | --- |
 | [Bankr](https://bankr.bot) | [bankr](bankr/) | Launch a token, earn from every trade, and fund your agent. Built-in wallet with IP whitelisting, hallucination guards, and transaction verification. |
 | [Builder's Garden](https://builders.garden) | [siwa](siwa/) | Sign-In With Agent (SIWA) authentication for ERC-8004 registered agents. Sign messages using Bankr wallets, verify on the server, and protect API routes with ERC-8128. |
-| [Axiom](https://clawbots.org) | [bankr-signals](bankr-signals/) | Transaction-verified trading signals on Base. Register as provider, publish trades with TX hash proof, consume signals from top performers. |
+| [Axiom](https://clawbots.org) | [signals](signals/) | Transaction-verified trading signals on Base. Register as provider, publish trades with TX hash proof, consume signals from top performers. |
 | botchan | [botchan](botchan/) | On-chain agent messaging on Base. Explore agents, post to feeds, send DMs, store data permanently via Net Protocol. |
 | [Endaoment](https://endaoment.org) | [endaoment](endaoment/) | Charitable donations on-chain. Look up 501(c)(3) organizations by EIN, donate crypto, deploy donor-advised fund entities. |
 | [ENS](https://ens.domains) | [ens-primary-name](ens-primary-name/) | ENS name management. Set primary names, update avatars, manage reverse resolution across L1 and L2. |

--- a/signals/SKILL.md
+++ b/signals/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: bankr-signals
+name: signals
 description: >
   Transaction-verified trading signals on Base. Register agent as signal provider,
   publish trades with TX hash proof, consume signals from top performers via REST API.


### PR DESCRIPTION
## Summary
- Fixed broken link in README.md: `bankr-signals/` → `signals/` (directory was renamed in #316)
- Updated SKILL.md frontmatter `name: bankr-signals` → `name: signals`

## Test plan
- [ ] Verify README link to `signals/` resolves correctly on GitHub
- [ ] Confirm skill name renders correctly in any tooling that reads SKILL.md frontmatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)