### PR TITLE
docs(bankr): document ENS in `bankr wallet transfer --to`

### DIFF
--- a/bankr/SKILL.md
+++ b/bankr/SKILL.md
@@ -233,6 +233,15 @@ Omit `threadId` to start a new conversation. CLI equivalent: `bankr agent prompt
 - **Write endpoints** (`/wallet/transfer`, `/wallet/sign`, `/wallet/submit`) — require `walletApiEnabled`, `readOnly` check, and `allowedRecipients` enforcement
 - IP allowlist enforced on all endpoints
 
+#### Recipient & user lookup helpers (public, no auth)
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/addresses/resolve?value=<recipient>&type=<address\|ens\|twitter\|farcaster>` | GET | Resolve a recipient (0x address, ENS-style name `.eth`/`.base.eth`/`.cb.id`, or social handle) to a 0x address. Used by `bankr wallet transfer --to` to support ENS input. |
+| `/users/search?...` | GET | Search Bankr users by Twitter or Farcaster username. |
+
+The legacy aliases `/public/resolve-recipient` and `/public/search-users` still work but are marked deprecated (Sunset: 2026-06-03) — migrate callers to the structured `/addresses/*` and `/users/*` namespaces.
+
 #### Agent API (`/agent/*`) — AI-powered endpoints (async)
 
 | Endpoint | Method | Description |
