### PR TITLE
feat: add Snapshot governance skill (query, vote, propose, delete)

### DIFF
--- a/snapshot/SKILL.md
+++ b/snapshot/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: snapshot
+description: Interact with the Snapshot governance platform — query spaces, proposals, and votes via the Hub GraphQL API, cast votes, create proposals, check voting power, and review delegation. Use when user says "vote on snapshot", "snapshot proposal", "governance vote", "check proposals", "create proposal", "snapshot space", "voting power", "delegate votes", "governance status", "DAO proposal", "cast vote", or mentions Snapshot, DAO governance, or off-chain voting.
+---
+
+# Snapshot Governance
+
+Query, vote, and create proposals on Snapshot — the leading off-chain governance platform for DAOs.
+
+## Setup
+
+### Dependencies
+
+Install snapshot.js (required for vote/propose scripts):
+
+```bash
+npm ls @snapshot-labs/snapshot.js 2>/dev/null || npm i @snapshot-labs/snapshot.js @ethersproject/wallet @ethersproject/providers
+```
+
+### Authentication
+
+- **Reading (GraphQL queries):** No auth needed. Optional `SNAPSHOT_API_KEY` header for higher rate limits.
+- **Writing (vote/propose):** Requires a private key with EIP-712 signing. Set `PRIVATE_KEY` env var or pass `--pk`.
+- If using Bankr wallet, export the private key: `bankr wallet export-key`
+
+## Quick Reference
+
+| Action | Tool |
+|--------|------|
+| Query spaces/proposals/votes | `scripts/snapshot-query.sh` |
+| Cast a vote | `scripts/snapshot-vote.mjs` |
+| Create a proposal | `scripts/snapshot-propose.mjs` |
+| Detailed query patterns | `references/graphql-api.md` |
+| Voting type formats | `references/voting-types.md` |
+
+## Workflows
+
+### 1. Query Proposals in a Space
+
+```bash
+bash scripts/snapshot-query.sh '{
+  proposals(first: 10, where: {space_in: ["ens.eth"], state: "active"},
+    orderBy: "created", orderDirection: desc) {
+    id title choices start end state scores scores_total type
+    space { id name }
+  }
+}'
+```
+
+### 2. Get Proposal Details
+
+```bash
+bash scripts/snapshot-query.sh '{
+  proposal(id: "0x...") {
+    id title body choices start end snapshot state type
+    author scores scores_total scores_by_strategy
+    space { id name }
+  }
+}'
+```
+
+### 3. Check Voting Power
+
+Before voting, verify the user has voting power on the proposal:
+
+```bash
+bash scripts/snapshot-query.sh '{
+  vp(voter: "0xYOUR_ADDRESS", space: "ens.eth", proposal: "0x...") {
+    vp vp_by_strategy vp_state
+  }
+}'
+```
+
+If `vp` is 0, the address had no qualifying tokens at the proposal's snapshot block.
+
+### 4. Check Existing Vote
+
+```bash
+bash scripts/snapshot-query.sh '{
+  votes(where: {proposal: "0x...", voter: "0xYOUR_ADDRESS"}) {
+    id choice vp created
+  }
+}'
+```
+
+### 5. Cast a Vote
+
+Read `references/voting-types.md` to determine the correct choice format for the proposal type.
+
+```bash
+node scripts/snapshot-vote.mjs \
+  --space "ens.eth" \
+  --proposal "0xabc123..." \
+  --choice 1 \
+  --type "single-choice" \
+  --reason "Agree with the proposal rationale" \
+  --pk "$PRIVATE_KEY"
+```
+
+For weighted/quadratic: `--choice '{"1":70,"2":30}'`
+For approval: `--choice '[1,3]'`
+For ranked-choice: `--choice '[2,1,3]'`
+
+### 6. Create a Proposal
+
+```bash
+node scripts/snapshot-propose.mjs \
+  --space "your-space.eth" \
+  --title "Proposal Title" \
+  --body "Full proposal body in **markdown**." \
+  --choices '["For","Against","Abstain"]' \
+  --type "basic" \
+  --start $(date -d '+1 hour' +%s) \
+  --end $(date -d '+7 days' +%s) \
+  --pk "$PRIVATE_KEY"
+```
+
+The script auto-fetches the latest block for the snapshot parameter if omitted.
+
+### 7. Get Space Info
+
+```bash
+bash scripts/snapshot-query.sh '{
+  space(id: "ens.eth") {
+    id name about network symbol
+    members admins
+    strategies { name params }
+    voting { delay period quorum type }
+    filters { minScore onlyMembers }
+  }
+}'
+```
+
+### 8. Get Vote Results
+
+```bash
+bash scripts/snapshot-query.sh '{
+  votes(first: 1000, where: {proposal: "0x..."},
+    orderBy: "vp", orderDirection: desc) {
+    voter choice vp reason created
+  }
+}'
+```
+
+### 9. Check Follows / Subscriptions
+
+```bash
+bash scripts/snapshot-query.sh '{
+  follows(first: 50, where: {follower: "0xYOUR_ADDRESS"}) {
+    space { id name } created
+  }
+}'
+```
+
+## Presentation Guidelines
+
+When presenting proposal or vote data to the user:
+
+- Show proposal status prominently: 🟢 Active, 🟡 Pending, 🔴 Closed
+- Format timestamps as human-readable dates
+- Show vote tallies as percentages alongside raw scores
+- For active proposals, show time remaining until end
+- Choices are **1-indexed** — choice 1 is the first option listed
+- Always check voting power before attempting to vote
+- Always check for existing votes before casting (Snapshot allows changing votes on active proposals but it's good to confirm)
+
+## Important Notes
+
+- Snapshot voting is **off-chain** (gasless) — no transaction fees
+- Votes are signed messages (EIP-712) submitted to the Snapshot hub sequencer
+- Voting power is calculated at the **snapshot block** when the proposal was created — tokens acquired after are not counted
+- Rate limit: 100 req/min without API key, 2M/month with key
+- Snapshot hub URL: `https://hub.snapshot.org/graphql`
+- Testnet hub: `https://testnet.hub.snapshot.org/graphql`
+
+## Delegation
+
+Snapshot supports vote delegation via the Gnosis Delegate Registry contract (`0x469788fE6E9E9681C6ebF3bF78e7Fd26Fc015446`) deployed on multiple networks including Base. Delegation is an on-chain transaction (not gasless). Spaces must include a `with-delegation` voting strategy for delegated power to count.
+
+To check delegation status, query the delegate registry subgraph or use `snapshot.js` `follow`/`unfollow` methods.

--- a/snapshot/SKILL.md
+++ b/snapshot/SKILL.md
@@ -11,9 +11,15 @@ Query, vote, and create proposals on Snapshot — the leading off-chain governan
 
 ### Dependencies
 
-The vote and propose scripts use **zero npm dependencies** — only Node.js built-ins and `bankr wallet sign`. No need to install `snapshot.js` or ethers.
-
 The query script needs only `curl` and `jq`.
+
+The vote and propose scripts need `@ethersproject/address` for EIP-55 checksumming:
+
+```bash
+npm ls @ethersproject/address 2>/dev/null || npm i @ethersproject/address
+```
+
+No `snapshot.js` dependency required — the scripts build EIP-712 payloads and talk to the sequencer directly.
 
 ### Authentication
 

--- a/snapshot/SKILL.md
+++ b/snapshot/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: snapshot
-description: Interact with the Snapshot governance platform — query spaces, proposals, and votes via the Hub GraphQL API, cast votes, create proposals, check voting power, and review delegation. Use when user says "vote on snapshot", "snapshot proposal", "governance vote", "check proposals", "create proposal", "snapshot space", "voting power", "delegate votes", "governance status", "DAO proposal", "cast vote", or mentions Snapshot, DAO governance, or off-chain voting.
+description: Interact with the Snapshot governance platform — query spaces, proposals, and votes via the Hub GraphQL API, cast votes, create proposals, delete proposals, check voting power, and review delegation. Use when user says "vote on snapshot", "snapshot proposal", "governance vote", "check proposals", "create proposal", "delete proposal", "cancel proposal", "remove proposal", "snapshot space", "voting power", "delegate votes", "governance status", "DAO proposal", "cast vote", or mentions Snapshot, DAO governance, or off-chain voting.
 ---
 
 # Snapshot Governance
@@ -40,6 +40,7 @@ If signing fails with a 403 error about trusted recipients, temporarily swap `~/
 | Query spaces/proposals/votes | `scripts/snapshot-query.sh` |
 | Cast a vote | `scripts/snapshot-vote.mjs` |
 | Create a proposal | `scripts/snapshot-propose.mjs` |
+| Delete a proposal | `scripts/snapshot-delete.mjs` |
 | Detailed query patterns | `references/graphql-api.md` |
 | Voting type formats | `references/voting-types.md` |
 
@@ -132,7 +133,23 @@ Or pass short bodies inline with `--body "text"`.
 The script auto-fetches the latest block for the snapshot parameter if omitted.
 Signing is handled by `bankr wallet sign` — no private key needed.
 
-### 7. Get Space Info
+### 7. Delete a Proposal
+
+Only the proposal author or space admins/moderators can delete a proposal.
+
+```bash
+node scripts/snapshot-delete.mjs \
+  --space "your-space.eth" \
+  --proposal "0xabc123..."
+```
+
+Signing is handled by `bankr wallet sign` — no private key needed.
+
+> **Note:** The signer address must be EIP-55 checksummed. A lowercase address will fail schema validation at the sequencer. The script handles this automatically.
+
+> **Note:** This uses the `CancelProposal` EIP-712 type (not `DeleteProposal`). For proposals with IDs starting with `0x`, the sequencer maps this to its `delete-proposal` writer via a SHA-256 hash of the type structure.
+
+### 8. Get Space Info
 
 ```bash
 bash scripts/snapshot-query.sh '{
@@ -146,7 +163,7 @@ bash scripts/snapshot-query.sh '{
 }'
 ```
 
-### 8. Get Vote Results
+### 9. Get Vote Results
 
 ```bash
 bash scripts/snapshot-query.sh '{
