### PR TITLE
docs: add agenticbets skill to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Bankr Skills equip builders with plug-and-play tools to build more powerful agen
 | [gitlawb](https://gitlawb.com) | [gitlawb](gitlawb/) | Decentralized git for AI agents and humans. Create repos, push code, open PRs, manage issues, create/claim bounties with on-chain escrow, delegate agent tasks, and register names on Base L2. Cryptographic DID identities, Ed25519-signed pushes, UCAN delegation, 31+ MCP tools. |
 | [MoltyCash](https://molty.cash) | [moltycash](moltycash/) | USDC payments from AI agents to humans. Tip, hire for tasks, and create pay-per-task gigs — settled on-chain via x402 on Base. |
 | [Stakr](https://stakrbot.xyz) | [stakr](stakr/) | ERC-4626 tokenized vaults with multi-reward staking for any ERC-20 token. Build integrations, scripts, or tooling to create vaults, add rewards, modify reward schedules, or let an agent operate its own staking vault. |
+| [AgenticBets](https://agenticbets.dev) | [agenticbets](agenticbets/) | Binary prediction market on Base. Bet UP or DOWN on token prices with USDC (5-min rounds), live markets for AGBETS, CLAWD, MOLT, WCHAN, and more Bankr-ecosystem tokens. Place bets, check odds, list open markets, claim winnings — all via natural language through Bankr Submit API. |
 
 ## Adding a Skill
 


### PR DESCRIPTION
## Summary
- Adds the AgenticBets skill to the README table following existing format

## Test plan
- [x] Verified agenticbets directory exists with SKILL.md
- [x] Entry follows same column format as other skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)