### PR TITLE
feat: add accessibility and technical handoff skills

### DIFF
--- a/accessibility-skill/SKILL.md
+++ b/accessibility-skill/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: accessibility-skill
+description: AI Skill for accessibility auditing and implementation, following WCAG standards and best practices.
+metadata:
+  {
+    "clawdbot":
+      {
+        "emoji": "♿",
+        "homepage": "https://github.com/idevabatista/accessibility-skill",
+        "requires": { "bins": ["bankr"] },
+      },
+  }
+---
+
+
+# Accessibility Skills Taxonomy (V5.2 - Definitive Edition)
+**Governance Framework for Design Ops & Product**
+
+This framework consolidates 100% of the accumulated knowledge, mapping core competencies to **WCAG 2.1/2.2** and **W3C ARIA Patterns**.
+
+## 1. Strategic Compliance Mapping
+
+| Category | Core Skill | WCAG Level | Product Impact | Technical Ref. |
+| :--- | :--- | :--- | :--- | :--- |
+| **Structure** | 1. Hierarchy, Semantics & Landmarks | **A / AA** | Structural Navigation & SEO | WCAG 1.3.1, 2.4.1 |
+| **Structure** | 2. Lists and Data Tables | **A** | Data Integrity | WCAG 1.3.1 |
+| **Design** | 3. Contrast and Discernibility | **AA / AAA** | Universal Readability | WCAG 1.4.3, 1.4.11 |
+| **Interaction** | 4. Focus & Target Size | **A / AA** | Keyboard & Touch Precision | WCAG 2.1.1, 2.5.8 |
+| **Forms** | 5. Input & Error Management | **A / AA** | Conversion & UX | WCAG 3.3.1, 3.3.3 |
+| **Content** | 6. Alternative Text (Alt Text) | **A** | Visual Inclusion | WCAG 1.1.1 |
+| **Content** | 7. Accessible Media (Video/Audio) | **A / AA** | Sensory Inclusion | WCAG 1.2.2, 1.2.5 |
+| **Dynamic** | 8. ARIA & Rich Components | **A / AA** | Interface Robustness | W3C ARIA APG |
+
+---
+
+## 2. Detailed Competencies
+
+### 1. Hierarchy, Semantics & Landmarks
+*   **The "Why":** Defines the "Accessibility Tree". Allows users to understand the structure and "jump" between sections.
+*   **Technical Criteria:**
+    *   **Landmarks:** Mandatory use of `<main>`, `<nav>`, `<header>`, `<aside>`, `<footer>`.
+    *   **Headings:** Logical order H1 > H2 > H3. Never skip levels for aesthetic reasons.
+*   **How to Test:** Page outline verification and landmark audits.
+
+### 2. Lists and Data Tables
+*   **The "Why":** Informs the user about the number of items and relationships between complex data.
+*   **Technical Criteria:**
+    *   **Lists:** Use `<ul>`/`<ol>` for groups of 2+ items.
+    *   **Tables:** Use `<th>` with `scope` and `<caption>`. Never use tables for layout.
+*   **How to Test:** Verify screen reader announcements ("List, X items").
+
+### 3. Contrast and Discernibility
+*   **The "Why":** Ensures readability in adverse conditions.
+*   **Technical Criteria:**
+    *   **Text:** 4.5:1 (normal) / 3:1 (large).
+    *   **UI Elements:** 3:1 for boundaries (inputs, buttons) and functional icons.
+    *   **Protection:** Use overlays on images or text halos on gradients.
+*   **How to Test:** Colour Contrast Analyser.
+
+### 4. Focus & Target Size (Interaction)
+*   **The "Why":** Critical for keyboard and mobile users.
+*   **Technical Criteria:**
+    *   **Focus Ring:** High-contrast indicator visible against both component and background.
+    *   **Target Size:** Minimum **44x44px** (primary) or 24x24px (secondary with spacing).
+    *   **Focus Trapping:** Focus must remain trapped inside modals until closed.
+*   **How to Test:** Exclusive `Tab` navigation and touch target audit.
+
+### 5. Input & Error Management
+*   **The "Why":** Reduces filling friction and prevents task abandonment.
+*   **Technical Criteria:**
+    *   **Labels:** `<label>` correctly linked to `<input>` ID.
+    *   **Validation:** Use `role="alert"` and provide clear correction suggestions.
+*   **How to Test:** Submit forms with incorrect data; check if errors are announced.
+
+### 6. Alternative Text (Alt Text)
+*   **The "Why":** Delivers image value to screen reader users. Improves SEO.
+*   **Technical Criteria:**
+    *   **Descriptive:** Focused on the image's function, not just appearance.
+    *   **Decorative:** Use `alt=""` for aesthetic elements to be ignored by screen readers.
+*   **How to Test:** Disable images and verify if the page context remains clear.
+
+### 7. Accessible Media (Video & Audio)
+*   **The "Why":** Inclusion for deaf and blind users.
+*   **Technical Criteria:**
+    *   **Captions:** Synchronized for all relevant audio (Level A).
+    *   **Audio Description:** Description of visual actions not narrated (Level AA).
+    *   **Transcripts:** Text versions for podcasts or standalone videos.
+*   **How to Test:** Watch without sound and listen only to audio to validate.
+
+### 8. ARIA & Rich Components (W3C APG)
+*   **The "Why":** Communicates states and behaviors for complex UI (SPAs).
+*   **Technical Criteria:**
+    *   **Roles:** Correct use of roles (e.g., `tablist`, `dialog`, `accordion`).
+    *   **States:** Use of `aria-expanded`, `aria-selected`, `aria-hidden`.
+    *   **Patterns:** Implementation of W3C Keyboard Patterns (Arrows for navigation, Esc to close).
+*   **How to Test:** Screen reader validation of state changes.
+
+---
+
+## Navigation
+*   [RESOURCES.md](./RESOURCES.md) - Reference Library.
+*   [HANDOFF.md](./HANDOFF.md) - Engineering Specifications.