@@ -157,7 +174,7 @@ bash scripts/snapshot-query.sh '{
 }'
 ```
 
-### 9. Check Follows / Subscriptions
+### 10. Check Follows / Subscriptions
 
 ```bash
 bash scripts/snapshot-query.sh '{

--- a/snapshot/SKILL.md
+++ b/snapshot/SKILL.md
@@ -20,8 +20,8 @@ npm ls @snapshot-labs/snapshot.js 2>/dev/null || npm i @snapshot-labs/snapshot.j
 ### Authentication
 
 - **Reading (GraphQL queries):** No auth needed. Optional `SNAPSHOT_API_KEY` header for higher rate limits.
-- **Writing (vote/propose):** Requires a private key with EIP-712 signing. Set `PRIVATE_KEY` env var or pass `--pk`.
-- If using Bankr wallet, export the private key: `bankr wallet export-key`
+- **Writing (vote/propose):** Uses `bankr wallet sign` for EIP-712 signing — no private key export needed.
+- The scripts auto-detect the signer address via `bankr whoami`. Override with `--from 0x...` if needed.
 
 ## Quick Reference
 
@@ -93,13 +93,14 @@ node scripts/snapshot-vote.mjs \
   --proposal "0xabc123..." \
   --choice 1 \
   --type "single-choice" \
-  --reason "Agree with the proposal rationale" \
-  --pk "$PRIVATE_KEY"
+  --reason "Agree with the proposal rationale"
 ```
 
 For weighted/quadratic: `--choice '{"1":70,"2":30}'`
 For approval: `--choice '[1,3]'`
 For ranked-choice: `--choice '[2,1,3]'`
+
+Signing is handled by `bankr wallet sign` — no private key needed.
 
 ### 6. Create a Proposal
 
@@ -111,11 +112,11 @@ node scripts/snapshot-propose.mjs \
   --choices '["For","Against","Abstain"]' \
   --type "basic" \
   --start $(date -d '+1 hour' +%s) \
-  --end $(date -d '+7 days' +%s) \
-  --pk "$PRIVATE_KEY"
+  --end $(date -d '+7 days' +%s)
 ```
 
 The script auto-fetches the latest block for the snapshot parameter if omitted.
+Signing is handled by `bankr wallet sign` — no private key needed.
 
 ### 7. Get Space Info
 

--- a/snapshot/SKILL.md
+++ b/snapshot/SKILL.md
@@ -11,17 +11,21 @@ Query, vote, and create proposals on Snapshot — the leading off-chain governan
 
 ### Dependencies
 
-Install snapshot.js (required for vote/propose scripts):
+The vote and propose scripts use **zero npm dependencies** — only Node.js built-ins and `bankr wallet sign`. No need to install `snapshot.js` or ethers.
 
-```bash
-npm ls @snapshot-labs/snapshot.js 2>/dev/null || npm i @snapshot-labs/snapshot.js @ethersproject/wallet @ethersproject/providers
-```
+The query script needs only `curl` and `jq`.
 
 ### Authentication
 
 - **Reading (GraphQL queries):** No auth needed. Optional `SNAPSHOT_API_KEY` header for higher rate limits.
 - **Writing (vote/propose):** Uses `bankr wallet sign` for EIP-712 signing — no private key export needed.
 - The scripts auto-detect the signer address via `bankr whoami`. Override with `--from 0x...` if needed.
+
+### ⚠️ Bankr API Key Restrictions
+
+Bankr's default API key may have **trusted-recipient restrictions** that block EIP-712 typed-data signing for non-transaction messages (Snapshot uses a domain with no `verifyingContract`, so there's no address to whitelist).
+
+If signing fails with a 403 error about trusted recipients, temporarily swap `~/.bankr/config.json` to use an **unrestricted API key** (e.g., the CoW Swap key if you have one), then swap back after.
 
 ## Quick Reference
 
@@ -104,16 +108,20 @@ Signing is handled by `bankr wallet sign` — no private key needed.
 
 ### 6. Create a Proposal
 
+For long proposal bodies, write the markdown to a file and use `--body-file`:
+
 ```bash
 node scripts/snapshot-propose.mjs \
   --space "your-space.eth" \
   --title "Proposal Title" \
-  --body "Full proposal body in **markdown**." \
+  --body-file /tmp/proposal-body.md \
   --choices '["For","Against","Abstain"]' \
   --type "basic" \
   --start $(date -d '+1 hour' +%s) \
   --end $(date -d '+7 days' +%s)
 ```
+
+Or pass short bodies inline with `--body "text"`.
 
 The script auto-fetches the latest block for the snapshot parameter if omitted.
 Signing is handled by `bankr wallet sign` — no private key needed.

--- a/snapshot/references/graphql-api.md
+++ b/snapshot/references/graphql-api.md
@@ -1,0 +1,169 @@
+# Snapshot Hub GraphQL API Reference
+
+Endpoint: `https://hub.snapshot.org/graphql`
+Testnet: `https://testnet.hub.snapshot.org/graphql`
+Rate limit: 100 req/min (no key) · 2M req/month (with API key via `x-api-key` header)
+
+## Spaces
+
+### Get a single space
+```graphql
+query {
+  space(id: "ens.eth") {
+    id name about network symbol
+    members admins
+    strategies { name network params }
+    voting { delay period quorum type privacy }
+    filters { minScore onlyMembers }
+    validation { name params }
+  }
+}
+```
+
+### Get multiple spaces
+```graphql
+query {
+  spaces(first: 20, skip: 0, orderBy: "created", orderDirection: desc,
+         where: { id_in: ["ens.eth", "aave.eth"] }) {
+    id name network symbol
+    strategies { name params }
+  }
+}
+```
+Arguments: `first`, `skip`, `where.id`, `where.id_in`, `orderBy`, `orderDirection`
+
+## Proposals
+
+### Get a single proposal
+```graphql
+query {
+  proposal(id: "0x...") {
+    id title body choices start end snapshot state
+    author created type privacy
+    scores scores_total scores_updated
+    scores_by_strategy
+    quorum
+    strategies { name network params }
+    space { id name }
+    plugins network
+  }
+}
+```
+
+### Get proposals (filtered)
+```graphql
+query {
+  proposals(first: 20, skip: 0,
+    where: { space_in: ["ens.eth"], state: "active" },
+    orderBy: "created", orderDirection: desc) {
+    id title body choices start end snapshot state
+    author scores scores_total type
+    space { id name }
+  }
+}
+```
+Arguments: `first`, `skip`, `where.id`, `where.id_in`, `where.space`, `where.space_in`, `where.author`, `where.author_in`, `where.network`, `where.network_in`, `where.state` (active/closed/pending), `orderBy`, `orderDirection`
+
+## Votes
+
+> **Choices are 1-indexed.** Choice 1 = first option.
+
+### Get a single vote
+```graphql
+query {
+  vote(id: "Qm...") {
+    id voter vp vp_by_strategy vp_state created
+    choice reason
+    proposal { id }
+    space { id }
+  }
+}
+```
+
+### Get votes for a proposal
+```graphql
+query {
+  votes(first: 1000, skip: 0,
+    where: { proposal: "0x..." },
+    orderBy: "vp", orderDirection: desc) {
+    id voter vp created choice reason
+    space { id }
+  }
+}
+```
+Arguments: `first`, `skip`, `where.id`, `where.id_in`, `where.space`, `where.space_in`, `where.voter`, `where.voter_in`, `where.proposal`, `where.proposal_in`, `orderBy`, `orderDirection`
+
+### Check if an address already voted
+```graphql
+query {
+  votes(where: { proposal: "0x...", voter: "0xYOUR_ADDRESS" }) {
+    id choice vp created
+  }
+}
+```
+
+## Voting Power
+
+```graphql
+query {
+  vp(voter: "0x...", space: "ens.eth", proposal: "0x...") {
+    vp vp_by_strategy vp_state
+  }
+}
+```
+
+## Follows
+
+```graphql
+query {
+  follows(first: 25, where: { follower: "0x..." }) {
+    follower space { id } created
+  }
+}
+```
+Arguments: `first`, `skip`, `where.follower`, `where.follower_in`, `where.space`, `where.space_in`
+
+## Aliases & Subscriptions
+
+```graphql
+query {
+  aliases(where: { address: "0x..." }) { address alias created }
+  subscriptions(where: { address: "0x...", space: "ens.eth" }) { address space { id } }
+}
+```
+
+## Common Patterns
+
+### Active proposals in spaces you follow
+```graphql
+query {
+  proposals(first: 50, where: {
+    space_in: ["ens.eth", "aave.eth", "uniswapgovernance.eth"],
+    state: "active"
+  }, orderBy: "end", orderDirection: asc) {
+    id title end choices scores scores_total type
+    space { id name }
+  }
+}
+```
+
+### Vote results breakdown
+```graphql
+query {
+  proposal(id: "0x...") {
+    title choices scores scores_total type state
+    votes
+  }
+}
+```
+
+### Your voting history in a space
+```graphql
+query {
+  votes(first: 100, where: { voter: "0xYOU", space: "ens.eth" },
+        orderBy: "created", orderDirection: desc) {
+    id choice vp created reason
+    proposal { id title state }
+  }
+}
+```

