### PR TITLE
docs(bankr): weekly skill update — May 9–16

### DIFF
--- a/bankr/SKILL.md
+++ b/bankr/SKILL.md
@@ -482,7 +482,7 @@ bankr agent cancel job_abc123
 
 ## LLM Gateway
 
-The [Bankr LLM Gateway](https://docs.bankr.bot/llm-gateway/overview) is a unified API for Claude, Gemini, GPT, and other models — multi-provider access, cost tracking, automatic failover, and SDK compatibility through a single endpoint.
+The [Bankr LLM Gateway](https://docs.bankr.bot/llm-gateway/overview) is a unified API for Claude, Gemini, GPT, Grok, and other models — multi-provider access, cost tracking, automatic failover, and SDK compatibility through a single endpoint.
 
 **Base URL:** `https://llm.bankr.bot` | **Dashboard:** [bankr.bot/llm](https://bankr.bot/llm) | **API Keys:** [bankr.bot/api](https://bankr.bot/api)
 
@@ -624,6 +624,7 @@ For full details — setup paths, model list, provider config, SDK examples, key
 - DCA (dollar-cost averaging)
 - TWAP (time-weighted average price)
 - Scheduled commands
+- Per-automation model selection (Max Mode) — choose a specific LLM model for each automation; consumes LLM credits when enabled
 
 **Reference**: [references/automation.md](references/automation.md)
 
@@ -633,7 +634,7 @@ The agent can discover, call, and deploy x402-protected API endpoints, automatic
 
 - **Discover** endpoints in the Bankr registry or via web search
 - **Inspect** endpoint pricing, methods, and input/output schemas
-- **Call** endpoints with automatic payment signing (max $10/request)
+- **Call** endpoints with automatic payment signing (each call requires explicit approval via confirmation modal)
 - **Deploy** new x402 endpoints directly through the agent (write handler code, set pricing, deploy)
 - Works with any x402-compatible endpoint (Bankr-hosted or external)
 

--- a/bankr/references/automation.md
+++ b/bankr/references/automation.md
@@ -114,6 +114,18 @@ Run any Bankr command on a schedule.
 - Can recreate anytime
 - To modify an automation, cancel and recreate with new parameters
 
+## Per-Automation Model Selection (Max Mode)
+
+Each automation can optionally run with a specific LLM model instead of the wallet-wide default. When a custom model is selected, that automation consumes **LLM credits** on each execution.
+
+- Configure via the automation detail page in the Bankr Terminal or through the agent
+- Available models match the LLM Gateway model catalog
+- When credits run out, automations using a custom model will skip their next run (or pause) until credits are topped up
+- The automation detail page shows your current credit balance and provides a top-up CTA when credits are low or exhausted
+- To revert to the wallet default model, clear the model selection
+
+**Tip:** Set up auto top-up (`bankr llm credits auto --enable`) to prevent automations from pausing due to empty credits.
+
 ## Chain Support
 
 ### EVM Chains (Base, Polygon, Ethereum)

--- a/bankr/references/llm-gateway.md
+++ b/bankr/references/llm-gateway.md
@@ -1,6 +1,6 @@
 # LLM Gateway Reference
 
-The Bankr LLM Gateway is a unified API for Claude, Gemini, GPT, and other models. It provides multi-provider access, cost tracking, automatic failover, and SDK compatibility through a single endpoint.
+The Bankr LLM Gateway is a unified API for Claude, Gemini, GPT, Grok, and other models. It provides multi-provider access, cost tracking, automatic failover, and SDK compatibility through a single endpoint.
 
 **Base URL:** `https://llm.bankr.bot`
 
@@ -57,6 +57,7 @@ bankr config get llmKey
 | `minimax-m2.7` | MiniMax | Balanced performance (204.8K context) |
 | `kimi-k2.5` | Moonshot AI | Long-context reasoning |
 | `qwen3-coder` | Alibaba | Code generation, debugging |
+| `grok-4.3` | xAI | Reasoning, value-tier (1M context, image input) |
 | `glm-5` | Z.ai | General purpose reasoning |
 | `glm-5-turbo` | Z.ai | Fast, cost-effective |
 


### PR DESCRIPTION
## Summary

Weekly sync of the bankr skill with recent platform changes (May 9–16).

- **LLM Gateway — Grok 4.3**: Add xAI Grok 4.3 to the model catalog (1M context, image input, value-tier pricing). Update provider descriptions to mention Grok alongside Claude, Gemini, and GPT.
- **Per-automation model selection (Max Mode)**: Automations can now run with a specific LLM model instead of the wallet default. New section in `references/automation.md` covers configuration, LLM credit consumption, and out-of-credits behavior.
- **x402 security model update**: The per-app daily spend cap has been removed. Each x402 call now requires explicit user approval via a confirmation modal showing the probed price — updated the capability description accordingly.

### Files changed

| File | Change |
|------|--------|
| `bankr/SKILL.md` | Add Grok to LLM gateway description, add per-automation model selection to automation capabilities, update x402 call description |
| `bankr/references/llm-gateway.md` | Add `grok-4.3` to Available Models table, update gateway description |
| `bankr/references/automation.md` | New "Per-Automation Model Selection (Max Mode)" section |

## Test plan

- [ ] Verify SKILL.md renders correctly on GitHub
- [ ] Verify model table in `references/llm-gateway.md` is properly formatted
- [ ] Verify new automation section in `references/automation.md` is consistent with existing style

---
_Generated by [Claude Code](https://claude.ai/code/session_019988n5FHvU9RaMYoywSGfh)_