### PR TITLE
litcoin: sync to v2.3.0 — RS vertical + boost auto-enrollment + SDK 4.14.8

### DIFF
--- a/litcoin/README.md
+++ b/litcoin/README.md
@@ -1,46 +1,89 @@
 # LITCOIN Agent Skill
 
-Mine $LITCOIN by solving comprehension challenges and real research problems. Full DeFi protocol access for coding agents.
+Mine $LITCOIN by solving comprehension challenges and real research problems. Full DeFi protocol access for coding agents. Conforms to the open [agentskills.io](https://agentskills.io) standard, so it installs natively in every compliant agent (Hermes, Claude Code, Codex, Cursor, Gemini CLI, OpenCode, OpenHands, Goose, GitHub Copilot, VS Code, and more).
 
 ## Install
 
+### Hermes (Nous Research)
+
 ```bash
-npx skills add tekkaadan/litcoin-skill
+hermes skills install well-known/litcoin.app/litcoin-miner
+```
+
+Or via the skills.sh GitHub aggregator:
+
+```bash
+hermes skills install skills-sh/tekkaadan/litcoin-skill
+```
+
+### Claude Code
+
+**Windows (PowerShell):**
+
+```powershell
+git clone https://github.com/tekkaadan/litcoin-skill.git "$env:USERPROFILE\.claude\skills\litcoin-miner"
+```
+
+**macOS / Linux:**
+
+```bash
+git clone https://github.com/tekkaadan/litcoin-skill.git ~/.claude/skills/litcoin-miner
+```
+
+Then restart Claude Code. The skill auto-activates on crypto, mining, and DeFi prompts.
+
+### Codex, Cursor, OpenCode, Goose, Gemini CLI, and any other agentskills.io-compatible client
+
+Clone directly into your agent's skills directory. Example for Cursor:
+
+```bash
+git clone https://github.com/tekkaadan/litcoin-skill.git ~/.cursor/skills/litcoin-miner
+```
+
+The skill folder name must be `litcoin-miner` to match the `name` field in the SKILL.md frontmatter. Most agents also accept a direct GitHub identifier; see your client's docs.
+
+### Universal (no skill runtime needed)
+
+The Python SDK works from any environment, including scripts and custom agents:
+
+```bash
+pip install litcoin
 ```
 
 ## What It Does
 
-Gives your coding agent (Claude Code, OpenClaw, Codex, etc.) the ability to:
+Gives your agent the ability to:
 
 - **Mine**: Comprehension challenges (no LLM needed) + research optimization
-- **Research**: Solve real problems across 7 domains (algorithms, math, bioinformatics, ML, pattern recognition, software engineering, code optimization)
-- **DeFi**: Stake (4 tiers), open vaults, mint LITCREDIT, manage guilds, deposit escrow
+- **Research**: Solve real problems across 20 adapters (algorithms, math, bioinformatics, ML, pattern recognition, software engineering, code optimization, security audits, red team, knowledge synthesis, exploit forensics, adversarial robustness, agentic traces, TCG intelligence, and more)
+- **DeFi**: Stake (4 tiers), open vaults (LITCOIN or USDC collateral), mint LITCREDIT, manage guilds, deposit escrow
 - **Relay**: Serve AI inference and earn 2x LITCOIN
 - **Agents**: Deploy autonomous Sentinels that run the full flywheel 24/7
 
 ## Requirements
 
-- Bankr API key (get at [bankr.bot/api](https://bankr.bot/api))
+- Bankr API key with agent write access (get at [bankr.bot/api](https://bankr.bot/api))
 - Optional: AI provider key for research mining (OpenRouter, Bankr LLM, Groq, etc.)
+- Python 3.9+ (installed automatically by most agents)
 
 ## Protocol Stats
 
-- 1.55M+ verified research submissions
-- 7 research adapters, 1,599 active problems
-- 20+ AI model families competing
+- 3.3M+ verified research submissions
+- 20 research adapters, 2,653+ active problems
+- 73+ AI model families competing
 - Proven: LoRA fine-tune on LITCOIN data improved Qwen2.5-Coder-7B by +3.0 points on HumanEval
 - Code execution sandboxed in Docker (no network, memory limited, read-only)
 - Dataset: [huggingface.co/datasets/tekkaadan/litcoin-research](https://huggingface.co/datasets/tekkaadan/litcoin-research)
 
 ## Links
 
-- Site: [litcoiin.xyz](https://litcoiin.xyz)
-- SDK: `pip install litcoin` (v4.9.2)
-- MCP Server: `npx litcoin-mcp` (v2.4.0, 43 tools)
-- Research Lab: [litcoiin.xyz/research](https://litcoiin.xyz/research)
-- Proof: [litcoiin.xyz/proof](https://litcoiin.xyz/proof)
-- Compute: [litcoiin.xyz/compute](https://litcoiin.xyz/compute)
+- Site: [litcoin.app](https://litcoin.app)
+- SDK: `pip install litcoin` (v4.10.3)
+- Research Lab: [litcoin.app/research](https://litcoin.app/research)
+- Proof: [litcoin.app/proof](https://litcoin.app/proof)
+- Compute: [litcoin.app/compute](https://litcoin.app/compute)
 - Chain: Base mainnet (8453)
+- Contact: [contact@litcoin.app](mailto:contact@litcoin.app)
 
 ## License
 

--- a/litcoin/README.md
+++ b/litcoin/README.md
@@ -1,6 +1,6 @@
 # LITCOIN Agent Skill
 
-Mine $LITCOIN by solving comprehension challenges and real research problems. Full DeFi protocol access for coding agents. Conforms to the open [agentskills.io](https://agentskills.io) standard, so it installs natively in every compliant agent (Hermes, Claude Code, Codex, Cursor, Gemini CLI, OpenCode, OpenHands, Goose, GitHub Copilot, VS Code, and more).
+Mine $LITCOIN by solving comprehension challenges and real research problems. Full DeFi protocol access for coding agents, plus hosted mining and the entire protocol surface routable through @bankrbot on X. Conforms to the open [agentskills.io](https://agentskills.io) standard, so it installs natively in every compliant agent (Hermes, Claude Code, Codex, Cursor, Gemini CLI, OpenCode, OpenHands, Goose, GitHub Copilot, VS Code, and more).
 
 ## Install
 
@@ -57,8 +57,10 @@ Gives your agent the ability to:
 - **Mine**: Comprehension challenges (no LLM needed) + research optimization
 - **Research**: Solve real problems across 24 adapters (algorithms, math, bioinformatics, ML, pattern recognition, software engineering, code optimization, security audits, red team, knowledge synthesis, exploit forensics, adversarial robustness, agentic traces, TCG intelligence, RuneScape vertical with insight + TA + sentiment + update-impact across OSRS and RS3, and more)
 - **DeFi**: Stake (4 tiers), open vaults (LITCOIN or USDC collateral), mint LITCREDIT, manage guilds, deposit escrow
+- **Delegation**: Direct stake-power to one of six Nen archetype pools, opt into the boost program, claim commission
 - **Relay**: Serve AI inference and earn 2x LITCOIN
 - **Agents**: Deploy autonomous Sentinels that run the full flywheel 24/7
+- **Bankr-native**: Every protocol surface above is routable through @bankrbot on X using only a bk_ key. Hosted mining uses the Bankr key as the LLM key against llm.bankr.bot, so no OpenRouter or Python is required.
 
 ## Requirements
 
@@ -69,7 +71,7 @@ Gives your agent the ability to:
 ## Protocol Stats
 
 - 3.3M+ verified research submissions
-- 20 research adapters, 2,653+ active problems
+- 24 research adapters, 2,653+ active problems
 - 73+ AI model families competing
 - Proven: LoRA fine-tune on LITCOIN data improved Qwen2.5-Coder-7B by +3.0 points on HumanEval
 - Code execution sandboxed in Docker (no network, memory limited, read-only)
@@ -78,7 +80,7 @@ Gives your agent the ability to:
 ## Links
 
 - Site: [litcoin.app](https://litcoin.app)
-- SDK: `pip install litcoin` (v4.10.3)
+- SDK: `pip install litcoin` (v4.15.1)
 - Research Lab: [litcoin.app/research](https://litcoin.app/research)
 - Proof: [litcoin.app/proof](https://litcoin.app/proof)
 - Compute: [litcoin.app/compute](https://litcoin.app/compute)

--- a/litcoin/README.md
+++ b/litcoin/README.md
@@ -55,7 +55,7 @@ pip install litcoin
 Gives your agent the ability to:
 
 - **Mine**: Comprehension challenges (no LLM needed) + research optimization
-- **Research**: Solve real problems across 20 adapters (algorithms, math, bioinformatics, ML, pattern recognition, software engineering, code optimization, security audits, red team, knowledge synthesis, exploit forensics, adversarial robustness, agentic traces, TCG intelligence, and more)
+- **Research**: Solve real problems across 24 adapters (algorithms, math, bioinformatics, ML, pattern recognition, software engineering, code optimization, security audits, red team, knowledge synthesis, exploit forensics, adversarial robustness, agentic traces, TCG intelligence, RuneScape vertical with insight + TA + sentiment + update-impact across OSRS and RS3, and more)
 - **DeFi**: Stake (4 tiers), open vaults (LITCOIN or USDC collateral), mint LITCREDIT, manage guilds, deposit escrow
 - **Relay**: Serve AI inference and earn 2x LITCOIN
 - **Agents**: Deploy autonomous Sentinels that run the full flywheel 24/7

--- a/litcoin/SKILL.md
+++ b/litcoin/SKILL.md
@@ -5,7 +5,7 @@ license: MIT-0
 compatibility: "Requires Python 3.9+ and pip. Network access to api.litcoin.app."
 metadata:
   author: tekkaadan
-  version: "2.2.0"
+  version: "2.3.0"
   homepage: "https://litcoin.app"
   repository: "https://github.com/tekkaadan/litcoin-skill"
   tags: [crypto, mining, defi, ai-agent, base, research, staking, litcoin]
@@ -76,10 +76,11 @@ result = agent.research_mine()
 # Iterate on one task (this is where breakthroughs happen)
 agent.research_loop(task_id="sort-benchmark-001", rounds=50, delay=30)
 
-# List available tasks (20 adapters: code_optimization, algorithm, pattern_recognition, software_engineering,
+# List available tasks (24 adapters: code_optimization, algorithm, pattern_recognition, software_engineering,
 # bioinformatics, mathematics, compression, security-audit, red-team, proof-of-verification,
 # knowledge-synthesis, exploit-forensics, adversarial-robustness, agentic-trace,
-# tcg-card-profile, tcg-sentiment, and more)
+# tcg-card-profile, tcg-sentiment, vault-comp, variant-pathogenicity,
+# runescape-insight, runescape-ta, runescape-sentiment, runescape-update-impact, and more)
 tasks = agent.research_tasks()
 ```
 
@@ -297,6 +298,8 @@ Miners can opt INTO a pool's boost program to earn the boost share that delegato
 
 The boost share is sourced from a 2.5% carve-out of the daily research pool plus recycled forfeits (failed pools' pending yield, unused boost, miner penalties, and emergency-exit penalties all flow back into the research mining pool, which then refeeds the carve-out). Unbacked miners are unaffected.
 
+**Auto-enrollment (added 2026-05-04).** Miners who consistently produce in one archetype get auto-enrolled into that pool at Conservative tier with a 14-day risk-free preview. During preview, the boost upside fires on qualifying days but the haircut clause is suspended even on missed-threshold days. The eligibility filter requires ≥10 verified subs in the last 7 days, average quality ≥6/10, and one archetype representing ≥60% of submission volume. Generalists are excluded (they would miss threshold and lose money). After preview matures, normal rules apply automatically. Operator can opt out anytime during preview, zero penalty. Check status with `GET /v1/boost/preview-status?wallet=...` or via the dashboard banner.
+
 ### Read State
 - `balance()` — LITCOIN + LITCREDIT
 - `oracle_prices()` — CPI and LITCOIN prices
@@ -320,10 +323,10 @@ The SDK raises exceptions with clear messages:
 
 - Chain: Base mainnet (8453)
 - Token: `0x316ffb9c875f900AdCF04889E415cC86b564EBa3`
-- SDK: v4.14.1 on [PyPI](https://pypi.org/project/litcoin/)
+- SDK: v4.14.8 on [PyPI](https://pypi.org/project/litcoin/)
 - Emission: 1.0% APR of treasury (soft-landing)
 - 1 LITCREDIT = 1,000 output tokens of frontier AI
-- 20 research adapters producing verified code and structured data
+- 24 research adapters producing verified code and structured data (incl. RuneScape vertical Phases 1-4)
 - TCG intelligence across Pokemon, Magic, Yu-Gi-Oh, One Piece, Greed Island
 - Docs: https://litcoin.app/docs
 - Cards: https://litcoin.app/cards

--- a/litcoin/SKILL.md
+++ b/litcoin/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: litcoin-miner
-description: "Mine LITCOIN, a proof-of-comprehension and proof-of-research cryptocurrency on Base. Use when the user wants to mine crypto with AI, earn tokens through reading comprehension or solving optimization problems, stake LITCOIN, open vaults, mint LITCREDIT, manage mining guilds, deploy autonomous agents, or interact with the LITCOIN DeFi protocol."
+description: "Mine, stake, claim, and manage LITCOIN end-to-end through Bankr. Hosted mining via @bankrbot: 'start a research miner for me' deploys a server-side Sentinel that uses the Bankr key as the LLM key against llm.bankr.bot, so no other AI provider is needed. Stake at one of four tiers (Spark, Circuit, Conduit, Architect), claim accumulated rewards, delegate LITCOIN to one of six Nen archetype boost pools, opt into the miner boost program, open vaults, mint LITCREDIT, manage mining guilds, check or fund the compute escrow, become a LITCOIN X compute provider, or interact with the LITCOIN DeFi protocol on Base."
 license: MIT-0
 compatibility: "Requires Python 3.9+ and pip. Network access to api.litcoin.app."
 metadata:
   author: tekkaadan
-  version: "2.3.0"
+  version: "2.4.0"
   homepage: "https://litcoin.app"
   repository: "https://github.com/tekkaadan/litcoin-skill"
   tags: [crypto, mining, defi, ai-agent, base, research, staking, litcoin]
@@ -96,6 +96,56 @@ agent = Agent(
 )
 agent.research_mine()
 ```
+
+## Bankr X Bot (@bankrbot) Integration
+
+Every Python SDK call above maps to a coordinator endpoint at `https://api.litcoin.app/v1/bankr/*`. Bankr's @bankrbot on X is wired into this surface, so a Bankr user can do the entire LITCOIN flywheel from X with plain-language requests like:
+
+- "claim my litcoin rewards"
+- "stake 5M litcoin into tier 2"
+- "upgrade my stake to architect"
+- "add 10M to my stake"
+- "open a usdc vault with 1000"
+- "mint 500 litcredit from vault 7"
+- "delegate 100% of my stake to manipulator"
+- "opt me into the conjurer boost pool"
+- "join guild 1 with 5M"
+- "deposit 100 litcredit into compute escrow"
+
+Bankr resolves the user's wallet from their bk_ key, the coordinator builds the calldata, Bankr signs and submits the tx on Base. No private key ever touches the coordinator. The full Bankr surface today:
+
+| Domain | Endpoints |
+|---|---|
+| Claims | `/v1/bankr/claim-with-key` |
+| Staking | `stake` `unstake` `early-unstake` `upgrade-tier` `add-to-stake` `stake/info` |
+| Vaults | `vault/open` `vault/add-collateral` `vault/mint` `vault/repay` `vault/withdraw` `vault/close` `vault/details` |
+| Delegation | `delegate` `undelegate` `boost/opt-in` `boost/opt-out` |
+| Guilds | `guild/join` `guild/leave` `guild/unstake` |
+| Hosted mining | `mine/start` `mine/stop` `mine/status` |
+| Compute | `escrow/deposit` `compute/status` `compute/balance` `compute/become-provider` |
+| Read | `balance` |
+| Buy | Bankr's native swap on Aerodrome handles this. DM `@bankrbot "swap 100 usdc for litcoin"` directly. No coordinator endpoint needed. |
+
+All Bankr-routed delegation changes pass through a 24-hour safety window (rate-limited to 3 per wallet per 24h, max 50% of stake-power per change) before activating. All other Bankr calls execute immediately on-chain. Set `BANKR_API_KEY` once and every Agent method routes through Bankr automatically.
+
+### Hosted mining via Bankr (zero AI key required)
+
+`POST /v1/bankr/mine/start` deploys a hosted Sentinel that runs server-side. The Bankr key doubles as the AI key against `https://llm.bankr.bot/v1`, so the user never needs an OpenRouter account or a Python install. Strategies accept human-friendly aliases (`sentinel`, `architect`, `vanguard`, `research`, `audit`, `forensics`, `recipe`) plus the canonical IDs. The underlying 5M LITCOIN balance check from `/v1/agent/deploy` still applies.
+
+```
+POST /v1/bankr/mine/start
+{ "bankrKey": "bk_...", "strategy": "research" }
+
+POST /v1/bankr/mine/status
+{ "bankrKey": "bk_..." }
+
+POST /v1/bankr/mine/stop
+{ "bankrKey": "bk_..." }
+```
+
+### Becoming a compute provider (via Bankr or otherwise)
+
+Compute serving requires a long-lived WebSocket from the LITCOIN X desktop app. `POST /v1/bankr/compute/become-provider` checks 5M LITCOIN eligibility (staked or liquid) and returns a structured next-steps payload pointing at `litcoin.app/x`. The desktop app does the real registration on first launch. `POST /v1/bankr/compute/status` returns live provider metrics once the desktop app is running.
 
 ## Staking (Mining Boost)
 
@@ -323,7 +373,7 @@ The SDK raises exceptions with clear messages:
 
 - Chain: Base mainnet (8453)
 - Token: `0x316ffb9c875f900AdCF04889E415cC86b564EBa3`
-- SDK: v4.14.9 on [PyPI](https://pypi.org/project/litcoin/)
+- SDK: v4.15.1 on [PyPI](https://pypi.org/project/litcoin/)
 - Emission: 1.0% APR of treasury (soft-landing)
 - 1 LITCREDIT = 1,000 output tokens of frontier AI
 - 24 research adapters producing verified code and structured data (incl. RuneScape vertical Phases 1-4)

--- a/litcoin/SKILL.md
+++ b/litcoin/SKILL.md
@@ -1,12 +1,21 @@
 ---
 name: litcoin-miner
-description: "Mine LITCOIN — a proof-of-comprehension and proof-of-research cryptocurrency on Base. Use when the user wants to mine crypto with AI, earn tokens through reading comprehension or solving optimization problems, stake LITCOIN, open vaults, mint LITCREDIT, manage mining guilds, deploy autonomous agents, or interact with the LITCOIN DeFi protocol."
+description: "Mine LITCOIN, a proof-of-comprehension and proof-of-research cryptocurrency on Base. Use when the user wants to mine crypto with AI, earn tokens through reading comprehension or solving optimization problems, stake LITCOIN, open vaults, mint LITCREDIT, manage mining guilds, deploy autonomous agents, or interact with the LITCOIN DeFi protocol."
 license: MIT-0
-compatibility: "Requires Python 3.9+ and pip. Network access to api.litcoiin.xyz."
-homepage: "https://litcoiin.xyz"
+compatibility: "Requires Python 3.9+ and pip. Network access to api.litcoin.app."
 metadata:
   author: tekkaadan
-  version: "2.0.0"
+  version: "2.2.0"
+  homepage: "https://litcoin.app"
+  repository: "https://github.com/tekkaadan/litcoin-skill"
+  tags: [crypto, mining, defi, ai-agent, base, research, staking, litcoin]
+  hermes:
+    tags: [crypto, mining, defi, ai-agent, base, research, staking]
+    required_environment_variables:
+      - name: BANKR_API_KEY
+        prompt: "Paste your Bankr API key (starts with 'bk_'). Get one at https://bankr.bot/api with agent write access enabled."
+        help: "Controls the on-chain wallet used for mining, claims, staking, and vault operations."
+        required_for: [mining, claims, staking, vaults, compute]
   openclaw:
     requires:
       env: ["BANKR_API_KEY"]
@@ -15,9 +24,6 @@ metadata:
     requires:
       env: ["BANKR_API_KEY"]
       primaryEnv: "BANKR_API_KEY"
-  hermes:
-    tags: [crypto, mining, defi, ai-agent, base, research, staking]
-    category: crypto
 ---
 
 # LITCOIN Miner
@@ -70,7 +76,10 @@ result = agent.research_mine()
 # Iterate on one task (this is where breakthroughs happen)
 agent.research_loop(task_id="sort-benchmark-001", rounds=50, delay=30)
 
-# List available tasks (20 tasks across code_optimization, algorithm, pattern_recognition, software_engineering, bioinformatics, mathematics)
+# List available tasks (20 adapters: code_optimization, algorithm, pattern_recognition, software_engineering,
+# bioinformatics, mathematics, compression, security-audit, red-team, proof-of-verification,
+# knowledge-synthesis, exploit-forensics, adversarial-robustness, agentic-trace,
+# tcg-card-profile, tcg-sentiment, and more)
 tasks = agent.research_tasks()
 ```
 
@@ -147,6 +156,30 @@ result = agent.compute("Explain proof of research")
 print(result['response'])
 ```
 
+## TCG Intelligence
+
+Query the card catalog across Pokemon, Magic, Yu-Gi-Oh, One Piece, and Greed Island. 800K+ cards indexed with live pricing and community sentiment.
+
+```python
+# Catalog stats
+stats = agent.tcg_stats()
+
+# Search by game, rarity, sort by price
+holos = agent.tcg_search(game="pokemon", rarity="Holo Rare", sort="price-desc", limit=10)
+
+# Single card details + latest price
+card = agent.tcg_card("pokemon", "base1", "4")  # Base set Charizard
+
+# 90-day price history for one card
+history = agent.tcg_price_history("pokemon", "base1", "4", days=90)
+
+# Currently trending cards
+trending = agent.tcg_trending(game="mtg", days=7, limit=20)
+
+# Live prices for top-value cards (refreshed every 30 minutes)
+live = agent.tcg_prices_live()
+```
+
 ## Full Flywheel Example
 
 ```python
@@ -204,8 +237,16 @@ print(result['response'])
 - `vault_health(vault_id)` — Collateral ratio
 
 ### Compute
-- `deposit_escrow(amount)` — Deposit LITCREDIT
-- `compute(prompt)` — AI inference via relay network
+- `deposit_escrow(amount)` - Deposit LITCREDIT
+- `compute(prompt)` - AI inference via relay network
+
+### TCG Intelligence
+- `tcg_stats()` - Catalog stats across all five games
+- `tcg_search(game, query, set_code, rarity, sort, limit, offset)` - Search cards (sort: name, number, rarity, price-desc, price-asc, recent)
+- `tcg_card(game, set_code, card_number)` - Full card details + latest price
+- `tcg_price_history(game, set_code, card_number, days)` - Daily price history (up to 365 days)
+- `tcg_trending(game, days, limit)` - Trending cards by price momentum + sentiment
+- `tcg_prices_live()` - Live prices for top-value cards across all games
 
 ### Guilds
 - `create_guild(name)` — Create guild
@@ -214,6 +255,47 @@ print(result['response'])
 - `stake_guild(tier)` — Stake pool (leader)
 - `unstake_guild()` — Unstake pool (leader)
 - `guild_membership()` — Your guild info
+
+### Delegation (Liquidity → Production)
+Direct your already-staked LITCOIN at one of six research archetypes
+(Enhancer, Transmuter, Conjurer, Specialist, Manipulator, Emitter). Backed
+miners get a boost; you earn commission on what they produce. Funds never
+move — your principal stays in the staking contract. Tier-weighted power:
+Spark 1x, Circuit 2x, Core 4x, Architect 8x.
+
+Pool IDs: `0=Enhancer 1=Transmuter 2=Conjurer 3=Specialist 4=Manipulator 5=Emitter`
+
+- `delegate(allocations)` — Sign + record delegation. Allocations is a list
+  of `{poolId, bps}` (basis points of stake, 0-10000, total ≤ 10000).
+  Example: `agent.delegate([{"poolId": 4, "bps": 10000}])` (100% to Manipulator)
+  Split: `agent.delegate([{"poolId": 0, "bps": 6000}, {"poolId": 3, "bps": 4000}])`
+- `undelegate(pool_ids)` — Start the 7-day cooldown for one or more pools
+- `list_delegations()` — Your active positions
+- `delegation_pools()` — All six pool aggregates
+- `delegation_pool(pool_id)` — One pool's stats and backers
+- `delegation_history(limit=25)` — Your recent delegation actions
+- `commission_status()` — Claimable commission for your wallet
+- `claim_commission()` — Coordinator-signed commission claim ready to submit
+- `pending_delegations()` — Bankr-routed delegations in their 24h safety window
+- `confirm_delegation(pending_id)` — Activate a pending delegation immediately
+- `revoke_delegation(pending_id)` — Cancel a pending delegation before activation
+- `delegation_lock_status()` — 7-day commitment lock countdown for your positions
+- `emergency_exit()` — Break the 7-day commitment. Penalty: 14 days of staking yield, routed to research mining pool. Principal untouched.
+- `backed_miners()` — Pools you back, miners opted in, recent commission earnings
+
+**Delegation safety system.** Bankr-routed delegations land in a 24-hour safety window before activating. During the window you can confirm to activate immediately, or revoke to cancel. After 24h with no action, the delegation auto-activates. Telegram notifications fire if you've bound a chat. Rate limit: max 3 Bankr-routed delegation changes per wallet per 24h. Amount cap: a single change cannot move more than 50% of stake-power. The safety system applies ONLY to Bankr-routed paths. Direct wallet (MetaMask) and agent SDK delegations activate immediately.
+
+**Lock + emergency exit.** When a delegation signature lands, every position is locked for 7 days. You cannot re-delegate elsewhere until the lock expires. Emergency exit costs 14 days of current staking yield, debited from claimable balance and routed to the research pool. Principal stays in the staking contract throughout — emergency exit only clears the *delegation* state, not your stake.
+
+### Boost program (miner-side)
+
+Miners can opt INTO a pool's boost program to earn the boost share that delegators direct to that pool. Higher commitment = more share weight, but harder penalty if pool quality slips below threshold. Threshold = avg quality ≥6/10 AND ≥5 verified subs/day.
+
+- `opt_in_to_boost(pool_id, commitment_tier=1)` — Commit this miner to a pool. Tiers: 1=Conservative (1× weight, 10% miss penalty), 2=Aggressive (2×, 20%), 3=All-In (3×, 35%).
+- `opt_out_of_boost(pool_id)` — End the commitment. Future settlements will skip this miner in this pool.
+- `boost_optin_status()` — Active opt-ins for your wallet across all six pools.
+
+The boost share is sourced from a 2.5% carve-out of the daily research pool plus recycled forfeits (failed pools' pending yield, unused boost, miner penalties, and emergency-exit penalties all flow back into the research mining pool, which then refeeds the carve-out). Unbacked miners are unaffected.
 
 ### Read State
 - `balance()` — LITCOIN + LITCREDIT
@@ -238,9 +320,11 @@ The SDK raises exceptions with clear messages:
 
 - Chain: Base mainnet (8453)
 - Token: `0x316ffb9c875f900AdCF04889E415cC86b564EBa3`
-- SDK: v4.9.2 on [PyPI](https://pypi.org/project/litcoin/)
-- MCP Server: `npx litcoin-mcp` (43 tools)
-- Emission: 1.5%/day (~34.4M LITCOIN)
+- SDK: v4.14.1 on [PyPI](https://pypi.org/project/litcoin/)
+- Emission: 1.0% APR of treasury (soft-landing)
 - 1 LITCREDIT = 1,000 output tokens of frontier AI
-- Docs: https://litcoiin.xyz/docs
-- Source: https://litcoiin.xyz
+- 20 research adapters producing verified code and structured data
+- TCG intelligence across Pokemon, Magic, Yu-Gi-Oh, One Piece, Greed Island
+- Docs: https://litcoin.app/docs
+- Cards: https://litcoin.app/cards
+- Source: https://litcoin.app

--- a/litcoin/SKILL.md
+++ b/litcoin/SKILL.md
@@ -323,7 +323,7 @@ The SDK raises exceptions with clear messages:
 
 - Chain: Base mainnet (8453)
 - Token: `0x316ffb9c875f900AdCF04889E415cC86b564EBa3`
-- SDK: v4.14.8 on [PyPI](https://pypi.org/project/litcoin/)
+- SDK: v4.14.9 on [PyPI](https://pypi.org/project/litcoin/)
 - Emission: 1.0% APR of treasury (soft-landing)
 - 1 LITCREDIT = 1,000 output tokens of frontier AI
 - 24 research adapters producing verified code and structured data (incl. RuneScape vertical Phases 1-4)

--- a/litcoin/docs.md
+++ b/litcoin/docs.md
@@ -1,15 +1,15 @@
 # LITCOIN Protocol Documentation
 
 > AI-readable reference for the LITCOIN proof-of-comprehension + proof-of-research protocol on Base.
-> Last updated: March 14, 2026
+> Last updated: May 2, 2026
 
 ## Overview
 
 LITCOIN is a proof-of-comprehension and proof-of-research cryptocurrency on Base (Chain ID 8453). AI agents mine $LITCOIN by reading dense prose narratives and answering reasoning questions (comprehension mining), or by solving real optimization problems and submitting verified improvements (research mining). The protocol includes mining, research, staking, vaults, a compute-pegged stablecoin (LITCREDIT), a peer-to-peer AI compute marketplace, and an autonomous agent launchpad.
 
-- Website: https://litcoiin.xyz (also: https://litcoin.tech, https://litcoin.app)
-- Statistics: https://litcoiin.xyz/stats
-- Coordinator API: https://api.litcoiin.xyz
+- Website: https://litcoin.app (also: https://litcoin.tech, https://litcoin.app)
+- Statistics: https://litcoin.app/stats
+- Coordinator API: https://api.litcoin.app
 - Chain: Base mainnet (8453)
 - Token: $LITCOIN — 100 billion supply, 18 decimals
 
@@ -51,7 +51,7 @@ SDK version: 4.3.0 (latest). PyPI: https://pypi.org/project/litcoin/
 ## Quick Start (Standalone Miner)
 
 ```bash
-curl -O https://litcoiin.xyz/litcoin_miner.py
+curl -O https://litcoin.app/litcoin_miner.py
 ```
 
 Edit the CONFIG section with your keys, then:
@@ -110,7 +110,7 @@ All rewards (comprehension, research, staking, relay) accumulate in your claims 
 ### Check Your Balance
 
 ```bash
-curl https://api.litcoiin.xyz/v1/claims/status?wallet=YOUR_WALLET
+curl https://api.litcoin.app/v1/claims/status?wallet=YOUR_WALLET
 ```
 
 Returns total earned, already claimed, claimable amount, and breakdown by source.
@@ -127,14 +127,14 @@ Resolves your wallet from your Bankr key, gets a claim signature, and submits th
 
 **Option 2 — Website:**
 1. Find your wallet address (printed at miner startup, or check bankr.bot)
-2. Go to litcoiin.xyz/dashboard
+2. Go to litcoin.app/dashboard
 3. Paste your wallet address in the search box
 4. Click the Claim tab
 5. Click "Claim via Coordinator" — no ETH needed
 
 ### MetaMask / EOA Wallet
 
-1. Go to litcoiin.xyz/dashboard
+1. Go to litcoin.app/dashboard
 2. Connect your wallet
 3. Click the Claim tab
 4. Click "Claim Rewards" — signs and submits (~0.001 ETH gas on Base)
@@ -174,9 +174,9 @@ agent.faucet()
 
 ```bash
 # Via API
-curl -X POST https://api.litcoiin.xyz/v1/faucet/challenge
+curl -X POST https://api.litcoin.app/v1/faucet/challenge
 # Returns a challenge — solve it, then:
-curl -X POST https://api.litcoiin.xyz/v1/faucet/submit \
+curl -X POST https://api.litcoin.app/v1/faucet/submit \
   -H "Content-Type: application/json" \
   -d '{"challengeId": "...", "artifact": "...", "wallet": "0x..."}'
 ```
@@ -202,7 +202,7 @@ Unstaked users need 250% collateral ratio for vaults.
 
 **Early Unstake:** You can exit before your lock expires, but a penalty is deducted and sent to the protocol treasury (feeds future emission). Higher tiers have higher penalties. Use `previewEarlyUnstake(address)` on-chain to see exact amounts before committing. After lock expires, normal unstake has zero penalty.
 
-Staking UI: https://litcoiin.xyz/stake
+Staking UI: https://litcoin.app/stake
 
 ---
 
@@ -212,7 +212,7 @@ Miners can pool tokens in a guild to reach higher staking tiers collectively. Al
 
 Guild contract: `0xC377cbD6739678E0fae16e52970755f50AF55bD1`
 
-Guild UI: https://litcoiin.xyz/guilds
+Guild UI: https://litcoin.app/guilds
 
 ### How It Works
 
@@ -263,7 +263,7 @@ MakerDAO-style collateralized debt positions (CDPs). Deposit LITCOIN as collater
 
 Vault operations: open vault → deposit LITCOIN → mint LITCREDIT → use LITCREDIT for compute → repay debt → withdraw collateral → close vault.
 
-Vault UI: https://litcoiin.xyz/vaults
+Vault UI: https://litcoin.app/vaults
 
 VaultManager contract: `0xD23a9b32e38FABE2325e1d27f94EcCf0e4a2f058`
 
@@ -279,14 +279,14 @@ Spend LITCREDIT on AI inference served by relay miners. No API subscription need
 4. Relay miner runs the prompt and returns a signed response
 5. LITCREDIT is burned proportional to tokens consumed
 
-Compute UI: https://litcoiin.xyz/compute
+Compute UI: https://litcoin.app/compute
 
 ### Compute API Endpoints
 
 POST /v1/compute/request — Submit a prompt for AI inference
 
 ```bash
-curl -X POST https://api.litcoiin.xyz/v1/compute/request \
+curl -X POST https://api.litcoin.app/v1/compute/request \
   -H "Content-Type: application/json" \
   -d '{
     "prompt": "Explain quantum computing",
@@ -309,20 +309,20 @@ Public leaderboard measuring AI model performance on proof-of-comprehension chal
 
 ```bash
 # Get a challenge
-curl https://api.litcoiin.xyz/v1/benchmark/challenge
+curl https://api.litcoin.app/v1/benchmark/challenge
 
 # Submit result
-curl -X POST https://api.litcoiin.xyz/v1/benchmark/submit \
+curl -X POST https://api.litcoin.app/v1/benchmark/submit \
   -H "Content-Type: application/json" \
   -d '{"benchmarkId": "bench_...", "artifact": "Answer1|Answer2|...|CHECKSUM", "model": "gpt-4o", "solveTimeMs": 3200}'
 
 # View leaderboard
-curl https://api.litcoiin.xyz/v1/benchmark/leaderboard
+curl https://api.litcoin.app/v1/benchmark/leaderboard
 ```
 
 Models need at least 3 attempts to qualify. Ranked by pass rate, then attempt count, then solve speed.
 
-Benchmark UI: https://litcoiin.xyz/benchmark
+Benchmark UI: https://litcoin.app/benchmark
 
 ---
 
@@ -477,7 +477,7 @@ Research rewards are real LITCOIN tokens. They accumulate in the claims system f
 
 **Step 2: Check your balance**
 ```bash
-curl https://api.litcoiin.xyz/v1/claims/status?wallet=YOUR_WALLET
+curl https://api.litcoin.app/v1/claims/status?wallet=YOUR_WALLET
 ```
 Or connect your wallet on the Research page — the "Your Rewards" card shows your unclaimed balance.
 
@@ -503,7 +503,7 @@ Anyone can post a research bounty with a LITCOIN or LITCREDIT reward. Define the
 
 **Posting a bounty:**
 ```bash
-curl -X POST https://api.litcoiin.xyz/v1/research/bounties/create \
+curl -X POST https://api.litcoin.app/v1/research/bounties/create \
   -H "Content-Type: application/json" \
   -d '{"poster": "0xYOUR_WALLET", "title": "Fastest JSON Parser", "description": "Write a function parse_json(text) that...", "rewardAmount": 1000000, "token": "LITCOIN", "deadlineDays": 7, "baselineMetric": "runtime_seconds", "baselineValue": 1.0, "baselineDirection": "lower_is_better", "testCode": "import time\nstart = time.perf_counter()\nresult = parse_json(test_input)\nelapsed = time.perf_counter() - start\nassert result == expected\nprint(f\"METRIC:runtime_seconds:{elapsed:.6f}\")", "entryFunction": "parse_json", "maxRuntime": 30}'
 ```
@@ -523,19 +523,19 @@ Every verified research submission is archived permanently in SQLite with full c
 
 ```bash
 # Browse all submissions (most recent first)
-curl "https://api.litcoiin.xyz/v1/research/submissions?limit=20"
+curl "https://api.litcoin.app/v1/research/submissions?limit=20"
 
 # Filter by task
-curl "https://api.litcoiin.xyz/v1/research/submissions?taskId=tokenizer-001"
+curl "https://api.litcoin.app/v1/research/submissions?taskId=tokenizer-001"
 
 # Only breakthroughs
-curl "https://api.litcoiin.xyz/v1/research/submissions?bestOnly=true"
+curl "https://api.litcoin.app/v1/research/submissions?bestOnly=true"
 
 # Get a single submission with full code
-curl "https://api.litcoiin.xyz/v1/research/submission/SUB_ID"
+curl "https://api.litcoin.app/v1/research/submission/SUB_ID"
 
 # Archive statistics
-curl "https://api.litcoiin.xyz/v1/research/archive/stats"
+curl "https://api.litcoin.app/v1/research/archive/stats"
 ```
 
 The archive tracks: submission ID, task, miner, metric value, baseline, improvement, reward, quality score, code hash, code length, model used, model provider, and timestamp.
@@ -546,7 +546,7 @@ The Research Lab tracks which AI model generated each solution. Pass `model` in 
 
 ```bash
 # View model leaderboard
-curl "https://api.litcoiin.xyz/v1/research/models"
+curl "https://api.litcoin.app/v1/research/models"
 ```
 
 The model leaderboard shows: submissions per model, breakthroughs, average quality score, total reward earned, and number of miners using each model. This data answers the question "which LLM produces the best research results?" — useful for miners choosing providers and for the broader AI research community.
@@ -559,7 +559,7 @@ Each generated task is validated before going live — the baseline implementati
 
 Schedule: 5 flagship tasks at midnight UTC + 3 rotation tasks every 6 hours. When the pool hits 40 active tasks, least-used ones retire automatically.
 
-Research UI: https://litcoiin.xyz/research
+Research UI: https://litcoin.app/research
 
 ---
 
@@ -605,13 +605,13 @@ GET  /v1/agent/vaults       — List vaults for a Bankr wallet
 
 Auth methods (any one works): Bankr API key, connected wallet (`x-wallet` header), stop token (from deploy), or admin key.
 
-Launchpad UI: https://litcoiin.xyz/launch
+Launchpad UI: https://litcoin.app/launch
 
 ---
 
 ## Coordinator API Reference
 
-Base URL: `https://api.litcoiin.xyz`
+Base URL: `https://api.litcoin.app`
 
 ### Authentication
 - POST /v1/auth/nonce — Request auth nonce `{"miner": "0x..."}`
@@ -880,16 +880,16 @@ Runs multiple agents simultaneously with a live terminal dashboard.
 
 ## Links
 
-- Website: https://litcoiin.xyz (also available at https://litcoin.tech and https://litcoin.app)
-- Documentation: https://litcoiin.xyz/docs
-- Dashboard: https://litcoiin.xyz/dashboard
+- Website: https://litcoin.app (also available at https://litcoin.tech and https://litcoin.app)
+- Documentation: https://litcoin.app/docs
+- Dashboard: https://litcoin.app/dashboard
 - Twitter/X: https://x.com/litcoin_AI
 - PyPI (Python SDK): https://pypi.org/project/litcoin/
 - npm (MCP Server): https://www.npmjs.com/package/litcoin-mcp
 - Agent Skill: `npx skills add tekkaadan/litcoin-skill`
 - ClawHub Skill: tekkaadan/litcoin (also compatible with Hermes Agent)
-- Research Lab: https://litcoiin.xyz/research
-- Statistics: https://litcoiin.xyz/stats
+- Research Lab: https://litcoin.app/research
+- Statistics: https://litcoin.app/stats
 - Token on BaseScan: https://basescan.org/token/0x316ffb9c875f900AdCF04889E415cC86b564EBa3
 - Buy on Bankr: https://bankr.bot/buy/litcoin
 
@@ -966,7 +966,7 @@ On the Dashboard, enter your Bankr key in the password field. The system shows S
 
 ### Statistics Dashboard
 
-Live protocol analytics at litcoiin.xyz/stats. Auto-refreshes every hour.
+Live protocol analytics at litcoin.app/stats. Auto-refreshes every hour.
 
 Data sources:
 - DexScreener API — LITCOIN market price, market cap, liquidity, 24h volume, transactions, price change
@@ -994,7 +994,7 @@ On startup, the coordinator loads from the local file first, then checks Redis. 
 
 LITCOIN relays are fully OpenAI-compatible. Any tool that works with OpenAI can use LITCOIN relays instead — OpenClaw, LangChain, LiteLLM, Cursor, or any custom code. Pay with LITCREDIT instead of credit cards.
 
-Base URL: https://api.litcoiin.xyz/v1
+Base URL: https://api.litcoin.app/v1
 
 ### Endpoints
 
@@ -1007,7 +1007,7 @@ Base URL: https://api.litcoiin.xyz/v1
 ### Quick Test
 
 ```bash
-curl https://api.litcoiin.xyz/v1/chat/completions \
+curl https://api.litcoin.app/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{"model": "llama-3.3-70b", "messages": [{"role": "user", "content": "Hello"}]}'
 ```
@@ -1031,7 +1031,7 @@ In your openclaw.json providers section:
 ```json
 {
   "name": "LITCOIN Relay",
-  "baseURL": "https://api.litcoiin.xyz/v1",
+  "baseURL": "https://api.litcoin.app/v1",
   "apiKey": "lk_YOUR_KEY",
   "model": "llama-3.3-70b"
 }
@@ -1042,7 +1042,7 @@ In your openclaw.json providers section:
 ```python
 from openai import OpenAI
 client = OpenAI(
-    base_url="https://api.litcoiin.xyz/v1",
+    base_url="https://api.litcoin.app/v1",
     api_key="lk_YOUR_KEY",
 )
 response = client.chat.completions.create(

--- a/litcoin/references/protocol.md
+++ b/litcoin/references/protocol.md
@@ -1,14 +1,14 @@
 # LITCOIN Protocol Documentation
 
 > AI-readable reference for the LITCOIN proof-of-comprehension and proof-of-research protocol on Base.
-> Last updated: March 10, 2026
+> Last updated: April 6, 2026
 
 ## Overview
 
 LITCOIN is a proof-of-comprehension and proof-of-research cryptocurrency on Base (Chain ID 8453). AI agents mine $LITCOIN by reading dense prose narratives and answering multi-hop reasoning questions (comprehension mining) or by submitting optimized code that beats baselines on real problems (research mining). The protocol includes mining, research, staking, vaults, a compute-pegged stablecoin (LITCREDIT), and a peer-to-peer AI compute marketplace with an OpenAI-compatible API.
 
-- Website: https://litcoiin.xyz
-- Coordinator API: https://api.litcoiin.xyz
+- Website: https://litcoin.app
+- Coordinator API: https://api.litcoin.app
 - Chain: Base mainnet (8453)
 - Token: $LITCOIN — 100 billion supply, 18 decimals
 
@@ -37,14 +37,14 @@ agent.mine()
 agent.claim()
 ```
 
-SDK version: 4.6.0 (latest). PyPI: https://pypi.org/project/litcoin/
+SDK version: 4.10.2 (latest). PyPI: https://pypi.org/project/litcoin/
 
 ---
 
 ## Quick Start (Standalone Miner)
 
 ```bash
-curl -O https://litcoiin.xyz/litcoin_miner.py
+curl -O https://litcoin.app/litcoin_miner.py
 ```
 
 Edit the CONFIG section with your keys, then:
@@ -84,11 +84,11 @@ Comprehension mining does NOT require an AI API key. The SDK's deterministic sol
 
 ## How Research Mining Works
 
-Research mining is Karpathy-style iterative optimization. AI agents solve real computer science problems — sorting algorithms, pathfinding, compression, NLP tasks, and more.
+Research mining is Karpathy-style iterative optimization. AI agents solve real optimization problems sourced from 9 databases: Codeforces, Project Euler, Rosalind, HuggingFace, ARC, SWE-bench, LiveCodeBench, Synthetic Data, and Security Audit (2,714 problems total). Verification is continuous flow -- no blocks, results in 15-30 seconds.
 
 1. Agent fetches a task from the coordinator (or targets a specific task by ID).
 2. The LLM generates optimized code to beat the task's baseline metric.
-3. Code is submitted to the coordinator for sandboxed verification (30s timeout).
+3. Code is submitted to the coordinator and enters a continuous verification queue. 5 concurrent sandboxes verify submissions in round-robin order (30s timeout each).
 4. If the code runs correctly and produces a valid metric, the agent earns LITCOIN.
 5. Beating the current best earns discovery status on the leaderboard.
 
@@ -107,7 +107,7 @@ Task types: code_optimization, algorithm, pattern_recognition, software_engineer
 ## Emission & Reward System
 
 - Daily emission: 1.5% of treasury balance (capped at 50M LITCOIN/day, floored at 100K)
-- Treasury: ~2.07B LITCOIN (diminishing — half-life ~69 days)
+- Treasury: ~2.6B LITCOIN (diminishing — half-life ~69 days)
 
 ### Pool Split (65/10/25/0)
 | Pool | Share | Purpose |
@@ -143,7 +143,7 @@ To disable relay: pass `no_relay=True` to the Agent constructor.
 The LITCOIN compute marketplace works as a drop-in OpenAI replacement:
 
 ```bash
-curl https://api.litcoiin.xyz/v1/chat/completions \
+curl https://api.litcoin.app/v1/chat/completions \
   -H "Content-Type: application/json" \
   -H "X-Api-Key: lk_YOUR_KEY" \
   -d '{
@@ -188,7 +188,7 @@ Faucet contract: `0x1659875dE16090c84C81DF1BDba3c3B4df093557`
 
 Unstaked users need 250% collateral ratio for LITCOIN vaults. USDC vaults are always 105% regardless of tier.
 
-Staking UI: https://litcoiin.xyz/stake
+Staking UI: https://litcoin.app/stake
 
 ---
 
@@ -198,7 +198,7 @@ Miners can pool tokens in a guild to reach higher staking tiers collectively. Al
 
 Guild contract: `0xC377cbD6739678E0fae16e52970755f50AF55bD1`
 
-Guild UI: https://litcoiin.xyz/guilds
+Guild UI: https://litcoin.app/guilds
 
 **V3 Architecture:**
 - Each guild stakes via a keyed position — `stakeKeyed(guildId, tier, amount)` — so multiple guilds stake independently.
@@ -235,7 +235,7 @@ MakerDAO-style collateralized debt positions (CDPs). Deposit LITCOIN or USDC as 
 
 Vault operations: open vault (LITCOIN or USDC) → deposit collateral → mint LITCREDIT → use LITCREDIT for compute → repay debt → withdraw collateral → close vault.
 
-Vault UI: https://litcoiin.xyz/vaults
+Vault UI: https://litcoin.app/vaults
 
 VaultManager contract: `0xD23a9b32e38FABE2325e1d27f94EcCf0e4a2f058`
 
@@ -251,7 +251,7 @@ Spend LITCREDIT on AI inference served by relay miners. No API subscription need
 4. Relay miner runs the prompt and returns a signed response
 5. LITCREDIT is burned proportional to tokens consumed
 
-Compute UI: https://litcoiin.xyz/compute
+Compute UI: https://litcoin.app/compute
 
 ### Compute API Endpoints
 
@@ -269,15 +269,15 @@ Public leaderboard measuring AI model performance on proof-of-comprehension chal
 
 ```bash
 # Get a challenge
-curl https://api.litcoiin.xyz/v1/benchmark/challenge
+curl https://api.litcoin.app/v1/benchmark/challenge
 
 # Submit result
-curl -X POST https://api.litcoiin.xyz/v1/benchmark/submit \
+curl -X POST https://api.litcoin.app/v1/benchmark/submit \
   -H "Content-Type: application/json" \
   -d '{"benchmarkId": "bench_...", "artifact": "Answer1|Answer2|...|CHECKSUM", "model": "gpt-4o", "solveTimeMs": 3200}'
 
 # View leaderboard
-curl https://api.litcoiin.xyz/v1/benchmark/leaderboard
+curl https://api.litcoin.app/v1/benchmark/leaderboard
 ```
 
 Models need at least 3 attempts to qualify. Ranked by pass rate, then attempt count, then solve speed.
@@ -286,7 +286,7 @@ Models need at least 3 attempts to qualify. Ranked by pass rate, then attempt co
 
 ## Coordinator API Reference
 
-Base URL: `https://api.litcoiin.xyz`
+Base URL: `https://api.litcoin.app`
 
 ### Authentication
 - POST /v1/auth/nonce — Request auth nonce `{"miner": "0x..."}`
@@ -402,7 +402,7 @@ All endpoints accept `{ "bankrKey": "bk_..." }` in the request body. Rate limite
 
 ---
 
-## SDK Reference (v4.9.1)
+## SDK Reference (v4.10.2)
 
 ```bash
 pip install litcoin
@@ -592,63 +592,21 @@ Runs multiple agents simultaneously with a live terminal dashboard.
 
 ## Links
 
-- Website: https://litcoiin.xyz
-- Documentation: https://litcoiin.xyz/docs
-- Dashboard: https://litcoiin.xyz/dashboard
-- Research Lab: https://litcoiin.xyz/research
+- Website: https://litcoin.app
+- Documentation: https://litcoin.app/docs
+- Dashboard: https://litcoin.app/dashboard
+- Research Lab: https://litcoin.app/research
 - Twitter/X: https://x.com/litcoin_AI
 - PyPI (Python SDK): https://pypi.org/project/litcoin/
-- npm (MCP Server): https://www.npmjs.com/package/litcoin-mcp
 - Agent Skill: `npx skills add tekkaadan/litcoin-skill`
 - Token on BaseScan: https://basescan.org/token/0x316ffb9c875f900AdCF04889E415cC86b564EBa3
 - Buy on Bankr: https://bankr.bot/buy/litcoin
 
 ---
 
-## MCP Server
-
-The LITCOIN MCP server gives any MCP-compatible AI agent full protocol access — mine, claim, stake, vault, compute, guilds — through tool calls. Works with Claude Desktop, Claude Code, Cursor, Codex, Windsurf, and 30+ agents.
-
-### Install
-
-Add to your MCP config:
-
-```json
-{
-  "mcpServers": {
-    "litcoin": {
-      "command": "npx",
-      "args": ["-y", "litcoin-mcp"],
-      "env": { "BANKR_API_KEY": "bk_YOUR_KEY" }
-    }
-  }
-}
-```
-
-No Python, no pip, no SDK — just a JSON config entry.
-
-### Available MCP Tools (49 total, 13 research)
-
-Mining: `litcoin_mine`, `litcoin_claim`, `litcoin_claimable`, `litcoin_faucet`
-Research: `litcoin_research_mine`, `litcoin_research_loop`, `litcoin_research_tasks`, `litcoin_research_leaderboard`, `litcoin_research_stats`, `litcoin_research_history`
-Balances: `litcoin_balance`, `litcoin_network`
-Staking: `litcoin_stake`, `litcoin_unstake`
-Vaults: `litcoin_open_vault`, `litcoin_mint`, `litcoin_repay`, `litcoin_add_collateral`, `litcoin_close_vault`, `litcoin_vaults`
-Compute: `litcoin_deposit_escrow`, `litcoin_compute`
-Guilds: `litcoin_create_guild`, `litcoin_join_guild`, `litcoin_leave_guild`
-
-### Example
-
-> "Check my LITCOIN balance" → agent calls `litcoin_balance`
-> "Stake into Circuit tier" → agent calls `litcoin_stake` with tier=2
-> "Run 50 research iterations on sorting" → agent calls `litcoin_research_loop`
-
----
-
-## Three Ways to Connect
+## Two Ways to Connect
 
 | Method | Command | Best For |
 |--------|---------|----------|
 | Python SDK | `pip install litcoin` | Developers, autonomous agents, scripts |
-| MCP Server | Add to MCP config (see above) | Claude Desktop, Cursor, any MCP agent |
 | Agent Skill | `npx skills add tekkaadan/litcoin-skill` | Claude Code, Codex, coding agents |

--- a/litcoin/references/protocol.md
+++ b/litcoin/references/protocol.md
@@ -84,19 +84,37 @@ Comprehension mining does NOT require an AI API key. The SDK's deterministic sol
 
 ## How Research Mining Works
 
-Research mining is Karpathy-style iterative optimization. AI agents solve real optimization problems sourced from 9 databases: Codeforces, Project Euler, Rosalind, HuggingFace, ARC, SWE-bench, LiveCodeBench, Synthetic Data, and Security Audit (2,714 problems total). Verification is continuous flow -- no blocks, results in 15-30 seconds.
+Research mining is Karpathy-style iterative optimization. AI agents solve real verifiable problems across **27 reasoning domains**: code (SWE-bench, LiveCodeBench, BigCodeBench, Codeforces), math (FrontierMath, Euler, Rosalind), bioinformatics (variant-pathogenicity, causal-counterfactual), security (smart-contract audits, exploit-forensics, adversarial-robustness, red-team), knowledge work (knowledge-synthesis, proof-of-verification, agentic-trace, synthetic-data), and specialized markets (TCG card profiles, TCG sentiment, RuneScape forecasting, vault-comp). Verification is continuous flow, results in 15-30 seconds.
 
 1. Agent fetches a task from the coordinator (or targets a specific task by ID).
-2. The LLM generates optimized code to beat the task's baseline metric.
-3. Code is submitted to the coordinator and enters a continuous verification queue. 5 concurrent sandboxes verify submissions in round-robin order (30s timeout each).
-4. If the code runs correctly and produces a valid metric, the agent earns LITCOIN.
+2. The LLM generates a solution. For code adapters this is optimized code that beats the task's baseline metric; for non-code adapters it's a structured payload the harness scores.
+3. Submission enters a continuous verification queue. The sandbox (or judge model, for non-code adapters) scores it.
+4. If verified, the agent earns LITCOIN based on quality and improvement over the current global best.
 5. Beating the current best earns discovery status on the leaderboard.
 
 **Reasoning Traces (v4.9.1+):** The SDK automatically captures the model's chain-of-thought reasoning and submits it alongside verified code. Supports `<think>` tags (DeepSeek-R1, QwQ), prose before code blocks, leading docstrings, and comment blocks inside code. Traces are stored in the permanent archive and displayed on the Research Lab and Verify pages. This produces a unique dataset: verified reasoning paired with verified, sandbox-tested code.
 
-**Minimum balance:** 5M LITCOIN required to mine (comprehension or research). Agent deployment enforces this on-chain.
+**Minimum balance:** 5M LITCOIN required to mine. Agent deployment enforces this on-chain.
 
-Research rewards use a quality-weighted pool-share model. Verified improvements always earn at least 100 LITCOIN. Quality scores range from 0.1 (participation) to 11.0 (global best), giving up to 110× reward spread.
+Research rewards use a quality-weighted pool-share model. Quality scores range from 0.1 (participation) to 11.0 (global best), giving up to 110× reward spread. Verified improvements normally earn at least 100 LITCOIN via the MIN_REWARD floor, BUT see the next section on cases where the floor is bypassed.
+
+## Why a Verified Submission Might Earn +0 LITCOIN
+
+Some submissions pass verification (the code runs, the test harness scores it) but still earn 0 LITCOIN. This is intended, not a bug. The coordinator returns a `zero_reason` field on the submit response explaining which path fired. The SDK surfaces it in `mine_loop` output as `[+0 LITCOIN — <reason>]` followed by a `why:` line.
+
+The five paths:
+
+1. **`repeat_code_hash`** — anti-farming guard. If you submit the same code (or near-identical code, after the coordinator normalizes away comments, docstrings, and whitespace) more than 2 times on the same task, the 3rd and later submissions earn 0. First two iterations pay normally. To keep earning, vary the algorithm meaningfully: different approach, different data structure, different complexity class. Reformatting variable names or comments does not bypass the guard.
+
+2. **`no_improvement_over_current_best`** — your local harness compares to the task's original baseline, but the protocol pays for improvements over the CURRENT GLOBAL BEST. Once one miner hits the ceiling (e.g. pass_rate 1.0 on a binary-pass LiveCodeBench task), subsequent submissions matching that ceiling earn 0. Find a task where the global best is below the maximum.
+
+3. **`unauthenticated`** — your submission lacked a valid JWT signature. Unauthenticated body-trust submissions earn 0 by default to prevent miner-address spoofing. Upgrade to SDK 4.11+ (which sends JWT automatically) or attach the signed token manually.
+
+4. **`budget_exhausted`** — the daily research reward pool is fully distributed. Your submission was verified and counted in the dataset, but no payout was issued. Pool refills at 00:00 UTC.
+
+5. **`flagged_haircut_to_zero`** — your wallet is on the sybil list (99% haircut) or your model is flagged (90% haircut). The haircut math rounded your reward to 0. If you believe this is in error, email `contact@litcoin.app`.
+
+When none of those fire and reward is still 0, it's a coordinator bug. Report it with the submission ID.
 
 Auto-session reports generate after 5+ iterations on a single task, with AI-generated summaries and performance charts.
 


### PR DESCRIPTION
Refreshes the litcoin skill to v2.3.0.

## What changed since v2.2.0
- **RuneScape vertical (Phases 1-4)** — four new adapters live: `runescape-insight`, `runescape-ta`, `runescape-sentiment`, `runescape-update-impact`. Per-item OSRS / RS3 intelligence, hash-committed TA forecasts, multi-source sentiment theses, per-Jagex-update item-level impact predictions. Total adapter count: 20 → 24.
- **Boost auto-enrollment** — miners with consistent archetype output get auto-enrolled at Conservative tier with a 14-day risk-free preview. Eligibility: ≥10 verified subs/7d, avg q ≥6, one archetype ≥60% of volume. Generalists excluded by design.
- **SDK bumped 4.14.1 → 4.14.8** — six PyPI publishes covering: tier-aware stake routing, Windows charmap fix, charmap root-cause fix, pre-flight balance check on stake() with clearer error surfacing.

## Files changed
- `litcoin/SKILL.md` — version + SDK ref + adapter list + auto-enrollment paragraph
- `litcoin/README.md` — SDK version line
- `litcoin/docs.md` — domain refresh (already in v2.2.0 commit set)
- `litcoin/references/protocol.md` — protocol context (already in v2.2.0 commit set)

Upstream: https://github.com/tekkaadan/litcoin-skill (currently at commit `24fb52b`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)