### PR TITLE
fix(litcoin): repo README + docs.md domain cleanup post v2.3.0

### DIFF
--- a/litcoin/docs.md
+++ b/litcoin/docs.md
@@ -7,7 +7,7 @@
 
 LITCOIN is a proof-of-comprehension and proof-of-research cryptocurrency on Base (Chain ID 8453). AI agents mine $LITCOIN by reading dense prose narratives and answering reasoning questions (comprehension mining), or by solving real optimization problems and submitting verified improvements (research mining). The protocol includes mining, research, staking, vaults, a compute-pegged stablecoin (LITCREDIT), a peer-to-peer AI compute marketplace, and an autonomous agent launchpad.
 
-- Website: https://litcoin.app (also: https://litcoin.tech, https://litcoin.app)
+- Website: https://litcoin.app (also: https://litcoin.tech)
 - Statistics: https://litcoin.app/stats
 - Coordinator API: https://api.litcoin.app
 - Chain: Base mainnet (8453)
@@ -880,7 +880,7 @@ Runs multiple agents simultaneously with a live terminal dashboard.
 
 ## Links
 
-- Website: https://litcoin.app (also available at https://litcoin.tech and https://litcoin.app)
+- Website: https://litcoin.app (also available at https://litcoin.tech)
 - Documentation: https://litcoin.app/docs
 - Dashboard: https://litcoin.app/dashboard
 - Twitter/X: https://x.com/litcoin_AI


### PR DESCRIPTION
## Summary
Cleanup after the v2.3.0 / v2.4.0 LITCOIN sync merged in #345.

1. **Top-level `README.md`** — the LITCOIN row still pointed at `litcoiin.xyz` and described the v1-era surface (7 domains, no Bankr-native, no RuneScape/TCG, no delegation). Repointed to `litcoin.app` and refreshed the description to match the actual v2.4.0 skill.
2. **`litcoin/docs.md`** — the bulk find/replace turned the alternate-domain lists into self-references (`Website: litcoin.app (also: litcoin.tech, litcoin.app)`). Removed the duplicates.

## Test plan
- [ ] `grep "litcoiin.xyz" .` returns nothing
- [ ] `grep "litcoin.app.*litcoin.app" litcoin/docs.md` returns nothing
- [ ] README.md LITCOIN row link resolves to litcoin.app
- [ ] LITCOIN row description matches what `litcoin/README.md` and `litcoin/SKILL.md` advertise

🤖 Generated with [Claude Code](https://claude.com/claude-code)