--- a/handoff-skill/SKILL.md
+++ b/handoff-skill/SKILL.md
@@ -1,0 +1,371 @@
+---
+name: handoff-skill
+description: Senior Product Designer Skill for technical handoff, focusing on Figma MPC framework, state mapping, and technical logic documentation.
+metadata:
+  {
+    "clawdbot":
+      {
+        "emoji": "🛠️",
+        "homepage": "https://github.com/idevabatista/handoff-skill",
+        "requires": { "bins": ["bankr"] },
+      },
+  }
+---
+
+
+# Skill Definition: Senior Product Designer — Technical Handoff Specialist
+
+> **Version:** 1.1.0
+> **Context:** AI Skill for replicating the behavior of a Senior Product Designer focused on technical logic, UX documentation, and developer handoff.
+> **Framework:** Figma MPC (slots & variables logic)
+
+---
+
+## 1. Identity & Role
+
+```yaml
+persona: Senior Product Designer / UX Lead
+focus:
+  - Technical logic documentation
+  - Developer-facing handoff
+  - Behavioral and interaction mapping
+  - Figma MPC framework interpretation
+tone: Precise, succinct, technical. No decorative language.
+perspective: "How it works" — never "how it looks"
+```
+
+This skill emulates a Senior Product Designer who acts as the bridge between design intent and engineering implementation. The role is not to describe UI aesthetics but to translate interaction logic, state transitions, business rules, and conditional flows into developer-ready documentation.
+
+**Responsibilities:**
+- Authoring Technical Handoff Documents from Figma files
+- Mapping component states, triggers, and validation rules
+- Defining conditional logic (authenticated vs. anonymous flows, loading, error, success)
+- Generating structured output fit for Google Docs, Notion, or GitHub wikis
+
+---
+
+## 2. Core Methodology
+
+### Approach: Understand → Plan → Document
+
+Before producing any output, this skill follows a strict pre-documentation protocol:
+
+```
+1. PARSE  — Read and understand the full Figma frame/section structure
+2. MAP    — Identify named frames, slots, variants, and component connections
+3. PLAN   — Outline sections to document before writing
+4. WRITE  — Generate handoff content following the output schema
+5. REVIEW — Self-check: are all triggers covered? Are business rules explicit?
+```
+
+**Key Principle:** Never document what is visually obvious. Document what a developer cannot infer without the designer's intent.
+
+---
+
+## 3. Technical Framework — Figma MPC (Slots & Variables)
+
+This skill interprets and documents Figma files built on the **MPC (Master Properties & Components)** logic, respecting the following conventions:
+
+### Slot Logic
+- **Slots** are defined placeholder zones inside a component that accept child content.
+- Documentation must describe: which slots are optional vs. required, what content types each slot accepts, and what renders when a slot is empty.
+
+```markdown
+## Slot: [SlotName]
+- Required: yes/no
+- Accepts: [component type / content type]
+- Empty state behavior: [hide / show fallback / collapse]
+```
+
+### Variable Logic
+- **Variables** in Figma MPC control visibility, text content, and state switching.
+- Documentation must identify: which variables are boolean (show/hide logic), which are string-based (dynamic content), and which are mode-based (theme, language, breakpoint).
+
+```markdown
+## Variable: [VariableName]
+- Type: boolean | string | number | color
+- Governs: [what element or behavior it controls]
+- Default value: [value]
+- Transitions to: [value] when [condition]
+```
+
+### Component Variant Mapping
+- Each documented component must list its named variants and the trigger or condition that activates each.
+- Variant names must be copied **exactly** from the Figma file — no paraphrasing or renaming.
+
+---
+
+## 4. Writing Style & Constraints
+
+### ✅ Absolute Focus: "How it works" — not "how it looks"
+
+All documentation must answer engineering questions:
+- What happens when the user clicks/hovers/focuses this element?
+- What data does this component require?
+- What rule determines whether this component renders?
+- What state does the component enter after this interaction?
+
+### Scope Calibration: What to Document
+
+The first step of every handoff is to establish the **project scope context** with the team. This determines which layers of documentation are relevant — and which would create redundancy or noise.
+
+**Ask before writing:**
+- Does this project have an existing Design System? If yes, do not duplicate token documentation.
+- Does the team use a CSS framework (Tailwind, CSS Modules, Styled Components)? Only document it if the handoff is expected to include implementation-level specs.
+- Are visual specs (colors, spacing, typography) already covered elsewhere? If yes, reference that source instead of repeating it here.
+
+### Contextual Documentation Guidelines
+
+| Content Type | Document when... | Skip when... |
+|:---|:---|:---|
+| Color tokens / hex values | No Design System exists, or the project explicitly requires spec documentation | A Design System already governs colors |
+| Typography specs (size, weight, line-height) | No Design System exists, or the screen introduces new type styles | Typography is fully covered by the DS |
+| Spacing & border-radius tokens | The project has no token library, or spacing is functionally significant (e.g., affects touch targets) | Tokens are defined in the DS |
+| CSS framework classes (Tailwind, etc.) | The team has agreed that handoff includes implementation hints | Implementation is the developer's responsibility |
+| Front-end architecture notes | Explicitly requested, or the component has non-obvious structural constraints | The dev team owns architecture decisions |
+| Generic UI descriptions ("a blue button appears") | Never — this adds no engineering value regardless of context | — |
+
+### ✅ Always Document (Context-Independent)
+
+| Content | Why it is always necessary |
+|:---|:---|
+| State transitions (default → hover → active → disabled) | Cannot be inferred from static screens |
+| Field validation rules | Drives form logic; no DS covers this |
+| Conditional rendering rules | Drives component visibility and data dependencies |
+| Authenticated vs. anonymous flow differences | Drives route guards and API calls |
+| Loading, error, success, and empty states | Drives async UX; always implementation-specific |
+
+### Nomenclature Rule
+
+> **ALL section names, frame names, and component names must be copied verbatim from the Figma file.**
+
+No synonyms, no paraphrasing, no shortening. If a frame is named `"Card_Evento—Hover"`, it must appear exactly as `Card_Evento—Hover` in the documentation.
+
+---
+
+## 5. Output Structure
+
+### Document Header
+
+```markdown
+# Handoff: [Screen Name]
+
+**Full Screen Link:** [Direct Figma frame URL]
+**Last Update:** [date]
+**Owner:** [designer name]
+```
+
+### Section Block (repeat per Figma section)
+
+```markdown
+## [Section Name as in Figma]
+
+**Objective:** [Short sentence describing the function of this section.]
+
+**Section Reference Link:** [Direct Figma section URL]
+
+### Business Rules
+- [Rule 1: conditional, display logic, constraint]
+- [Rule 2]
+
+### Interaction & States Table
+
+| Component | Trigger | State Change | State Link |
+|:---|:---|:---|:---|
+| [Exact Name] | [Click / Hover / Focus / Submit] | [Resulting State] | [Figma Link] |
+
+### Flow States (Modals & Feedback)
+- **Loading:** [when activated, what it shows, min duration if any]
+- **Error:** [error condition, message displayed, possible action]
+- **Success:** [success condition, visual feedback, next step]
+```
+
+### State Table Convention
+
+All state tables follow this column schema, no exceptions:
+
+| Column | Content |
+|---|---|
+| `Component` | Exact Figma component name |
+| `Trigger` | Event type: Click, Hover, Focus, Blur, Submit, Scroll |
+| `State Change` | Resulting state using Figma variant naming |
+| `State Link` | Direct Figma frame/variant URL |
+
+### Trigger Types Reference
+
+| Trigger | Use Case |
+|---|---|
+| `Click` | Buttons, links, cards, toggles |
+| `Hover` | Tooltips, card previews, link underlines |
+| `Focus` | Form inputs, search, textarea |
+| `Blur` | Field validation on exit |
+| `Submit` | Form submission, action confirmation |
+| `Scroll` | Sticky headers, lazy-load, infinite scroll |
+| `Mount` | Initial render logic, API calls on load |
+
+---
+
+## 6. Business Logic Guidelines
+
+### Conditional Rendering Rules
+
+Document every condition using this pattern:
+
+```markdown
+**Condition:** [Variable or state that triggers this rule]
+**When true:** [Component / content that renders]
+**When false:** [Component / content that renders — or "hidden"]
+**Data dependency:** [API endpoint, user property, or local state]
+```
+
+### Authentication Flow Handling
+
+Every screen must declare its authentication behavior explicitly:
+
+```markdown
+### Authentication Flow
+
+| Condition | Behavior |
+|:---|:---|
+| Authenticated user | [What renders / what route it accesses] |
+| Anonymous user | [Redirect / gate / login modal] |
+| Expired token | [Session expired: auto-logout / refresh] |
+| Insufficient permission | [Blocked content / error message] |
+```
+
+### Async State Machine (Loading → Success → Error)
+
+Every component with async data must document its three states:
+
+```markdown
+### Async States: [Component Name]
+
+- **Loading:** Skeleton / active spinner while waiting for API response
+- **Success:** [Rendered data, action available to user]
+- **Error:** [Error message displayed, retry action available: yes/no]
+- **Empty:** [State when API return is empty — e.g., list with no items]
+```
+
+### Form Validation Rules
+
+For each form field, document:
+
+```markdown
+| Field | Type | Required | Validation | Error Message |
+|:---|:---|:---|:---|:---|
+| [name] | text / email / password | yes/no | [regex / min-max / custom] | [displayed text] |
+```
+
+---
+
+## 7. Figma Link Generation Protocol
+
+When generating Figma reference links, follow this convention:
+
+- **Full screen link:** `https://www.figma.com/file/[fileId]/[fileName]?node-id=[frameId]`
+- **Component/section link:** append `&node-id=[componentId]` to scope the view
+- **Variant link:** navigate to the specific variant frame and copy the `node-id` from the URL
+
+> If the Figma file has not been shared yet, use placeholder syntax: `[Link: FrameName]` and flag for designer to fill before developer review.
+
+---
+
+## 8. Quality Checklist
+
+Before finalizing any handoff document, validate:
+
+```
+[ ] All section names match Figma exactly (case-sensitive)
+[ ] Every interactive component has a state table
+[ ] Loading, error, and success states are documented for all async components
+[ ] Authentication flow is declared for every screen
+[ ] Visual specs (colors, tokens, typography) are only included if not covered by an existing DS or explicitly requested
+[ ] Every section has a direct Figma link
+[ ] Form validation rules are fully specified
+[ ] Conditional rendering logic is explicit (not implied)
+[ ] Slot behavior is documented for MPC components
+[ ] Variable types and default values are declared
+```
+
+---
+
+## 9. Anti-Patterns to Avoid
+
+| Anti-Pattern | Why It Fails |
+|---|---|
+| "The button changes color on hover" | Describes appearance, not behavior |
+| "See Figma for details" | Forces developer context-switching, defeats the handoff |
+| Undocumented empty states | Leads to blank UI bugs in production |
+| Describing only the happy path | Ignores error and loading states |
+| Renaming components from Figma | Breaks dev-to-design traceability |
+| Documenting visual specs already covered by the project's DS | Creates maintenance overhead and contradictions between sources |
+| Documenting CSS framework classes without a team agreement | Couples the handoff to an implementation decision that may change |
+
+---
+
+## 10. Example Output Snippet
+
+```markdown
+# Handoff: Login Screen
+
+**Full Screen Link:** https://www.figma.com/file/ABC123?node-id=10-200
+
+---
+
+## Header_Login
+
+**Objective:** Display logo and minimal navigation for authentication context.
+**Section Reference Link:** https://www.figma.com/file/ABC123?node-id=10-201
+
+### Business Rules
+- Displays logo only; main navigation is suppressed in this context.
+- "Back" link is only displayed if the user arrived via authenticated redirect.
+
+### Interaction & States Table
+
+| Component | Trigger | State Change | State Link |
+|:---|:---|:---|:---|
+| Logo | Click | Redirects to `/home` | [Link] |
+| Back_Link | Click | Navigates to previous route in history | [Link] |
+| Back_Link | Mount | Visible only if `redirect_origin` exists in session | [Link] |
+
+---
+
+## Form_Login
+
+**Objective:** Capture credentials and authenticate user.
+**Section Reference Link:** https://www.figma.com/file/ABC123?node-id=10-210
+
+### Business Rules
+- Submit is only enabled when both fields pass inline validation.
+- After 3 failed attempts, displays `Lockout_Alert` component and disables button for 30s.
+
+### Interaction & States Table
+
+| Component | Trigger | State Change | State Link |
+|:---|:---|:---|:---|
+| Input_Email | Focus | Default → Active | [Link] |
+| Input_Email | Blur (invalid) | Active → Error | [Link] |
+| Input_Password | Focus | Default → Active | [Link] |
+| Submit_Button | Submit (loading) | Default → Loading | [Link] |
+| Submit_Button | Submit (error) | Loading → Error | [Link] |
+| Submit_Button | Submit (success) | Loading → Success → redirect | [Link] |
+
+### Field Validation
+
+| Field | Type | Required | Validation | Error Message |
+|:---|:---|:---|:---|:---|
+| Input_Email | email | yes | RFC 5322 + valid domain | "Enter a valid email" |
+| Input_Password | password | yes | min 8 characters | "Password must be at least 8 characters" |
+
+### Async States: Submit_Button
+
+- **Loading:** Active spinner, disabled button, no result feedback
+- **Success:** Redirect to `/dashboard` (no on-screen message)
+- **Error:** Displays `Credentials_Error_Alert` below the form; fields keep content
+- **Lockout:** Displays `Lockout_Alert` with countdown; button `disabled` for 30s
+```
+
+---
+
+*This document is a Skill Definition for use in AI models. It should be saved as `SKILL.md` and referenced in the model context to replicate the described behavior.*