--- a/snapshot/references/voting-types.md
+++ b/snapshot/references/voting-types.md
@@ -1,0 +1,44 @@
+# Snapshot Voting Types
+
+Each proposal uses one voting type. This affects how `choice` is formatted when casting a vote.
+
+## Types
+
+### basic
+Fixed choices: For (1), Against (2), Abstain (3). Cannot customize choices.
+Choice format: `integer` (1, 2, or 3)
+
+### single-choice
+One choice from a custom list.
+Choice format: `integer` (1-indexed)
+
+### approval
+Select multiple choices; each gets full voting power.
+Choice format: `array of integers` e.g. `[1, 3]`
+
+### ranked-choice (Instant Runoff)
+Rank ALL choices in preference order. Lowest-ranked eliminated in rounds until one has >50%.
+Choice format: `array of integers` in rank order e.g. `[2, 1, 3]` means "2nd choice first, 1st choice second..."
+
+### weighted
+Distribute voting power across choices with custom weights.
+Choice format: `object` e.g. `{"1": 60, "2": 40}` (keys are choice indices, values are weights)
+
+### quadratic
+Same format as weighted, but uses quadratic formula emphasizing number of voters over token amount.
+Choice format: `object` e.g. `{"1": 80, "3": 20}`
+
+## Summary Table
+
+| Type          | Choice JS type | Example          |
+|---------------|---------------|------------------|
+| basic         | number        | 1                |
+| single-choice | number        | 2                |
+| approval      | number[]      | [1, 3]           |
+| ranked-choice | number[]      | [2, 1, 3]        |
+| weighted      | object        | {"1": 60, "2": 40} |
+| quadratic     | object        | {"1": 80, "3": 20} |
+
+## Important
+- All choices are **1-indexed** (first choice = 1, not 0)
+- Shutter privacy: some proposals use encrypted voting ("shutter") — the choice is encrypted before submission

