### PR TITLE
docs(bankr): document multi-chain LLM credit top-ups

### DIFF
--- a/bankr/SKILL.md
+++ b/bankr/SKILL.md
@@ -500,8 +500,10 @@ The [Bankr LLM Gateway](https://docs.bankr.bot/llm-gateway/overview) is a unifie
 ```bash
 bankr llm models                           # List available models
 bankr llm credits                          # Check credit balance
-bankr llm credits add 25                   # Top up $25 credits (USDC)
-bankr llm credits auto --enable --amount 25 --tokens USDC  # Auto top-up
+bankr llm credits add 25                   # Top up $25 credits (defaults to Base USDC)
+bankr llm credits add 25 --token USDT      # Pay USDT on whichever chain holds the most
+bankr llm credits add 25 --token ETH       # Native token; auto-swapped on its chain
+bankr llm credits auto --enable --amount 25 --tokens USDC,USDT  # Multi-chain auto top-up
 bankr llm setup openclaw --install         # Install Bankr provider into OpenClaw
 bankr llm setup claude                     # Print Claude Code env vars
 bankr llm claude                           # Launch Claude Code through gateway
@@ -516,7 +518,7 @@ bankr agent prompt "Top up my LLM credits with $25"
 bankr agent prompt "Add $10 of LLM credits using my ETH"
 ```
 
-1 credit = $1 USD. Paid in USDC on Base by default; any other Base ERC-20 token you hold is auto-swapped to USDC at checkout. Maximum $1,000 per top-up.
+1 credit = $1 USD. Multi-chain: pay with USDC or USDT directly on Base, Polygon, Ethereum, Arbitrum, or BNB Chain, or with any other ERC-20 (auto-swapped to the chain's preferred stablecoin — USDC on most chains, USDT on BNB). When using `--token`, the CLI picks the chain with the highest USD balance of that token. Maximum $1,000 per top-up.
 
 ### Model Deprecation
 
@@ -970,6 +972,8 @@ See [references/safety.md](references/safety.md) for comprehensive safety guidan
 - "Top up my LLM credits with $25"
 - "Add $50 of LLM credits"
 - "Top up LLM credits using my ETH"
+- "Top up my LLM credits with $25 using USDT on Polygon"
+- "Add $10 of LLM credits paid in USDT on BNB"
 
 ### x402 Paid API Calls
 

--- a/bankr/references/llm-gateway.md
+++ b/bankr/references/llm-gateway.md
@@ -79,19 +79,24 @@ Check your LLM gateway credit balance:
 bankr llm credits
 ```
 
-Top up credits from your wallet:
+Top up credits from your wallet. Pay on any supported EVM chain — **Base, Polygon, Ethereum, Arbitrum, or BNB Chain** — and the CLI picks the chain holding the highest USD balance of your chosen token.
 
 ```bash
-bankr llm credits add 25                   # Add $25 credits (USDC default)
-bankr llm credits add 50 --token 0x...     # Add $50 from a specific token
+bankr llm credits add 25                   # Defaults to Base USDC
+bankr llm credits add 25 --token USDC      # USDC on the chain with the largest balance
+bankr llm credits add 25 --token USDT      # USDT (Polygon / Ethereum / Arbitrum / BNB)
+bankr llm credits add 50 --token ETH       # Native ETH (Base / Ethereum / Arbitrum)
+bankr llm credits add 50 --token 0x...     # By contract address
 bankr llm credits add 25 -y                # Skip confirmation prompt
 ```
 
-Configure automatic top-up so credits never run out:
+USDC and USDT are sent directly when they're an accepted stablecoin on the resolved chain. Any other token is auto-swapped to the chain's preferred stablecoin (USDC on most chains, USDT on BNB) with ≤5% slippage protection.
+
+Configure automatic top-up so credits never run out (tokens are resolved across every supported chain — the worker tries them in priority order on their saved chains):
 
 ```bash
 bankr llm credits auto                     # View current auto top-up config
-bankr llm credits auto --enable --amount 25 --threshold 5 --tokens USDC
+bankr llm credits auto --enable --amount 25 --threshold 5 --tokens USDC,USDT
 bankr llm credits auto --disable
 ```
 
@@ -106,7 +111,7 @@ bankr agent prompt "Top up my LLM credits with $25"
 bankr agent prompt "Add $10 of LLM credits using my ETH"
 ```
 
-1 credit = $1 USD. Paid in USDC on Base by default; any other Base ERC-20 token you hold is auto-swapped to USDC at checkout. Maximum $1,000 per top-up.
+1 credit = $1 USD. Multi-chain: pay with USDC or USDT directly on Base, Polygon, Ethereum, Arbitrum, or BNB Chain, or with any other ERC-20 (auto-swapped to the chain's preferred stablecoin — USDC on most chains, USDT on BNB). Maximum $1,000 per top-up.
 
 > **LLM credits vs trading wallet:** These are completely separate balances on the same account and API key. Your trading wallet (ETH, SOL, USDC) is for on-chain transactions. LLM credits (USD) are for gateway API calls. Having crypto does NOT give you LLM credits.
 


### PR DESCRIPTION
## Summary

- Updates `bankr/SKILL.md` and `bankr/references/llm-gateway.md` to reflect the multi-chain LLM credit top-up flow shipping in [bankr-3 PR #1411](https://github.com/BankrBot/bankr/pull/1411).
- `bankr llm credits add` and `bankr llm credits auto` now accept payment on any supported EVM chain (Base, Polygon, Ethereum, Arbitrum, BNB Chain). USDC/USDT are sent directly when accepted on the resolved chain; anything else is auto-swapped to the chain's preferred stablecoin (USDC on most chains, USDT on BNB).
- When `--token` is passed without an explicit chain, the CLI picks the chain holding the highest USD balance of that token.

## Test plan

- [x] Skim diff for accuracy against current CLI behavior on the bankr-3 feature branch
- [ ] Verify rendered SKILL.md examples once the corresponding `@bankr/cli` version is published to npm