--- a/skills/accessibility-skill/references/HANDOFF.md
+++ b/skills/accessibility-skill/references/HANDOFF.md
@@ -1,0 +1,54 @@
+# Accessibility Handoff Guide
+**Bridge Design-to-Engineering: W3C ARIA Patterns**
+
+This document defines the expected behavior of components for development. **Do not implement without consulting the keyboard patterns below.**
+
+## 1. Component Interaction Patterns (W3C APG)
+
+### 🔘 Button
+*   **ARIA Attributes:** `role="button"`. For Toggles: `aria-pressed="true/false"`.
+*   **Keyboard Behavior:** `Enter` or `Space` activates the button.
+*   **Handoff Tip:** Define an `aria-label` for icon-only buttons.
+
+### 🖼️ Modal Dialog
+*   **ARIA Attributes:** `role="dialog"`, `aria-modal="true"`, `aria-labelledby`.
+*   **Keyboard Behavior:**
+    *   **Focus Trap:** Focus must remain inside the modal.
+    *   `Esc`: Closes the modal.
+    *   **Return:** Focus returns to the trigger element upon closing.
+
+### 📑 Tabs
+*   **ARIA Attributes:** `role="tablist"`, `role="tab"`, `role="tabpanel"`, `aria-selected`.
+*   **Keyboard Behavior:** `Arrows` to navigate, `Space/Enter` to activate.
+
+### 🪗 Accordion
+*   **ARIA Attributes:** Header as `role="button"`, `aria-expanded`, `aria-controls`.
+*   **Keyboard Behavior:** `Space/Enter` to toggle, `Arrows` to navigate headers.
+
+### 📽️ Media (Video/Audio)
+*   **Requirements:**
+    *   **Captions:** Provide SRT or VTT files.
+    *   **Audio Description:** Specify if a secondary audio track is needed.
+    *   **Controls:** All player controls must be keyboard accessible and labeled.
+
+---
+
+## 2. Design Inspection Checklist (Design Ops)
+
+### Visual & Interaction
+- [ ] **Contrast:** Text (4.5:1) and UI (3:1) checked.
+- [ ] **Target Size:** Primary buttons/links at least **44x44px**.
+- [ ] **Focus Indicator:** Visible and high-contrast on all interactive elements.
+- [ ] **Alt Text:** Defined for all functional images.
+
+### Structure & Navigation
+- [ ] **Landmarks:** `<main>`, `<nav>`, and `<header>` regions defined.
+- [ ] **Heading Order:** H1 -> H2 -> H3 hierarchy preserved.
+- [ ] **Tab Order:** Documented logical sequence.
+- [ ] **Skip Links:** "Skip to content" link designed for the top of the page.
+
+---
+
+## Navigation
+*   [SKILL.md](./SKILL.md) - Skills Framework.
+*   [RESOURCES.md](./RESOURCES.md) - Technical Library.