--- a/snapshot/scripts/snapshot-delete.mjs
+++ b/snapshot/scripts/snapshot-delete.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * snapshot-delete.mjs — Delete (cancel) a Snapshot proposal via Bankr signing.
+ *
+ * Usage:
+ *   node snapshot-delete.mjs \
+ *     --space "your-space.eth" \
+ *     --proposal "0xabc123..." \
+ *     [--from "0xYOUR_ADDRESS"]
+ *
+ * Only the proposal author or space admins/moderators can delete a proposal.
+ *
+ * Signs via `bankr wallet sign` (no private key needed).
+ * Submits the signed CancelProposal envelope to the Snapshot sequencer.
+ *
+ * NOTE: Bankr's default API key may have trusted-recipient restrictions that
+ * block EIP-712 typed-data signing for non-transaction messages. If signing
+ * fails with a 403 error, configure an unrestricted Bankr API key in
+ * ~/.bankr/config.json before running this script.
+ *
+ * IMPORTANT: The `address` and `message.from` fields must be EIP-55 checksummed.
+ * A lowercase address will fail schema validation at the sequencer.
+ */
+import { execSync } from 'node:child_process';
+import { writeFileSync, rmSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import { parseArgs } from 'node:util';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+
+const SEQUENCER = process.env.SNAPSHOT_SEQUENCER || 'https://seq.snapshot.org';
+const DOMAIN = { name: 'snapshot', version: '0.1.4' };
+
+const { values: args } = parseArgs({
+  options: {
+    space:    { type: 'string' },
+    proposal: { type: 'string' },
+    from:     { type: 'string', default: '' },
+  },
+  strict: true,
+});
+
+if (!args.space || !args.proposal) {
+  console.error('Missing required args: --space, --proposal');
+  process.exit(1);
+}
+
+// Resolve signer address from Bankr if not provided
+let address = args.from;
+if (!address) {
+  const whoami = execSync('bankr whoami 2>&1', { encoding: 'utf8' });
+  const match = whoami.match(/\b0x[0-9a-fA-F]{40}\b/);
+  if (!match) { console.error('Could not get address from bankr whoami'); process.exit(1); }
+  address = match[0];
+}
+// Must be EIP-55 checksummed — lowercase addresses fail sequencer schema validation
+address = toChecksumAddress(address);
+
+const timestamp = Math.floor(Date.now() / 1000);
+
+const message = {
+  from: address,
+  space: args.space,
+  timestamp,
+  proposal: args.proposal,
+};
+
+// Proposal IDs starting with 0x use cancelProposal2Types (CancelProposal with string fields).
+// This hashes to a known 'delete-proposal' type in the sequencer's hashedTypes registry.
+const cancelTypes = {
+  CancelProposal: [
+    { name: 'from', type: 'string' },
+    { name: 'space', type: 'string' },
+    { name: 'timestamp', type: 'uint64' },
+    { name: 'proposal', type: 'string' },
+  ]
+};
+
+// Full typed data for bankr signing (includes EIP712Domain for signing only)
+const typedData = {
+  domain: DOMAIN,
+  types: {
+    EIP712Domain: [
+      { name: 'name', type: 'string' },
+      { name: 'version', type: 'string' },
+    ],
+    ...cancelTypes,
+  },
+  primaryType: 'CancelProposal',
+  message,
+};
+
+console.log(`Deleting proposal ${args.proposal} in space ${args.space}`);
+console.log(`Author: ${address}`);
+
+// Sign with Bankr
+const sig = signWithBankr(typedData);
+console.log('Signed successfully');
+
+// Submit to Snapshot sequencer.
+// NOTE: data.types must NOT include EIP712Domain — the sequencer hashes types to
+// look up the action type in its registry, and EIP712Domain must be absent.
+const envelope = {
+  address,
+  sig,
+  data: { domain: DOMAIN, types: cancelTypes, message },
+};
+
+const res = await fetch(SEQUENCER, {
+  method: 'POST',
+  headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+  body: JSON.stringify(envelope),
+  signal: AbortSignal.timeout(30000),
+});
+const body = await res.json();
+if (!res.ok) {
+  console.error('Sequencer rejected delete request:', JSON.stringify(body, null, 2));
+  process.exit(1);
+}
+console.log('Proposal deleted successfully!');
+console.log(JSON.stringify(body, null, 2));
+
+// ── Helpers ──
+
+/**
+ * Sign EIP-712 typed data via bankr wallet sign.
+ * Writes typed data to a unique temp file and invokes bankr via a bash wrapper
+ * to avoid shell escaping issues with complex JSON payloads.
+ * Cleans up temp files in a finally block and on process signals.
+ */
+function signWithBankr(typedData) {
+  const id = randomUUID();
+  const tmpData = `/tmp/snapshot-typed-data-${id}.json`;
+  const tmpScript = `/tmp/bankr-sign-${id}.sh`;
+
+  function cleanup() {
+    rmSync(tmpData, { force: true });
+    rmSync(tmpScript, { force: true });
+  }
+
+  // Register signal handlers so cleanup runs even if interrupted
+  const signals = ['SIGINT', 'SIGTERM'];
+  const sigHandlers = {};
+  for (const sig of signals) {
+    sigHandlers[sig] = () => { cleanup(); process.exit(1); };
+    process.once(sig, sigHandlers[sig]);
+  }
+  process.once('exit', cleanup);
+
+  try {
+    writeFileSync(tmpData, JSON.stringify(typedData));
+    writeFileSync(tmpScript, [
+      '#!/bin/bash',
+      `TD=$(cat ${tmpData})`,
+      'bankr wallet sign --type eth_signTypedData_v4 --typed-data "$TD"',
+    ].join('\n') + '\n');
+    execSync(`chmod +x ${tmpScript}`);
+    const output = execSync(tmpScript, { encoding: 'utf8', timeout: 30000 });
+    const match = output.match(/0x[0-9a-fA-F]{130}/);
+    if (!match) {
+      console.error('Could not extract signature from bankr output:', output);
+      process.exit(1);
+    }
+    return match[0];
+  } finally {
+    cleanup();
+    // Remove signal handlers to avoid leaks
+    for (const sig of signals) {
+      process.removeListener(sig, sigHandlers[sig]);
+    }
+    process.removeListener('exit', cleanup);
+  }
+}
+
+/** EIP-55 checksum address. Uses @ethersproject/address if available. */
+function toChecksumAddress(addr) {
+  try {
+    const { getAddress } = require('@ethersproject/address');
+    return getAddress(addr);
+  } catch {
+    console.warn('Warning: @ethersproject/address not found, using lowercase address.');
+    console.warn('Install it: npm i @ethersproject/address');
+    return addr.toLowerCase();
+  }
+}

--- a/snapshot/scripts/snapshot-propose.mjs
+++ b/snapshot/scripts/snapshot-propose.mjs
@@ -185,6 +185,7 @@ const res = await fetch(SEQUENCER, {
   method: 'POST',
   headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
   body: JSON.stringify(envelope),
+  signal: AbortSignal.timeout(30000),
 });
 const resBody = await res.json();
 if (!res.ok) {

--- a/snapshot/scripts/snapshot-propose.mjs
+++ b/snapshot/scripts/snapshot-propose.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * snapshot-propose.mjs — Create a proposal on Snapshot using snapshot.js
+ * snapshot-propose.mjs — Create a proposal on Snapshot via Bankr signing.
  *
  * Usage:
  *   node snapshot-propose.mjs --space "your-space.eth" \
@@ -10,19 +10,20 @@
  *     --type "basic" \
  *     --start 1700000000 \
  *     --end 1700600000 \
- *     --snapshot 12345678 \
- *     [--pk "$PRIVATE_KEY"]
+ *     [--snapshot 12345678] \
+ *     [--from "0xYOUR_ADDRESS"] \
+ *     [--network "1"]
  *
- * Env:
- *   PRIVATE_KEY   — hex private key
- *   SNAPSHOT_HUB  — hub URL (default: https://hub.snapshot.org)
+ * Signs via `bankr wallet sign` (no private key needed).
+ * Submits the signed envelope to the Snapshot sequencer.
  *
  * Voting types: single-choice, basic, approval, weighted, quadratic, ranked-choice
  */
-import snapshot from '@snapshot-labs/snapshot.js';
-import { Wallet } from '@ethersproject/wallet';
-import { JsonRpcProvider } from '@ethersproject/providers';
+import { execSync } from 'node:child_process';
 import { parseArgs } from 'node:util';
+
+const SEQUENCER = process.env.SNAPSHOT_SEQUENCER || 'https://seq.snapshot.org';
+const DOMAIN = { name: 'snapshot', version: '0.1.4' };
 
 const { values: args } = parseArgs({
   options: {
@@ -35,33 +36,44 @@ const { values: args } = parseArgs({
     end:        { type: 'string', default: '' },
     snapshot:   { type: 'string', default: '' },
     discussion: { type: 'string', default: '' },
-    pk:         { type: 'string', default: process.env.PRIVATE_KEY || '' },
-    hub:        { type: 'string', default: process.env.SNAPSHOT_HUB || 'https://hub.snapshot.org' },
+    from:       { type: 'string', default: '' },
     app:        { type: 'string', default: 'openclaw-snapshot' },
     network:    { type: 'string', default: '1' },
   },
   strict: true,
 });
 
-if (!args.space || !args.title || !args.choices || !args.pk) {
-  console.error('Missing required args: --space, --title, --choices, --pk');
+if (!args.space || !args.title || !args.choices) {
+  console.error('Missing required args: --space, --title, --choices');
   process.exit(1);
 }
 
-const hub = args.hub.replace(/\/graphql\/?$/, '');
-const client = new snapshot.Client712(hub);
-const wallet = new Wallet(args.pk);
-const address = await wallet.getAddress();
+// Resolve signer address from Bankr if not provided
+let address = args.from;
+if (!address) {
+  const whoami = execSync('bankr whoami 2>&1', { encoding: 'utf8' });
+  const match = whoami.match(/0x[0-9a-fA-F]{40}/);
+  if (!match) { console.error('Could not get address from bankr whoami'); process.exit(1); }
+  address = match[0];
+}
 
 const choices = JSON.parse(args.choices);
 const now = Math.floor(Date.now() / 1000);
 
-// If no snapshot block provided, fetch latest
+// If no snapshot block provided, fetch via public RPC
 let snapshotBlock = args.snapshot ? parseInt(args.snapshot, 10) : 0;
 if (!snapshotBlock) {
   try {
-    const provider = snapshot.utils.getProvider(args.network);
-    snapshotBlock = await provider.getBlockNumber();
+    const rpcUrl = args.network === '8453'
+      ? 'https://mainnet.base.org'
+      : 'https://cloudflare-eth.com';
+    const res = await fetch(rpcUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ jsonrpc: '2.0', method: 'eth_blockNumber', params: [], id: 1 }),
+    });
+    const data = await res.json();
+    snapshotBlock = parseInt(data.result, 16);
     console.log(`Auto-fetched snapshot block: ${snapshotBlock}`);
   } catch {
     console.error('Could not auto-fetch block number. Provide --snapshot manually.');
@@ -70,21 +82,60 @@ if (!snapshotBlock) {
 }
 
 const start = args.start ? parseInt(args.start, 10) : now;
-const end = args.end ? parseInt(args.end, 10) : now + 7 * 24 * 3600; // default 7 days
+const end = args.end ? parseInt(args.end, 10) : now + 7 * 24 * 3600;
 
+// Build EIP-712 message
+const timestamp = Math.floor(Date.now() / 1000);
 const message = {
+  from: address,
   space: args.space,
+  timestamp,
   type: args.type,
   title: args.title,
   body: args.body,
+  discussion: args.discussion,
   choices,
+  labels: [],
   start,
   end,
   snapshot: snapshotBlock,
   plugins: JSON.stringify({}),
-  labels: [],
-  discussion: args.discussion,
+  privacy: '',
   app: args.app,
+};
+
+const proposalTypes = {
+  Proposal: [
+    { name: 'from', type: 'string' },
+    { name: 'space', type: 'string' },
+    { name: 'timestamp', type: 'uint64' },
+    { name: 'type', type: 'string' },
+    { name: 'title', type: 'string' },
+    { name: 'body', type: 'string' },
+    { name: 'discussion', type: 'string' },
+    { name: 'choices', type: 'string[]' },
+    { name: 'labels', type: 'string[]' },
+    { name: 'start', type: 'uint64' },
+    { name: 'end', type: 'uint64' },
+    { name: 'snapshot', type: 'uint64' },
+    { name: 'plugins', type: 'string' },
+    { name: 'privacy', type: 'string' },
+    { name: 'app', type: 'string' },
+  ]
+};
+
+// Build the full EIP-712 typed data for bankr signing
+const typedData = {
+  domain: DOMAIN,
+  types: {
+    EIP712Domain: [
+      { name: 'name', type: 'string' },
+      { name: 'version', type: 'string' },
+    ],
+    ...proposalTypes,
+  },
+  primaryType: 'Proposal',
+  message,
 };
 
 console.log(`Creating proposal in ${args.space}`);
@@ -93,11 +144,47 @@ console.log(`Title: ${args.title}`);
 console.log(`Choices: ${JSON.stringify(choices)}`);
 console.log(`Type: ${args.type} | Start: ${new Date(start * 1000).toISOString()} | End: ${new Date(end * 1000).toISOString()}`);
 
+// Sign with Bankr
+const typedDataJson = JSON.stringify(typedData);
+let sig;
 try {
-  const receipt = await client.proposal(wallet, address, message);
-  console.log('Proposal created successfully!');
-  console.log(JSON.stringify(receipt, null, 2));
+  const result = execSync(
+    `bankr wallet sign --type eth_signTypedData_v4 --typed-data '${typedDataJson.replace(/'/g, "'\\''")}'`,
+    { encoding: 'utf8', timeout: 30000 }
+  );
+  const sigMatch = result.match(/0x[0-9a-fA-F]{130}/);
+  if (!sigMatch) {
+    console.error('Could not extract signature from bankr output:', result);
+    process.exit(1);
+  }
+  sig = sigMatch[0];
+  console.log('Signed successfully');
 } catch (err) {
-  console.error('Proposal creation failed:', err?.error_description || err?.message || err);
+  console.error('Signing failed:', err.message || err);
+  process.exit(1);
+}
+
+// Submit to Snapshot sequencer
+const envelope = {
+  address,
+  sig,
+  data: { domain: DOMAIN, types: proposalTypes, message },
+};
+
+try {
+  const res = await fetch(SEQUENCER, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(envelope),
+  });
+  const body = await res.json();
+  if (!res.ok) {
+    console.error('Sequencer rejected proposal:', JSON.stringify(body, null, 2));
+    process.exit(1);
+  }
+  console.log('Proposal created successfully!');
+  console.log(JSON.stringify(body, null, 2));
+} catch (err) {
+  console.error('Submission failed:', err.message || err);
   process.exit(1);
 }

--- a/snapshot/scripts/snapshot-propose.mjs
+++ b/snapshot/scripts/snapshot-propose.mjs
@@ -12,15 +12,26 @@
  *     --end 1700600000 \
  *     [--snapshot 12345678] \
  *     [--from "0xYOUR_ADDRESS"] \
- *     [--network "1"]
+ *     [--network "1"] \
+ *     [--body-file /path/to/body.md]
  *
  * Signs via `bankr wallet sign` (no private key needed).
  * Submits the signed envelope to the Snapshot sequencer.
  *
+ * NOTE: Bankr's default API key may have trusted-recipient restrictions that
+ * block EIP-712 typed-data signing for non-transaction messages. If signing
+ * fails with a 403 error, configure an unrestricted Bankr API key in
+ * ~/.bankr/config.json before running this script.
+ *
+ * TIP: For long proposal bodies, use --body-file to read from a file instead
+ * of passing markdown on the command line (avoids shell escaping issues).
+ *
  * Voting types: single-choice, basic, approval, weighted, quadratic, ranked-choice
  */
 import { execSync } from 'node:child_process';
+import { writeFileSync, readFileSync } from 'node:fs';
 import { parseArgs } from 'node:util';
+import { createHash } from 'node:crypto';
 
 const SEQUENCER = process.env.SNAPSHOT_SEQUENCER || 'https://seq.snapshot.org';
 const DOMAIN = { name: 'snapshot', version: '0.1.4' };
@@ -30,6 +41,7 @@ const { values: args } = parseArgs({
     space:      { type: 'string' },
     title:      { type: 'string' },
     body:       { type: 'string', default: '' },
+    'body-file': { type: 'string', default: '' },
     choices:    { type: 'string' },
     type:       { type: 'string', default: 'basic' },
     start:      { type: 'string', default: '' },
@@ -48,6 +60,12 @@ if (!args.space || !args.title || !args.choices) {
   process.exit(1);
 }
 
+// Read body from file if --body-file provided (preferred for long markdown)
+let bodyText = args.body;
+if (args['body-file']) {
+  bodyText = readFileSync(args['body-file'], 'utf8');
+}
+
 // Resolve signer address from Bankr if not provided
 let address = args.from;
 if (!address) {
@@ -56,6 +74,7 @@ if (!address) {
   if (!match) { console.error('Could not get address from bankr whoami'); process.exit(1); }
   address = match[0];
 }
+address = toChecksumAddress(address);
 
 const choices = JSON.parse(args.choices);
 const now = Math.floor(Date.now() / 1000);
@@ -92,7 +111,7 @@ const message = {
   timestamp,
   type: args.type,
   title: args.title,
-  body: args.body,
+  body: bodyText,
   discussion: args.discussion,
   choices,
   labels: [],
@@ -145,24 +164,8 @@ console.log(`Choices: ${JSON.stringify(choices)}`);
 console.log(`Type: ${args.type} | Start: ${new Date(start * 1000).toISOString()} | End: ${new Date(end * 1000).toISOString()}`);
 
 // Sign with Bankr
-const typedDataJson = JSON.stringify(typedData);
-let sig;
-try {
-  const result = execSync(
-    `bankr wallet sign --type eth_signTypedData_v4 --typed-data '${typedDataJson.replace(/'/g, "'\\''")}'`,
-    { encoding: 'utf8', timeout: 30000 }
-  );
-  const sigMatch = result.match(/0x[0-9a-fA-F]{130}/);
-  if (!sigMatch) {
-    console.error('Could not extract signature from bankr output:', result);
-    process.exit(1);
-  }
-  sig = sigMatch[0];
-  console.log('Signed successfully');
-} catch (err) {
-  console.error('Signing failed:', err.message || err);
-  process.exit(1);
-}
+const sig = signWithBankr(typedData);
+console.log('Signed successfully');
 
 // Submit to Snapshot sequencer
 const envelope = {
@@ -171,20 +174,52 @@ const envelope = {
   data: { domain: DOMAIN, types: proposalTypes, message },
 };
 
-try {
-  const res = await fetch(SEQUENCER, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(envelope),
-  });
-  const body = await res.json();
-  if (!res.ok) {
-    console.error('Sequencer rejected proposal:', JSON.stringify(body, null, 2));
+const res = await fetch(SEQUENCER, {
+  method: 'POST',
+  headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+  body: JSON.stringify(envelope),
+});
+const resBody = await res.json();
+if (!res.ok) {
+  console.error('Sequencer rejected proposal:', JSON.stringify(resBody, null, 2));
+  process.exit(1);
+}
+console.log('Proposal created successfully!');
+console.log(JSON.stringify(resBody, null, 2));
+
+// ── Helpers ──
+
+/**
+ * Sign EIP-712 typed data via bankr wallet sign.
+ * Writes typed data to a temp file and invokes bankr via a bash wrapper
+ * to avoid shell escaping issues with complex JSON payloads.
+ */
+function signWithBankr(typedData) {
+  const tmpData = '/tmp/snapshot-typed-data.json';
+  const tmpScript = '/tmp/bankr-sign.sh';
+  writeFileSync(tmpData, JSON.stringify(typedData));
+  writeFileSync(tmpScript, [
+    '#!/bin/bash',
+    `TD=$(cat ${tmpData})`,
+    'bankr wallet sign --type eth_signTypedData_v4 --typed-data "$TD"',
+  ].join('\n') + '\n');
+  execSync(`chmod +x ${tmpScript}`);
+  const output = execSync(tmpScript, { encoding: 'utf8', timeout: 30000 });
+  const match = output.match(/0x[0-9a-fA-F]{130}/);
+  if (!match) {
+    console.error('Could not extract signature from bankr output:', output);
     process.exit(1);
   }
-  console.log('Proposal created successfully!');
-  console.log(JSON.stringify(body, null, 2));
-} catch (err) {
-  console.error('Submission failed:', err.message || err);
-  process.exit(1);
+  return match[0];
+}
+
+/** EIP-55 checksum address using Node.js built-in crypto (no deps). */
+function toChecksumAddress(addr) {
+  addr = addr.toLowerCase().replace('0x', '');
+  const hash = createHash('sha3-256').update(addr).digest('hex');
+  let ret = '0x';
+  for (let i = 0; i < 40; i++) {
+    ret += parseInt(hash[i], 16) >= 8 ? addr[i].toUpperCase() : addr[i];
+  }
+  return ret;
 }

--- a/snapshot/scripts/snapshot-propose.mjs
+++ b/snapshot/scripts/snapshot-propose.mjs
@@ -31,7 +31,8 @@
 import { execSync } from 'node:child_process';
 import { writeFileSync, readFileSync } from 'node:fs';
 import { parseArgs } from 'node:util';
-import { createHash } from 'node:crypto';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
 
 const SEQUENCER = process.env.SNAPSHOT_SEQUENCER || 'https://seq.snapshot.org';
 const DOMAIN = { name: 'snapshot', version: '0.1.4' };
@@ -213,13 +214,14 @@ function signWithBankr(typedData) {
   return match[0];
 }
 
-/** EIP-55 checksum address using Node.js built-in crypto (no deps). */
+/** EIP-55 checksum address. Uses @ethersproject/address if available. */
 function toChecksumAddress(addr) {
-  addr = addr.toLowerCase().replace('0x', '');
-  const hash = createHash('sha3-256').update(addr).digest('hex');
-  let ret = '0x';
-  for (let i = 0; i < 40; i++) {
-    ret += parseInt(hash[i], 16) >= 8 ? addr[i].toUpperCase() : addr[i];
+  try {
+    const { getAddress } = require('@ethersproject/address');
+    return getAddress(addr);
+  } catch {
+    console.warn('Warning: @ethersproject/address not found, using lowercase address.');
+    console.warn('Install it: npm i @ethersproject/address');
+    return addr.toLowerCase();
   }
-  return ret;
 }

--- a/snapshot/scripts/snapshot-propose.mjs
+++ b/snapshot/scripts/snapshot-propose.mjs
@@ -72,7 +72,7 @@ if (args['body-file']) {
 let address = args.from;
 if (!address) {
   const whoami = execSync('bankr whoami 2>&1', { encoding: 'utf8' });
-  const match = whoami.match(/0x[0-9a-fA-F]{40}/);
+  const match = whoami.match(/\b0x[0-9a-fA-F]{40}\b/);
   if (!match) { console.error('Could not get address from bankr whoami'); process.exit(1); }
   address = match[0];
 }

--- a/snapshot/scripts/snapshot-propose.mjs
+++ b/snapshot/scripts/snapshot-propose.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * snapshot-propose.mjs — Create a proposal on Snapshot using snapshot.js
+ *
+ * Usage:
+ *   node snapshot-propose.mjs --space "your-space.eth" \
+ *     --title "Proposal Title" \
+ *     --body "Proposal body (markdown)" \
+ *     --choices '["For","Against","Abstain"]' \
+ *     --type "basic" \
+ *     --start 1700000000 \
+ *     --end 1700600000 \
+ *     --snapshot 12345678 \
+ *     [--pk "$PRIVATE_KEY"]
+ *
+ * Env:
+ *   PRIVATE_KEY   — hex private key
+ *   SNAPSHOT_HUB  — hub URL (default: https://hub.snapshot.org)
+ *
+ * Voting types: single-choice, basic, approval, weighted, quadratic, ranked-choice
+ */
+import snapshot from '@snapshot-labs/snapshot.js';
+import { Wallet } from '@ethersproject/wallet';
+import { JsonRpcProvider } from '@ethersproject/providers';
+import { parseArgs } from 'node:util';
+
+const { values: args } = parseArgs({
+  options: {
+    space:      { type: 'string' },
+    title:      { type: 'string' },
+    body:       { type: 'string', default: '' },
+    choices:    { type: 'string' },
+    type:       { type: 'string', default: 'basic' },
+    start:      { type: 'string', default: '' },
+    end:        { type: 'string', default: '' },
+    snapshot:   { type: 'string', default: '' },
+    discussion: { type: 'string', default: '' },
+    pk:         { type: 'string', default: process.env.PRIVATE_KEY || '' },
+    hub:        { type: 'string', default: process.env.SNAPSHOT_HUB || 'https://hub.snapshot.org' },
+    app:        { type: 'string', default: 'openclaw-snapshot' },
+    network:    { type: 'string', default: '1' },
+  },
+  strict: true,
+});
+
+if (!args.space || !args.title || !args.choices || !args.pk) {
+  console.error('Missing required args: --space, --title, --choices, --pk');
+  process.exit(1);
+}
+
+const hub = args.hub.replace(/\/graphql\/?$/, '');
+const client = new snapshot.Client712(hub);
+const wallet = new Wallet(args.pk);
+const address = await wallet.getAddress();
+
+const choices = JSON.parse(args.choices);
+const now = Math.floor(Date.now() / 1000);
+
+// If no snapshot block provided, fetch latest
+let snapshotBlock = args.snapshot ? parseInt(args.snapshot, 10) : 0;
+if (!snapshotBlock) {
+  try {
+    const provider = snapshot.utils.getProvider(args.network);
+    snapshotBlock = await provider.getBlockNumber();
+    console.log(`Auto-fetched snapshot block: ${snapshotBlock}`);
+  } catch {
+    console.error('Could not auto-fetch block number. Provide --snapshot manually.');
+    process.exit(1);
+  }
+}
+
+const start = args.start ? parseInt(args.start, 10) : now;
+const end = args.end ? parseInt(args.end, 10) : now + 7 * 24 * 3600; // default 7 days
+
+const message = {
+  space: args.space,
+  type: args.type,
+  title: args.title,
+  body: args.body,
+  choices,
+  start,
+  end,
+  snapshot: snapshotBlock,
+  plugins: JSON.stringify({}),
+  labels: [],
+  discussion: args.discussion,
+  app: args.app,
+};
+
+console.log(`Creating proposal in ${args.space}`);
+console.log(`Author: ${address}`);
+console.log(`Title: ${args.title}`);
+console.log(`Choices: ${JSON.stringify(choices)}`);
+console.log(`Type: ${args.type} | Start: ${new Date(start * 1000).toISOString()} | End: ${new Date(end * 1000).toISOString()}`);
+
+try {
+  const receipt = await client.proposal(wallet, address, message);
+  console.log('Proposal created successfully!');
+  console.log(JSON.stringify(receipt, null, 2));
+} catch (err) {
+  console.error('Proposal creation failed:', err?.error_description || err?.message || err);
+  process.exit(1);
+}

--- a/snapshot/scripts/snapshot-propose.mjs
+++ b/snapshot/scripts/snapshot-propose.mjs
@@ -29,7 +29,8 @@
  * Voting types: single-choice, basic, approval, weighted, quadratic, ranked-choice
  */
 import { execSync } from 'node:child_process';
-import { writeFileSync, readFileSync } from 'node:fs';
+import { writeFileSync, readFileSync, rmSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
 import { parseArgs } from 'node:util';
 import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
@@ -192,26 +193,52 @@ console.log(JSON.stringify(resBody, null, 2));
 
 /**
  * Sign EIP-712 typed data via bankr wallet sign.
- * Writes typed data to a temp file and invokes bankr via a bash wrapper
+ * Writes typed data to a unique temp file and invokes bankr via a bash wrapper
  * to avoid shell escaping issues with complex JSON payloads.
+ * Cleans up temp files in a finally block and on process signals.
  */
 function signWithBankr(typedData) {
-  const tmpData = '/tmp/snapshot-typed-data.json';
-  const tmpScript = '/tmp/bankr-sign.sh';
-  writeFileSync(tmpData, JSON.stringify(typedData));
-  writeFileSync(tmpScript, [
-    '#!/bin/bash',
-    `TD=$(cat ${tmpData})`,
-    'bankr wallet sign --type eth_signTypedData_v4 --typed-data "$TD"',
-  ].join('\n') + '\n');
-  execSync(`chmod +x ${tmpScript}`);
-  const output = execSync(tmpScript, { encoding: 'utf8', timeout: 30000 });
-  const match = output.match(/0x[0-9a-fA-F]{130}/);
-  if (!match) {
-    console.error('Could not extract signature from bankr output:', output);
-    process.exit(1);
+  const id = randomUUID();
+  const tmpData = `/tmp/snapshot-typed-data-${id}.json`;
+  const tmpScript = `/tmp/bankr-sign-${id}.sh`;
+
+  function cleanup() {
+    rmSync(tmpData, { force: true });
+    rmSync(tmpScript, { force: true });
   }
-  return match[0];
+
+  // Register signal handlers so cleanup runs even if interrupted
+  const signals = ['SIGINT', 'SIGTERM'];
+  const sigHandlers = {};
+  for (const sig of signals) {
+    sigHandlers[sig] = () => { cleanup(); process.exit(1); };
+    process.once(sig, sigHandlers[sig]);
+  }
+  process.once('exit', cleanup);
+
+  try {
+    writeFileSync(tmpData, JSON.stringify(typedData));
+    writeFileSync(tmpScript, [
+      '#!/bin/bash',
+      `TD=$(cat ${tmpData})`,
+      'bankr wallet sign --type eth_signTypedData_v4 --typed-data "$TD"',
+    ].join('\n') + '\n');
+    execSync(`chmod +x ${tmpScript}`);
+    const output = execSync(tmpScript, { encoding: 'utf8', timeout: 30000 });
+    const match = output.match(/0x[0-9a-fA-F]{130}/);
+    if (!match) {
+      console.error('Could not extract signature from bankr output:', output);
+      process.exit(1);
+    }
+    return match[0];
+  } finally {
+    cleanup();
+    // Remove signal handlers to avoid leaks
+    for (const sig of signals) {
+      process.removeListener(sig, sigHandlers[sig]);
+    }
+    process.removeListener('exit', cleanup);
+  }
 }
 
 /** EIP-55 checksum address. Uses @ethersproject/address if available. */

--- a/snapshot/scripts/snapshot-propose.mjs
+++ b/snapshot/scripts/snapshot-propose.mjs
@@ -105,6 +105,11 @@ if (!snapshotBlock) {
 const start = args.start ? parseInt(args.start, 10) : now;
 const end = args.end ? parseInt(args.end, 10) : now + 7 * 24 * 3600;
 
+if (start >= end) {
+  console.error('Error: --start must be before --end (start=' + start + ', end=' + end + ')');
+  process.exit(1);
+}
+
 // Build EIP-712 message
 const timestamp = Math.floor(Date.now() / 1000);
 const message = {

--- a/snapshot/scripts/snapshot-query.sh
+++ b/snapshot/scripts/snapshot-query.sh
@@ -14,4 +14,4 @@ HEADERS=(-H 'Content-Type: application/json')
 
 BODY=$(jq -n --arg q "$QUERY" --argjson v "$VARS" '{query: $q, variables: $v}')
 
-curl -s "$HUB" "${HEADERS[@]}" -d "$BODY" | jq .
+curl -sf "$HUB" "${HEADERS[@]}" -d "$BODY" | jq .

--- a/snapshot/scripts/snapshot-query.sh
+++ b/snapshot/scripts/snapshot-query.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# snapshot-query.sh — Send a GraphQL query to the Snapshot Hub API.
+# Usage: bash snapshot-query.sh '<graphql_query>' [variables_json]
+# Env: SNAPSHOT_API_KEY (optional, for higher rate limits)
+#      SNAPSHOT_HUB (optional, default: https://hub.snapshot.org/graphql)
+set -euo pipefail
+
+QUERY="${1:?Usage: snapshot-query.sh '<graphql_query>' [variables_json]}"
+VARS="${2:-null}"
+HUB="${SNAPSHOT_HUB:-https://hub.snapshot.org/graphql}"
+
+HEADERS=(-H 'Content-Type: application/json')
+[[ -n "${SNAPSHOT_API_KEY:-}" ]] && HEADERS+=(-H "x-api-key: ${SNAPSHOT_API_KEY}")
+
+BODY=$(jq -n --arg q "$QUERY" --argjson v "$VARS" '{query: $q, variables: $v}')
+
+curl -s "$HUB" "${HEADERS[@]}" -d "$BODY" | jq .

--- a/snapshot/scripts/snapshot-vote.mjs
+++ b/snapshot/scripts/snapshot-vote.mjs
@@ -25,7 +25,8 @@
  * ~/.bankr/config.json before running this script.
  */
 import { execSync } from 'node:child_process';
-import { writeFileSync } from 'node:fs';
+import { writeFileSync, rmSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
 import { parseArgs } from 'node:util';
 import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
@@ -173,26 +174,52 @@ console.log(JSON.stringify(body, null, 2));
 
 /**
  * Sign EIP-712 typed data via bankr wallet sign.
- * Writes typed data to a temp file and invokes bankr via a bash wrapper
+ * Writes typed data to a unique temp file and invokes bankr via a bash wrapper
  * to avoid shell escaping issues with complex JSON payloads.
+ * Cleans up temp files in a finally block and on process signals.
  */
 function signWithBankr(typedData) {
-  const tmpData = '/tmp/snapshot-typed-data.json';
-  const tmpScript = '/tmp/bankr-sign.sh';
-  writeFileSync(tmpData, JSON.stringify(typedData));
-  writeFileSync(tmpScript, [
-    '#!/bin/bash',
-    `TD=$(cat ${tmpData})`,
-    'bankr wallet sign --type eth_signTypedData_v4 --typed-data "$TD"',
-  ].join('\n') + '\n');
-  execSync(`chmod +x ${tmpScript}`);
-  const output = execSync(tmpScript, { encoding: 'utf8', timeout: 30000 });
-  const match = output.match(/0x[0-9a-fA-F]{130}/);
-  if (!match) {
-    console.error('Could not extract signature from bankr output:', output);
-    process.exit(1);
+  const id = randomUUID();
+  const tmpData = `/tmp/snapshot-typed-data-${id}.json`;
+  const tmpScript = `/tmp/bankr-sign-${id}.sh`;
+
+  function cleanup() {
+    rmSync(tmpData, { force: true });
+    rmSync(tmpScript, { force: true });
   }
-  return match[0];
+
+  // Register signal handlers so cleanup runs even if interrupted
+  const signals = ['SIGINT', 'SIGTERM'];
+  const sigHandlers = {};
+  for (const sig of signals) {
+    sigHandlers[sig] = () => { cleanup(); process.exit(1); };
+    process.once(sig, sigHandlers[sig]);
+  }
+  process.once('exit', cleanup);
+
+  try {
+    writeFileSync(tmpData, JSON.stringify(typedData));
+    writeFileSync(tmpScript, [
+      '#!/bin/bash',
+      `TD=$(cat ${tmpData})`,
+      'bankr wallet sign --type eth_signTypedData_v4 --typed-data "$TD"',
+    ].join('\n') + '\n');
+    execSync(`chmod +x ${tmpScript}`);
+    const output = execSync(tmpScript, { encoding: 'utf8', timeout: 30000 });
+    const match = output.match(/0x[0-9a-fA-F]{130}/);
+    if (!match) {
+      console.error('Could not extract signature from bankr output:', output);
+      process.exit(1);
+    }
+    return match[0];
+  } finally {
+    cleanup();
+    // Remove signal handlers to avoid leaks
+    for (const sig of signals) {
+      process.removeListener(sig, sigHandlers[sig]);
+    }
+    process.removeListener('exit', cleanup);
+  }
 }
 
 /** EIP-55 checksum address. Uses @ethersproject/address if available. */

--- a/snapshot/scripts/snapshot-vote.mjs
+++ b/snapshot/scripts/snapshot-vote.mjs
@@ -161,6 +161,7 @@ const res = await fetch(SEQUENCER, {
   method: 'POST',
   headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
   body: JSON.stringify(envelope),
+  signal: AbortSignal.timeout(30000),
 });
 const body = await res.json();
 if (!res.ok) {

--- a/snapshot/scripts/snapshot-vote.mjs
+++ b/snapshot/scripts/snapshot-vote.mjs
@@ -56,7 +56,7 @@ if (!args.space || !args.proposal || !args.choice) {
 let address = args.from;
 if (!address) {
   const whoami = execSync('bankr whoami 2>&1', { encoding: 'utf8' });
-  const match = whoami.match(/0x[0-9a-fA-F]{40}/);
+  const match = whoami.match(/\b0x[0-9a-fA-F]{40}\b/);
   if (!match) { console.error('Could not get address from bankr whoami'); process.exit(1); }
   address = match[0];
 }

--- a/snapshot/scripts/snapshot-vote.mjs
+++ b/snapshot/scripts/snapshot-vote.mjs
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * snapshot-vote.mjs — Cast a vote on a Snapshot proposal using snapshot.js
+ *
+ * Usage:
+ *   node snapshot-vote.mjs --space "ens.eth" \
+ *     --proposal "0xabc..." \
+ *     --choice 1 \
+ *     --type "single-choice" \
+ *     [--reason "My rationale"] \
+ *     [--pk "$PRIVATE_KEY"]
+ *
+ * Env:
+ *   PRIVATE_KEY        — hex private key (0x-prefixed or raw)
+ *   SNAPSHOT_HUB       — hub URL (default: https://hub.snapshot.org)
+ *
+ * Choice format by voting type:
+ *   single-choice / basic : integer (1-indexed)
+ *   approval              : JSON array of ints, e.g. [1,3]
+ *   ranked-choice         : JSON array of ints in rank order, e.g. [2,1,3]
+ *   weighted / quadratic  : JSON object, e.g. {"1":60,"2":40}
+ */
+import snapshot from '@snapshot-labs/snapshot.js';
+import { Wallet } from '@ethersproject/wallet';
+import { parseArgs } from 'node:util';
+
+const { values: args } = parseArgs({
+  options: {
+    space:    { type: 'string' },
+    proposal: { type: 'string' },
+    choice:   { type: 'string' },
+    type:     { type: 'string', default: 'single-choice' },
+    reason:   { type: 'string', default: '' },
+    pk:       { type: 'string', default: process.env.PRIVATE_KEY || '' },
+    hub:      { type: 'string', default: process.env.SNAPSHOT_HUB || 'https://hub.snapshot.org' },
+    app:      { type: 'string', default: 'openclaw-snapshot' },
+  },
+  strict: true,
+});
+
+if (!args.space || !args.proposal || !args.choice || !args.pk) {
+  console.error('Missing required args. Run with --help for usage.');
+  process.exit(1);
+}
+
+// Parse choice based on type
+let choice;
+const t = args.type;
+if (t === 'single-choice' || t === 'basic') {
+  choice = parseInt(args.choice, 10);
+} else {
+  // approval, ranked-choice, weighted, quadratic — parse as JSON
+  choice = JSON.parse(args.choice);
+}
+
+const hub = args.hub.replace(/\/graphql\/?$/, '');
+const client = new snapshot.Client712(hub);
+const wallet = new Wallet(args.pk);
+const address = await wallet.getAddress();
+
+console.log(`Voting on proposal ${args.proposal} in space ${args.space}`);
+console.log(`Voter: ${address} | Type: ${args.type} | Choice: ${JSON.stringify(choice)}`);
+
+try {
+  const receipt = await client.vote(wallet, address, {
+    space: args.space,
+    proposal: args.proposal,
+    type: args.type,
+    choice,
+    reason: args.reason,
+    app: args.app,
+  });
+  console.log('Vote submitted successfully!');
+  console.log(JSON.stringify(receipt, null, 2));
+} catch (err) {
+  console.error('Vote failed:', err?.error_description || err?.message || err);
+  process.exit(1);
+}

--- a/snapshot/scripts/snapshot-vote.mjs
+++ b/snapshot/scripts/snapshot-vote.mjs
@@ -18,9 +18,16 @@
  *
  * Signs via `bankr wallet sign` (no private key needed).
  * Submits the signed envelope to the Snapshot sequencer.
+ *
+ * NOTE: Bankr's default API key may have trusted-recipient restrictions that
+ * block EIP-712 typed-data signing for non-transaction messages. If signing
+ * fails with a 403 error, configure an unrestricted Bankr API key in
+ * ~/.bankr/config.json before running this script.
  */
 import { execSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
 import { parseArgs } from 'node:util';
+import { createHash } from 'node:crypto';
 
 const SEQUENCER = process.env.SNAPSHOT_SEQUENCER || 'https://seq.snapshot.org';
 const DOMAIN = { name: 'snapshot', version: '0.1.4' };
@@ -51,6 +58,7 @@ if (!address) {
   if (!match) { console.error('Could not get address from bankr whoami'); process.exit(1); }
   address = match[0];
 }
+address = toChecksumAddress(address);
 
 // Parse choice based on type
 let choice;
@@ -137,25 +145,8 @@ console.log(`Voting on proposal ${args.proposal} in space ${args.space}`);
 console.log(`Voter: ${address} | Type: ${args.type} | Choice: ${JSON.stringify(choice)}`);
 
 // Sign with Bankr
-const typedDataJson = JSON.stringify(typedData);
-let sig;
-try {
-  const result = execSync(
-    `bankr wallet sign --type eth_signTypedData_v4 --typed-data '${typedDataJson.replace(/'/g, "'\\''")}'`,
-    { encoding: 'utf8', timeout: 30000 }
-  );
-  // Extract signature from output
-  const sigMatch = result.match(/0x[0-9a-fA-F]{130}/);
-  if (!sigMatch) {
-    console.error('Could not extract signature from bankr output:', result);
-    process.exit(1);
-  }
-  sig = sigMatch[0];
-  console.log('Signed successfully');
-} catch (err) {
-  console.error('Signing failed:', err.message || err);
-  process.exit(1);
-}
+const sig = signWithBankr(typedData);
+console.log('Signed successfully');
 
 // Submit to Snapshot sequencer
 const envelope = {
@@ -164,20 +155,52 @@ const envelope = {
   data: { domain: DOMAIN, types: voteTypes, message },
 };
 
-try {
-  const res = await fetch(SEQUENCER, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(envelope),
-  });
-  const body = await res.json();
-  if (!res.ok) {
-    console.error('Sequencer rejected vote:', JSON.stringify(body, null, 2));
+const res = await fetch(SEQUENCER, {
+  method: 'POST',
+  headers: { Accept: 'application/json', 'Content-Type': 'application/json' },
+  body: JSON.stringify(envelope),
+});
+const body = await res.json();
+if (!res.ok) {
+  console.error('Sequencer rejected vote:', JSON.stringify(body, null, 2));
+  process.exit(1);
+}
+console.log('Vote submitted successfully!');
+console.log(JSON.stringify(body, null, 2));
+
+// ── Helpers ──
+
+/**
+ * Sign EIP-712 typed data via bankr wallet sign.
+ * Writes typed data to a temp file and invokes bankr via a bash wrapper
+ * to avoid shell escaping issues with complex JSON payloads.
+ */
+function signWithBankr(typedData) {
+  const tmpData = '/tmp/snapshot-typed-data.json';
+  const tmpScript = '/tmp/bankr-sign.sh';
+  writeFileSync(tmpData, JSON.stringify(typedData));
+  writeFileSync(tmpScript, [
+    '#!/bin/bash',
+    `TD=$(cat ${tmpData})`,
+    'bankr wallet sign --type eth_signTypedData_v4 --typed-data "$TD"',
+  ].join('\n') + '\n');
+  execSync(`chmod +x ${tmpScript}`);
+  const output = execSync(tmpScript, { encoding: 'utf8', timeout: 30000 });
+  const match = output.match(/0x[0-9a-fA-F]{130}/);
+  if (!match) {
+    console.error('Could not extract signature from bankr output:', output);
     process.exit(1);
   }
-  console.log('Vote submitted successfully!');
-  console.log(JSON.stringify(body, null, 2));
-} catch (err) {
-  console.error('Submission failed:', err.message || err);
-  process.exit(1);
+  return match[0];
+}
+
+/** EIP-55 checksum address using Node.js built-in crypto (no deps). */
+function toChecksumAddress(addr) {
+  addr = addr.toLowerCase().replace('0x', '');
+  const hash = createHash('sha3-256').update(addr).digest('hex');
+  let ret = '0x';
+  for (let i = 0; i < 40; i++) {
+    ret += parseInt(hash[i], 16) >= 8 ? addr[i].toUpperCase() : addr[i];
+  }
+  return ret;
 }

--- a/snapshot/scripts/snapshot-vote.mjs
+++ b/snapshot/scripts/snapshot-vote.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * snapshot-vote.mjs — Cast a vote on a Snapshot proposal using snapshot.js
+ * snapshot-vote.mjs — Cast a vote on a Snapshot proposal via Bankr signing.
  *
  * Usage:
  *   node snapshot-vote.mjs --space "ens.eth" \
@@ -8,21 +8,22 @@
  *     --choice 1 \
  *     --type "single-choice" \
  *     [--reason "My rationale"] \
- *     [--pk "$PRIVATE_KEY"]
- *
- * Env:
- *   PRIVATE_KEY        — hex private key (0x-prefixed or raw)
- *   SNAPSHOT_HUB       — hub URL (default: https://hub.snapshot.org)
+ *     [--from "0xYOUR_ADDRESS"]
  *
  * Choice format by voting type:
  *   single-choice / basic : integer (1-indexed)
  *   approval              : JSON array of ints, e.g. [1,3]
  *   ranked-choice         : JSON array of ints in rank order, e.g. [2,1,3]
  *   weighted / quadratic  : JSON object, e.g. {"1":60,"2":40}
+ *
+ * Signs via `bankr wallet sign` (no private key needed).
+ * Submits the signed envelope to the Snapshot sequencer.
  */
-import snapshot from '@snapshot-labs/snapshot.js';
-import { Wallet } from '@ethersproject/wallet';
+import { execSync } from 'node:child_process';
 import { parseArgs } from 'node:util';
+
+const SEQUENCER = process.env.SNAPSHOT_SEQUENCER || 'https://seq.snapshot.org';
+const DOMAIN = { name: 'snapshot', version: '0.1.4' };
 
 const { values: args } = parseArgs({
   options: {
@@ -31,16 +32,24 @@ const { values: args } = parseArgs({
     choice:   { type: 'string' },
     type:     { type: 'string', default: 'single-choice' },
     reason:   { type: 'string', default: '' },
-    pk:       { type: 'string', default: process.env.PRIVATE_KEY || '' },
-    hub:      { type: 'string', default: process.env.SNAPSHOT_HUB || 'https://hub.snapshot.org' },
+    from:     { type: 'string', default: '' },
     app:      { type: 'string', default: 'openclaw-snapshot' },
   },
   strict: true,
 });
 
-if (!args.space || !args.proposal || !args.choice || !args.pk) {
-  console.error('Missing required args. Run with --help for usage.');
+if (!args.space || !args.proposal || !args.choice) {
+  console.error('Missing required args: --space, --proposal, --choice');
   process.exit(1);
+}
+
+// Resolve signer address from Bankr if not provided
+let address = args.from;
+if (!address) {
+  const whoami = execSync('bankr whoami 2>&1', { encoding: 'utf8' });
+  const match = whoami.match(/0x[0-9a-fA-F]{40}/);
+  if (!match) { console.error('Could not get address from bankr whoami'); process.exit(1); }
+  address = match[0];
 }
 
 // Parse choice based on type
@@ -49,30 +58,126 @@ const t = args.type;
 if (t === 'single-choice' || t === 'basic') {
   choice = parseInt(args.choice, 10);
 } else {
-  // approval, ranked-choice, weighted, quadratic — parse as JSON
   choice = JSON.parse(args.choice);
 }
 
-const hub = args.hub.replace(/\/graphql\/?$/, '');
-const client = new snapshot.Client712(hub);
-const wallet = new Wallet(args.pk);
-const address = await wallet.getAddress();
+// Build EIP-712 message
+const timestamp = Math.floor(Date.now() / 1000);
+const message = {
+  from: address,
+  space: args.space,
+  timestamp,
+  proposal: args.proposal,
+  choice,
+  reason: args.reason,
+  app: args.app,
+  metadata: '{}',
+};
+
+// Determine the correct EIP-712 types based on voting type
+let voteTypes;
+if (t === 'single-choice' || t === 'basic') {
+  voteTypes = {
+    Vote: [
+      { name: 'from', type: 'string' },
+      { name: 'space', type: 'string' },
+      { name: 'timestamp', type: 'uint64' },
+      { name: 'proposal', type: 'string' },
+      { name: 'choice', type: 'uint32' },
+      { name: 'reason', type: 'string' },
+      { name: 'app', type: 'string' },
+      { name: 'metadata', type: 'string' },
+    ]
+  };
+} else if (['approval', 'ranked-choice'].includes(t)) {
+  voteTypes = {
+    Vote: [
+      { name: 'from', type: 'string' },
+      { name: 'space', type: 'string' },
+      { name: 'timestamp', type: 'uint64' },
+      { name: 'proposal', type: 'string' },
+      { name: 'choice', type: 'uint32[]' },
+      { name: 'reason', type: 'string' },
+      { name: 'app', type: 'string' },
+      { name: 'metadata', type: 'string' },
+    ]
+  };
+} else {
+  // weighted, quadratic — choice is stringified JSON
+  message.choice = JSON.stringify(choice);
+  voteTypes = {
+    Vote: [
+      { name: 'from', type: 'string' },
+      { name: 'space', type: 'string' },
+      { name: 'timestamp', type: 'uint64' },
+      { name: 'proposal', type: 'string' },
+      { name: 'choice', type: 'string' },
+      { name: 'reason', type: 'string' },
+      { name: 'app', type: 'string' },
+      { name: 'metadata', type: 'string' },
+    ]
+  };
+}
+
+// Build the full EIP-712 typed data for bankr signing
+const typedData = {
+  domain: DOMAIN,
+  types: {
+    EIP712Domain: [
+      { name: 'name', type: 'string' },
+      { name: 'version', type: 'string' },
+    ],
+    ...voteTypes,
+  },
+  primaryType: 'Vote',
+  message,
+};
 
 console.log(`Voting on proposal ${args.proposal} in space ${args.space}`);
 console.log(`Voter: ${address} | Type: ${args.type} | Choice: ${JSON.stringify(choice)}`);
 
+// Sign with Bankr
+const typedDataJson = JSON.stringify(typedData);
+let sig;
 try {
-  const receipt = await client.vote(wallet, address, {
-    space: args.space,
-    proposal: args.proposal,
-    type: args.type,
-    choice,
-    reason: args.reason,
-    app: args.app,
-  });
-  console.log('Vote submitted successfully!');
-  console.log(JSON.stringify(receipt, null, 2));
+  const result = execSync(
+    `bankr wallet sign --type eth_signTypedData_v4 --typed-data '${typedDataJson.replace(/'/g, "'\\''")}'`,
+    { encoding: 'utf8', timeout: 30000 }
+  );
+  // Extract signature from output
+  const sigMatch = result.match(/0x[0-9a-fA-F]{130}/);
+  if (!sigMatch) {
+    console.error('Could not extract signature from bankr output:', result);
+    process.exit(1);
+  }
+  sig = sigMatch[0];
+  console.log('Signed successfully');
 } catch (err) {
-  console.error('Vote failed:', err?.error_description || err?.message || err);
+  console.error('Signing failed:', err.message || err);
+  process.exit(1);
+}
+
+// Submit to Snapshot sequencer
+const envelope = {
+  address,
+  sig,
+  data: { domain: DOMAIN, types: voteTypes, message },
+};
+
+try {
+  const res = await fetch(SEQUENCER, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(envelope),
+  });
+  const body = await res.json();
+  if (!res.ok) {
+    console.error('Sequencer rejected vote:', JSON.stringify(body, null, 2));
+    process.exit(1);
+  }
+  console.log('Vote submitted successfully!');
+  console.log(JSON.stringify(body, null, 2));
+} catch (err) {
+  console.error('Submission failed:', err.message || err);
   process.exit(1);
 }

--- a/snapshot/scripts/snapshot-vote.mjs
+++ b/snapshot/scripts/snapshot-vote.mjs
@@ -27,7 +27,8 @@
 import { execSync } from 'node:child_process';
 import { writeFileSync } from 'node:fs';
 import { parseArgs } from 'node:util';
-import { createHash } from 'node:crypto';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
 
 const SEQUENCER = process.env.SNAPSHOT_SEQUENCER || 'https://seq.snapshot.org';
 const DOMAIN = { name: 'snapshot', version: '0.1.4' };
@@ -194,13 +195,14 @@ function signWithBankr(typedData) {
   return match[0];
 }
 
-/** EIP-55 checksum address using Node.js built-in crypto (no deps). */
+/** EIP-55 checksum address. Uses @ethersproject/address if available. */
 function toChecksumAddress(addr) {
-  addr = addr.toLowerCase().replace('0x', '');
-  const hash = createHash('sha3-256').update(addr).digest('hex');
-  let ret = '0x';
-  for (let i = 0; i < 40; i++) {
-    ret += parseInt(hash[i], 16) >= 8 ? addr[i].toUpperCase() : addr[i];
+  try {
+    const { getAddress } = require('@ethersproject/address');
+    return getAddress(addr);
+  } catch {
+    console.warn('Warning: @ethersproject/address not found, using lowercase address.');
+    console.warn('Install it: npm i @ethersproject/address');
+    return addr.toLowerCase();
   }
-  return ret;
 }


### PR DESCRIPTION
## Snapshot Governance Skill

Query, vote, create, and delete proposals on [Snapshot](https://snapshot.box) — the leading off-chain governance platform for DAOs.

### What's included

- `SKILL.md` — Full workflow instructions for querying, voting, creating, and deleting proposals
- `scripts/snapshot-query.sh` — Bash wrapper for Hub GraphQL API queries
- `scripts/snapshot-vote.mjs` — Cast votes using Bankr wallet signing with EIP-712 (supports all voting types)
- `scripts/snapshot-propose.mjs` — Create proposals programmatically with `--body-file` support for long markdown
- `scripts/snapshot-delete.mjs` — Delete/cancel proposals using `CancelProposal` EIP-712 type
- `references/graphql-api.md` — Complete GraphQL query reference with examples
- `references/voting-types.md` — Voting type format guide (basic, single-choice, approval, weighted, quadratic, ranked-choice)

### Dependencies

- `@ethersproject/address` (for EIP-55 checksumming)
- `bankr` CLI (for wallet signing via `bankr wallet sign`)

No `snapshot.js` dependency — scripts build EIP-712 payloads and POST to the sequencer directly.

### Proven in production ✅

All four operations used on real Snapshot proposals in the pawthereum.eth space:

- **Proposal created** via `snapshot-propose.mjs`: [Migration Strategy for the Future of Pawthereum](https://snapshot.box/#/s:pawthereum.eth/proposal/0x79a3721fa1296bd08d7b960595629a73d98dc9133e1d2c36c8a7066f27c28054)
- **Vote cast** via `snapshot-vote.mjs`
- **Proposal deleted** via `snapshot-delete.mjs` (confirmed by sequencer receipt)

### Delete implementation notes

The delete script uses the `CancelProposal` EIP-712 type. For proposal IDs starting with `0x`, the sequencer maps this to its `delete-proposal` writer via SHA-256 hash of the type structure. Two non-obvious requirements:
- `address` and `message.from` must be EIP-55 checksummed — lowercase fails schema validation
- `data.types` in the envelope must exclude `EIP712Domain` — only the signing step includes it

### Known considerations

- Bankr's default API key may have trusted-recipient restrictions that block EIP-712 typed-data signing for non-transaction messages. An unrestricted Bankr API key is needed. Documented in SKILL.md.
- The `--network` flag must match the space's chain (e.g. `8453` for Base) — the auto-fetch falls back to Ethereum mainnet and will produce a `NaN` block if the space is on a different network. Pass `--snapshot` and `--network` explicitly when needed.

### Use cases

- Query active proposals in any Snapshot space
- Cast votes programmatically with Bankr wallet
- Create new proposals with customizable parameters
- Delete/cancel proposals you authored or administer
- Check voting power before voting
- Review vote breakdowns and delegation status