@@ -256,9 +265,9 @@ For full API details (request/response schemas, job states, rich data, polling s
 
 **Reference**: [references/api-workflow.md](references/api-workflow.md) | [references/sign-submit-api.md](references/sign-submit-api.md)
 
-## CLI Command Reference (v0.2.0)
+## CLI Command Reference (v0.3.x)
 
-CLI 0.2.0 organizes commands into three namespaces: `wallet`, `agent`, and `tokens`. Old flat commands (`balances`, `prompt`, `status`, etc.) still work as deprecated aliases.
+`@bankr/cli` 0.2+ organizes commands into three namespaces: `wallet`, `agent`, and `tokens`. Old flat commands (`balances`, `prompt`, `status`, etc.) still work as deprecated aliases.
 
 ### `bankr wallet` — Wallet Operations
 
@@ -271,8 +280,8 @@ CLI 0.2.0 organizes commands into three namespaces: `wallet`, `agent`, and `toke
 | `bankr wallet portfolio --all` | Include both PnL and NFTs |
 | `bankr wallet portfolio --chain <chains>` | Filter by chain(s): base, polygon, mainnet, unichain, solana (comma-separated) |
 | `bankr wallet portfolio --json` | Output raw JSON |
-| `bankr wallet transfer --to <recipient> --token <symbol> --amount <amount>` | Transfer tokens with symbol resolution |
-| `bankr wallet transfer --to <recipient> --token USDC --amount 50 --chain base` | Transfer with explicit chain |
+| `bankr wallet transfer --to <recipient> --token <symbol> --amount <amount>` | Transfer tokens; `--to` accepts a 0x address or ENS-style name (`.eth`, `.base.eth`, `.cb.id`), `--token` resolves symbols to contracts. Social handles work via the AI agent only. |
+| `bankr wallet transfer --to vitalik.eth --token USDC --amount 50 --chain base` | ENS recipient with explicit chain |
 | `bankr wallet sign` | Sign messages/typed data/transactions |
 | `bankr wallet submit` | Submit raw transactions |
 
@@ -492,10 +501,11 @@ For full details — setup paths, model list, provider config, SDK examples, key
 
 ### Transfers
 
-- Send to addresses, ENS, or social handles
+- Send to 0x addresses, ENS-style names (`.eth`, `.base.eth`, `.cb.id`), or social handles
+- CLI direct (`bankr wallet transfer`) accepts 0x addresses + ENS only — social handles go through the AI agent
 - Multi-chain support
 - Flexible amount formats
-- Social handle resolution (Twitter, Farcaster, Telegram)
+- Social handle resolution (Twitter, Farcaster, Telegram) via the agent
 
 **Reference**: [references/transfers.md](references/transfers.md)
 
@@ -859,11 +869,12 @@ See [references/safety.md](references/safety.md) for comprehensive safety guidan
 
 ### Transfers (Direct)
 
-Transfer tokens via CLI or Wallet API without AI processing:
+Transfer tokens via CLI or Wallet API without AI processing. The CLI's `--to` accepts a 0x address or ENS-style name (`.eth`, `.base.eth`, `.cb.id`); the Wallet API accepts the same plus anything `/addresses/resolve` understands. For social handles (Twitter, Farcaster, Telegram) use the AI agent.
 
 ```bash
-# CLI — token symbol resolution built in
+# CLI — token symbol resolution + ENS resolution built in
 bankr wallet transfer --to vitalik.eth --token USDC --amount 50 --chain base
+bankr wallet transfer --to name.base.eth --native --amount 0.01
 bankr wallet transfer --to 0x1234... --token ETH --amount 0.1
 
 # REST API

--- a/bankr/references/transfers.md
+++ b/bankr/references/transfers.md
@@ -1,6 +1,6 @@
 # Transfers Reference
 
-Transfer tokens to addresses, ENS names, or social handles.
+Send tokens to a 0x address or ENS name directly via the CLI / Wallet API, or to social handles via the AI agent.
 
 ## CLI Command
 
@@ -9,11 +9,13 @@ Transfer tokens to addresses, ENS names, or social handles.
 bankr wallet transfer --to <recipient> --token <symbol> --amount <amount>
 bankr wallet transfer --to <recipient> --token <symbol> --amount <amount> --chain <chain>
 
-# Examples
-bankr wallet transfer --to vitalik.eth --token USDC --amount 50 --chain base
+# Examples — recipient may be a 0x address or ENS-style name (.eth, .base.eth, .cb.id)
 bankr wallet transfer --to 0x1234... --token ETH --amount 0.1
-bankr wallet transfer --to @friend --token USDC --amount 20
+bankr wallet transfer --to vitalik.eth --token USDC --amount 50 --chain base
+bankr wallet transfer --to name.base.eth --native --amount 0.01
 ```
+
+`--to` accepts a 0x address or an ENS-style name; ENS names (`.eth`, `.base.eth`, `.cb.id`) are resolved to an address via `/addresses/resolve` before the transfer is submitted, so the call fails fast with a clear error if the name doesn't resolve. To send to social handles (Twitter, Farcaster, Telegram), use the AI agent (`bankr agent ...`) instead — the CLI's direct `transfer` command intentionally does not accept handles to keep money-moving inputs unambiguous.
 
 The `--token` flag resolves token symbols (e.g. `USDC`) to contract addresses via the search API.
 
@@ -29,25 +31,38 @@ curl -X POST "https://api.bankr.bot/wallet/transfer" \
 
 The `/wallet/transfer` endpoint is a write endpoint — requires `walletApiEnabled`, `readOnly: false`, and is subject to `allowedRecipients` enforcement and IP allowlist.
 
+### Recipient Resolution Helper
+
+If you need to resolve an ENS-style name to a 0x address yourself (without submitting a transfer), use the structured `/addresses/resolve` endpoint. It is public — no API key required.
+
+```bash
+curl "https://api.bankr.bot/addresses/resolve?value=vitalik.eth&type=ens"
+# → { "resolved": true, "address": "0x...", "displayName": "vitalik.eth" }
+```
+
+`type` is one of `address`, `ens`, `twitter`, `farcaster`. The legacy `/public/resolve-recipient` endpoint still works as a backward-compat alias but is marked deprecated (Sunset: 2026-06-03). Migrate to `/addresses/resolve`. A parallel `/users/search` endpoint is available for Twitter/Farcaster username lookup (legacy alias: `/public/search-users`, same deprecation timeline).
+
 ## Supported Transfers
 
 - **EVM Chains**: Base, Polygon, Ethereum (mainnet), Unichain, World Chain, Arbitrum, BNB Chain
   - Native tokens: ETH, POL, BNB
   - ERC20 tokens: USDC, USDT, WETH, etc.
-- **Solana**: SOL and SPL tokens
+- **Solana**: SOL and SPL tokens (via AI agent — the CLI's `bankr wallet transfer` is EVM-only)
 
 ## Recipient Formats
 
-| Format | Example | Description |
-|--------|---------|-------------|
-| Address | `0x1234...abcd` | Direct wallet address (EVM) |
-| Address | `9x...abc` | Direct wallet address (Solana) |
-| ENS | `vitalik.eth` | Ethereum Name Service |
-| Twitter | `@elonmusk` | Twitter/X username |
-| Farcaster | `@dwr.eth` | Farcaster username |
-| Telegram | `@username` | Telegram handle |
+| Format | Example | `bankr wallet transfer` | AI agent (`bankr agent`) |
+|--------|---------|:-----------------------:|:------------------------:|
+| EVM address | `0x1234...abcd` | ✓ | ✓ |
+| Solana address | `9xKc...abc` | — | ✓ |
+| ENS | `vitalik.eth` | ✓ (resolved client-side) | ✓ |
+| Basename | `name.base.eth` | ✓ (resolved client-side) | ✓ |
+| Coinbase ID | `name.cb.id` | ✓ (resolved client-side) | ✓ |
+| Twitter | `@elonmusk` | — | ✓ |
+| Farcaster | `@dwr.eth` | — | ✓ |
+| Telegram | `@username` | — | ✓ |
 
-**Social Handle Resolution**: Handles are resolved to linked wallet addresses before sending. User must have linked their wallet to the social platform.
+**Social handle resolution** (agent only): handles are resolved to a linked wallet address before sending. The user must have linked a wallet to the social platform for resolution to succeed.
 
 ## Amount Formats
 
@@ -64,10 +79,10 @@ The `/wallet/transfer` endpoint is a write endpoint — requires `walletApiEnabl
 - "Transfer 100 USDC to 9xKc...abc"
 - "Send $20 of ETH to 0x1234..."
 
-**To ENS:**
+**To ENS / Basenames:**
 - "Send 1 ETH to vitalik.eth"
 - "Transfer $50 of USDC to mydomain.eth"
-- "Send 10 USDC to friend.eth"
+- "Send 10 USDC to friend.base.eth"
 
 **To social handles:**
 - "Send $20 of ETH to @friend on Twitter"
@@ -87,13 +102,14 @@ If not specified, Bankr selects automatically based on:
 - Token availability
 - Liquidity
 
-Specify chain in prompt if you need a specific network.
+Specify chain in prompt if you need a specific network. The CLI's `bankr wallet transfer` defaults to `base`; pass `--chain <name>` to override.
 
 ## Common Issues
 
 | Issue | Resolution |
 |-------|------------|
 | ENS not found | Verify the ENS name exists and is registered |
+| `--to` rejected as invalid | The CLI accepts only 0x addresses and ENS-style names (`.eth`, `.base.eth`, `.cb.id`). For social handles use the AI agent. |
 | Social handle not found | Check username spelling and platform |
 | No linked wallet | User hasn't linked wallet to their social account |
 | Insufficient balance | Reduce amount or ensure enough funds |

--- a/bankr/references/transfers.md
+++ b/bankr/references/transfers.md
@@ -51,6 +51,8 @@ curl "https://api.bankr.bot/addresses/resolve?value=vitalik.eth&type=ens"
 
 ## Recipient Formats
 
+Pass the bare username for social handles (no `.eth` suffix even if the user's display name has one) — the resolver only matches by exact Farcaster/Twitter username.
+
 | Format | Example | `bankr wallet transfer` | AI agent (`bankr agent`) |
 |--------|---------|:-----------------------:|:------------------------:|
 | EVM address | `0x1234...abcd` | ✓ | ✓ |
@@ -59,7 +61,7 @@ curl "https://api.bankr.bot/addresses/resolve?value=vitalik.eth&type=ens"
 | Basename | `name.base.eth` | ✓ (resolved client-side) | ✓ |
 | Coinbase ID | `name.cb.id` | ✓ (resolved client-side) | ✓ |
 | Twitter | `@elonmusk` | — | ✓ |
-| Farcaster | `@dwr.eth` | — | ✓ |
+| Farcaster | `@dwr` | — | ✓ |
 | Telegram | `@username` | — | ✓ |
 
 **Social handle resolution** (agent only): handles are resolved to a linked wallet address before sending. The user must have linked a wallet to the social platform for resolution to succeed.


### PR DESCRIPTION
## Summary

Updates the `bankr` skill to reflect a recent CLI change: `bankr wallet transfer --to` now accepts ENS-style names in addition to 0x addresses, and resolves them client-side via the new structured `/addresses/resolve` endpoint before submitting the transfer. Social handles remain agent-only.

### `bankr/references/transfers.md`
- Clarify CLI scope (0x + ENS only, no social handles) — the previous `--to @friend` example was never valid for the direct CLI command.
- Split the recipient-format table into CLI vs AI-agent columns so it's obvious which inputs work where.
- Document the public `/addresses/resolve?value=...&type=address|ens|twitter|farcaster` helper, plus the deprecated `/public/resolve-recipient` alias (Sunset: 2026-06-03) and parallel `/users/search` / `/public/search-users` pair.
- Note that `bankr wallet transfer` is EVM-only; Solana transfers go through the AI agent.

### `bankr/SKILL.md`
- Bump CLI Command Reference heading from `(v0.2.0)` to `(v0.3.x)`; the namespacing description still references when it was introduced (0.2+).
- Add the new public lookup endpoints (`/addresses/resolve`, `/users/search`) to the API endpoints summary, with deprecation note for the legacy `/public/*` aliases.
- Update the `bankr wallet transfer` row to describe the recipient formats `--to` actually accepts.
- Note CLI ENS support in the Capabilities-overview "Transfers" bullets and in the "Transfers (Direct)" example block.

## Test plan
- [ ] Skim rendered Markdown for the two files on the branch.
- [ ] Confirm the recipient table renders with the correct CLI / agent columns.
- [ ] Sanity-check that the `/addresses/resolve` query string (`?value=...&type=...`) matches what the CLI sends.
- [ ] No broken references — both files only link to existing references.