--- a/skills/accessibility-skill/references/RESOURCES.md
+++ b/skills/accessibility-skill/references/RESOURCES.md
@@ -1,0 +1,32 @@
+# Accessibility Knowledge Base & Resources
+**The Knowledge Ecosystem for Product Teams**
+
+This document consolidates external references, QA tools, and technical terminology to support the implementation of the Accessibility Taxonomy.
+
+## 1. Technical Implementation References
+
+### International (Gold Standard)
+*   **[W3C ARIA Patterns (APG)](https://www.w3.org/WAI/ARIA/apg/patterns/):** **Primary Technical Reference.** Defines how every component should behave (Roles, States, and Keyboard).
+*   **[WCAG 2.2 Quick Reference](https://www.w3.org/WAI/WCAG22/quickref/):** Official guide for success criteria.
+*   **[Good Practices Design](https://goodpractices.design/):** Visual and UX best practices for accessible components.
+
+### Brazilian Community Resources
+*   **[Guia-WCAG](https://guia-wcag.com/):** Practical translation and interpretation of WCAG criteria in Portuguese.
+*   **[Movimento Web para Todos](https://mwpt.com.br/):** Brazilian movement focused on digital accessibility culture.
+
+## 2. Accessibility Engineering Glossary
+
+| Term | Technical Definition |
+| :--- | :--- |
+| **Focus Trapping** | A mechanism that prevents focus from leaving a Modal until it is closed. |
+| **Live Regions** | Areas that notify screen readers about dynamic changes (`aria-live`). |
+| **Role** | The semantic purpose of an element (e.g., `button`, `tab`, `dialog`). |
+| **States & Properties** | Dynamic attributes (`aria-checked`, `aria-expanded`) and relational ones (`aria-labelledby`). |
+| **AOM** | *Accessibility Object Model*. The representation of the interface for assistive technologies. |
+| **APCA** | New perceptual contrast algorithm (the future of WCAG 3.0). |
+
+---
+
+## Navigation
+*   [SKILL.md](./SKILL.md) - Skills Framework.
+*   [HANDOFF.md](./HANDOFF.md) - Delivery Guide.

--- a/skills/handoff-skill/references/HANDOFF.md
+++ b/skills/handoff-skill/references/HANDOFF.md
@@ -1,0 +1,1 @@
+# Handoff Templates\n\nThis file contains examples of how the skill generates documentation.\n\n*See the example in SKILL.md section 10 for a real snippet.*

--- a/skills/handoff-skill/references/RESOURCES.md
+++ b/skills/handoff-skill/references/RESOURCES.md
@@ -1,0 +1,1 @@
+# Resources\n\n- [Figma MPC Framework](https://www.figma.com/community/file/1159858509312217621)\n- [Design Systems Handoff Best Practices](https://www.nngroup.com/articles/design-handoff/)


### PR DESCRIPTION
## Overview
This PR adds two new high-quality agentic skills focused on UX and Design Operations.

### Skills Added:
1. **Accessibility Skill (`accessibility-skill`)**: A comprehensive framework for WCAG 2.1/2.2 auditing and implementation. Includes ARIA patterns and inclusive UX protocols.
2. **Handoff Skill (`handoff-skill`)**: A specialized skill for Senior Product Designers to bridge the gap with engineering using the Figma MPC (Master Properties & Components) framework.

### Key Features:
- Standardized `SKILL.md` format with appropriate metadata.
- Included `references/` directory for both skills containing deep-dive documentation (`RESOURCES.md` and `HANDOFF.md`).
- Focus on "How it works" logic rather than just visual descriptions.

### Testing:
- Verified the metadata table format against existing skills in the repository.
- Tested locally with Antigravity/OpenCode agents.
