### PR TITLE
feat: add gnosis-safe skill

### DIFF
--- a/gnosis-safe/SKILL.md
+++ b/gnosis-safe/SKILL.md
@@ -16,7 +16,10 @@ Interact with Gnosis Safe multisig wallets on Base, Ethereum, and Polygon. Suppo
 - `python3` with `eth_utils` — for EIP-712 hash computation (`pip install eth-utils`)
 - `bankr` — for on-chain calls (`approveHash`, `execTransaction`)
 
-> ⚠️ **Important:** The Safe contract address must be in Bankr's **trusted addresses list** before you can call `approveHash` or `execTransaction` via Bankr. Add it once with `bankr address add <safe_address>`.
+> ⚠️ **Important:** The Safe contract address must be in Bankr's **trusted recipients list** before you can call `approveHash` or `execTransaction` via Bankr. Add it via the Bankr dashboard, or run:
+> ```
+> bankr agent 'add 0xYourSafeAddress to my trusted recipient addresses'
+> ```
 
 ---
 
@@ -68,9 +71,15 @@ python3 scripts/propose_tx.py \
   --safe    0xYourSafeAddress \
   --to      0xRecipientAddress \
   --value   0.01 \
+  --chain   8453
+
+# With explicit signer address (optional — auto-detected via 'bankr whoami' if omitted):
+python3 scripts/propose_tx.py \
+  --safe    0xYourSafeAddress \
+  --to      0xRecipientAddress \
+  --value   0.01 \
   --chain   8453 \
-  --rpc     https://mainnet.base.org \
-  --key     YOUR_BANKR_KEY_NAME
+  --signer  0xYourSignerAddress
 
 # With calldata (optional):
 python3 scripts/propose_tx.py \
@@ -78,9 +87,7 @@ python3 scripts/propose_tx.py \
   --to      0xContractAddress \
   --value   0 \
   --data    0xabcdef1234 \
-  --chain   8453 \
-  --rpc     https://mainnet.base.org \
-  --key     YOUR_BANKR_KEY_NAME
+  --chain   8453
 ```
 
 **What happens under the hood:**
@@ -116,13 +123,14 @@ All non-essential fields (`operation`, `safeTxGas`, `baseGas`, `gasPrice`, `gasT
 
 ### Step B — On-Chain Approval via Bankr
 
-```bash
-bankr call \
-  --to <safe_address> \
-  --key <bankr_key_name> \
-  --abi 'approveHash(bytes32)' \
-  --args '[<safe_tx_hash>]' \
-  --rpc <rpc_url>
+The script uses `bankr agent` with a raw-transaction prompt to call `approveHash(bytes32)` on-chain:
+
+```
+bankr agent "Submit raw transaction on Base (chain 8453):
+- to: <safe_address>
+- data: 0xd4d9bdcd<safe_tx_hash_without_0x_padded_to_64_chars>
+- value: 0
+Wait for confirmation and return the tx hash."
 ```
 
 Function selector: `0xd4d9bdcd` (`approveHash(bytes32)`)
@@ -192,42 +200,41 @@ GET {TX_SERVICE}/api/v1/safes/{safe_address}/multisig-transactions/?executed=fal
 
 ## Operation 4: Check If a Hash Is Approved
 
-Query whether a specific owner has approved a given `safeTxHash` on-chain.
+Query whether a specific owner has approved a given `safeTxHash` on-chain via the Safe TX Service:
 
 ```bash
-bankr call \
-  --to <safe_address> \
-  --rpc <rpc_url> \
-  --abi 'approvedHashes(address,bytes32)(uint256)' \
-  --args '["<owner_address>", "<safe_tx_hash>"]'
+curl -s "{TX_SERVICE}/api/v1/safes/{safe_address}/multisig-transactions/?safe_tx_hash={safe_tx_hash}" \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); print('Confirmed' if d['results'][0]['confirmations'] else 'Not confirmed')"
+```
+
+Or use `bankr agent` to query on-chain:
+
+```bash
+bankr agent "Call approvedHashes on Safe {safe_address} on Base with args ['{owner_address}', '{safe_tx_hash}']. Return 1 if approved, 0 if not."
 ```
 
 Function selector: `0x7d832974` (`approvedHashes(address,bytes32)`)
 
 Returns `1` if approved, `0` if not.
 
-**Example:**
-```bash
-bankr call \
-  --to 0xYourSafeAddress \
-  --rpc https://mainnet.base.org \
-  --abi 'approvedHashes(address,bytes32)(uint256)' \
-  --args '["0xYourSignerAddress", "0xSafeTxHash"]'
-```
-
 ---
 
 ## Operation 5: Execute a Transaction
 
-Once the required number of approvals (`threshold`) is reached, execute the transaction on-chain.
+Once the required number of approvals (`threshold`) is reached, execute via `bankr agent`:
 
 ```bash
-bankr call \
-  --to <safe_address> \
-  --key <bankr_key_name> \
-  --rpc <rpc_url> \
-  --abi 'execTransaction(address,uint256,bytes,uint8,uint256,uint256,uint256,address,address,bytes)(bool)' \
-  --args '["<to>","<value_wei>","<data_hex>",0,0,0,0,"0x0000000000000000000000000000000000000000","0x0000000000000000000000000000000000000000","<packed_signatures>"]'
+bankr agent "Call execTransaction on Safe contract 0xYourSafeAddress on Base with:
+- to: 0xRecipient
+- value: <value_wei>
+- data: 0x
+- operation: 0
+- safeTxGas: 0
+- baseGas: 0
+- gasPrice: 0
+- gasToken: 0x0000000000000000000000000000000000000000
+- refundReceiver: 0x0000000000000000000000000000000000000000
+- signatures: <packed_signatures>"
 ```
 
 Function selector: `0x6a761202` (`execTransaction(...)`)
@@ -257,8 +264,7 @@ def build_packed_signatures(signer_addresses):
    └─ ./scripts/safe_info.sh 0xSafe base
 
 2. Propose transaction (computes hash, approves on-chain, posts to service)
-   └─ python3 scripts/propose_tx.py --safe 0xSafe --to 0xRecipient --value 0.5 \
-        --chain 8453 --rpc https://mainnet.base.org --key mykey
+   └─ python3 scripts/propose_tx.py --safe 0xSafe --to 0xRecipient --value 0.5 --chain 8453
 
 3. Share safeTxHash with other owners so they can approve
    └─ They can approve via Safe UI or another approveHash call
@@ -267,7 +273,7 @@ def build_packed_signatures(signer_addresses):
    └─ ./scripts/list_pending.sh 0xSafe base
 
 5. Once threshold is met, execute
-   └─ bankr call --to 0xSafe --key mykey --abi 'execTransaction(...)' ...
+   └─ bankr agent "Call execTransaction on Safe 0xSafe on Base with to 0xRecipient ..."
       OR use Safe UI at app.safe.global
 ```
 
@@ -278,7 +284,7 @@ def build_packed_signatures(signer_addresses):
 | Error | Cause | Fix |
 |-------|-------|-----|
 | `1337` (Safe TX service) | Nonce already used or invalid signature | Check nonce with `safe_info.sh`, verify signer is an owner |
-| `approveHash` reverts | Safe address not in Bankr trusted list | `bankr address add <safe_address>` |
+| `approveHash` reverts | Safe address not in Bankr trusted list | Add via Bankr dashboard or `bankr agent 'add 0xSafe to my trusted recipient addresses'` |
 | `CALL_EXCEPTION` | Wrong RPC or contract address | Verify chain ID matches RPC and safe address |
 | `confirmations not met` | Not enough approvals | Check threshold vs confirmed count with `list_pending.sh` |
 

--- a/gnosis-safe/SKILL.md
+++ b/gnosis-safe/SKILL.md
@@ -1,0 +1,306 @@
+---
+name: gnosis-safe
+description: Interact with Gnosis Safe multisig wallets — propose transactions, check status, list pending proposals, and execute when threshold is met
+metadata: {"clawdbot":{"emoji":"🔐","homepage":"https://safe.global","requires":{"bins":["curl","python3","bankr"]}}}
+---
+
+# Gnosis Safe Skill
+
+Interact with Gnosis Safe multisig wallets on Base, Ethereum, and Polygon. Supports proposing transactions, approving via on-chain `approveHash`, querying pending proposals, and executing transactions when threshold is met.
+
+---
+
+## Prerequisites
+
+- `curl` — for Safe Transaction Service API calls
+- `python3` with `eth_utils` — for EIP-712 hash computation (`pip install eth-utils`)
+- `bankr` — for on-chain calls (`approveHash`, `execTransaction`)
+
+> ⚠️ **Important:** The Safe contract address must be in Bankr's **trusted addresses list** before you can call `approveHash` or `execTransaction` via Bankr. Add it once with `bankr address add <safe_address>`.
+
+---
+
+## Chain Configuration
+
+| Chain    | Chain ID | Safe TX Service URL                                  |
+|----------|----------|------------------------------------------------------|
+| Base     | 8453     | `https://safe-transaction-base.safe.global`          |
+| Ethereum | 1        | `https://safe-transaction-mainnet.safe.global`       |
+| Polygon  | 137      | `https://safe-transaction-polygon.safe.global`       |
+
+Set `CHAIN` to `base`, `ethereum`, or `polygon`. Scripts auto-resolve the URL.
+
+---
+
+## Operation 1: Check Safe Info
+
+Get current nonce, threshold, owners, and ETH balance for a Safe.
+
+```bash
+./scripts/safe_info.sh <SAFE_ADDRESS> <CHAIN>
+
+# Example:
+./scripts/safe_info.sh 0xYourSafeAddress base
+```
+
+**What it returns:**
+- `nonce` — current transaction sequence number (use this when proposing)
+- `threshold` — number of confirmations required to execute
+- `owners` — list of owner addresses
+- ETH balance from the blockchain
+
+**API used:**
+```
+GET {TX_SERVICE}/api/v1/safes/{safe_address}/
+```
+
+---
+
+## Operation 2: Propose a Transaction
+
+Propose a new transaction to a Safe. This involves three steps:
+1. Compute the EIP-712 `safeTxHash` in Python
+2. Call `approveHash(bytes32)` on-chain via Bankr (registers your approval on-chain)
+3. POST the proposal + contract signature to the Safe Transaction Service
+
+```bash
+python3 scripts/propose_tx.py \
+  --safe    0xYourSafeAddress \
+  --to      0xRecipientAddress \
+  --value   0.01 \
+  --chain   8453 \
+  --rpc     https://mainnet.base.org \
+  --key     YOUR_BANKR_KEY_NAME
+
+# With calldata (optional):
+python3 scripts/propose_tx.py \
+  --safe    0xYourSafeAddress \
+  --to      0xContractAddress \
+  --value   0 \
+  --data    0xabcdef1234 \
+  --chain   8453 \
+  --rpc     https://mainnet.base.org \
+  --key     YOUR_BANKR_KEY_NAME
+```
+
+**What happens under the hood:**
+
+### Step A — EIP-712 Hash Computation
+
+```python
+from eth_utils import keccak
+
+def compute_safe_tx_hash(safe_address, to, value_wei, nonce, chain_id, data=b""):
+    DOMAIN_SEPARATOR_TYPEHASH = keccak(b"EIP712Domain(uint256 chainId,address verifyingContract)")
+    domain_data = (DOMAIN_SEPARATOR_TYPEHASH +
+                   chain_id.to_bytes(32, 'big') +
+                   bytes.fromhex(safe_address[2:].lower().zfill(64)))
+    domain_separator = keccak(domain_data)
+
+    SAFE_TX_TYPEHASH = keccak(b"SafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,uint256 nonce)")
+
+    to_bytes = bytes.fromhex(to[2:].lower().zfill(64))
+    value_bytes = value_wei.to_bytes(32, 'big')
+    data_hash = keccak(data)
+    zeros = bytes(32)
+
+    safe_tx_data = (SAFE_TX_TYPEHASH + to_bytes + value_bytes + data_hash +
+                    zeros + zeros + zeros + zeros + zeros + zeros +
+                    nonce.to_bytes(32, 'big'))
+    safe_tx_hash_inner = keccak(safe_tx_data)
+    final_hash = keccak(b"\x19\x01" + domain_separator + safe_tx_hash_inner)
+    return "0x" + final_hash.hex()
+```
+
+All non-essential fields (`operation`, `safeTxGas`, `baseGas`, `gasPrice`, `gasToken`, `refundReceiver`) default to zero.
+
+### Step B — On-Chain Approval via Bankr
+
+```bash
+bankr call \
+  --to <safe_address> \
+  --key <bankr_key_name> \
+  --abi 'approveHash(bytes32)' \
+  --args '[<safe_tx_hash>]' \
+  --rpc <rpc_url>
+```
+
+Function selector: `0xd4d9bdcd` (`approveHash(bytes32)`)
+
+This records your approval on-chain. The Safe contract's `approvedHashes[caller][txHash]` mapping is set to `1`.
+
+### Step C — Contract Signature Encoding
+
+Since Bankr holds the key server-side, use a **contract signature** (v=1):
+
+```python
+def build_contract_signature(signer_address):
+    r = signer_address[2:].lower().zfill(64)  # address padded to 32 bytes
+    s = "0" * 64                               # 32 zero bytes
+    v = "01"                                   # type 1 = contract signature
+    return "0x" + r + s + v
+```
+
+### Step D — POST to Safe Transaction Service
+
+```bash
+curl -X POST "{TX_SERVICE}/api/v1/safes/{safe_address}/multisig-transactions/" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": "<to>",
+    "value": "<value_wei>",
+    "data": "<hex_data_or_null>",
+    "operation": 0,
+    "safeTxGas": 0,
+    "baseGas": 0,
+    "gasPrice": "0",
+    "gasToken": "0x0000000000000000000000000000000000000000",
+    "refundReceiver": "0x0000000000000000000000000000000000000000",
+    "nonce": <nonce>,
+    "contractTransactionHash": "<safe_tx_hash>",
+    "sender": "<signer_address>",
+    "signature": "<contract_signature>"
+  }'
+```
+
+---
+
+## Operation 3: List Pending Transactions
+
+Show all pending (unexecuted) proposals with confirmation counts.
+
+```bash
+./scripts/list_pending.sh <SAFE_ADDRESS> <CHAIN>
+
+# Example:
+./scripts/list_pending.sh 0xYourSafeAddress base
+```
+
+**Output includes:**
+- `safeTxHash` — the EIP-712 hash uniquely identifying this proposal
+- `nonce` — transaction sequence number
+- `to`, `value`, `data` — destination, ETH value, calldata
+- `confirmations` — list of addresses that have approved
+- `confirmationsRequired` — threshold
+
+**API used:**
+```
+GET {TX_SERVICE}/api/v1/safes/{safe_address}/multisig-transactions/?executed=false&ordering=-nonce
+```
+
+---
+
+## Operation 4: Check If a Hash Is Approved
+
+Query whether a specific owner has approved a given `safeTxHash` on-chain.
+
+```bash
+bankr call \
+  --to <safe_address> \
+  --rpc <rpc_url> \
+  --abi 'approvedHashes(address,bytes32)(uint256)' \
+  --args '["<owner_address>", "<safe_tx_hash>"]'
+```
+
+Function selector: `0x7d832974` (`approvedHashes(address,bytes32)`)
+
+Returns `1` if approved, `0` if not.
+
+**Example:**
+```bash
+bankr call \
+  --to 0xYourSafeAddress \
+  --rpc https://mainnet.base.org \
+  --abi 'approvedHashes(address,bytes32)(uint256)' \
+  --args '["0xYourSignerAddress", "0xSafeTxHash"]'
+```
+
+---
+
+## Operation 5: Execute a Transaction
+
+Once the required number of approvals (`threshold`) is reached, execute the transaction on-chain.
+
+```bash
+bankr call \
+  --to <safe_address> \
+  --key <bankr_key_name> \
+  --rpc <rpc_url> \
+  --abi 'execTransaction(address,uint256,bytes,uint8,uint256,uint256,uint256,address,address,bytes)(bool)' \
+  --args '["<to>","<value_wei>","<data_hex>",0,0,0,0,"0x0000000000000000000000000000000000000000","0x0000000000000000000000000000000000000000","<packed_signatures>"]'
+```
+
+Function selector: `0x6a761202` (`execTransaction(...)`)
+
+**Packed signatures** — concatenate all contract signatures sorted by signer address (ascending). Each signature is 65 bytes: r (32 bytes, address padded) + s (32 bytes, zeros) + v (1 byte, `0x01`).
+
+```python
+def build_packed_signatures(signer_addresses):
+    """Build packed signatures sorted by address (required by Safe)."""
+    sorted_addresses = sorted(signer_addresses, key=lambda a: a.lower())
+    packed = "0x"
+    for addr in sorted_addresses:
+        packed += addr[2:].lower().zfill(64)  # r: address as bytes32
+        packed += "0" * 64                     # s: 32 zero bytes
+        packed += "01"                          # v: contract signature type
+    return packed
+```
+
+> 💡 Alternatively, use the Safe UI at `app.safe.global` — connect your wallet and execute from there once threshold is met. The Transaction Service will show it as ready.
+
+---
+
+## Typical Workflow
+
+```
+1. Check Safe info to get current nonce and threshold
+   └─ ./scripts/safe_info.sh 0xSafe base
+
+2. Propose transaction (computes hash, approves on-chain, posts to service)
+   └─ python3 scripts/propose_tx.py --safe 0xSafe --to 0xRecipient --value 0.5 \
+        --chain 8453 --rpc https://mainnet.base.org --key mykey
+
+3. Share safeTxHash with other owners so they can approve
+   └─ They can approve via Safe UI or another approveHash call
+
+4. List pending to check confirmation count
+   └─ ./scripts/list_pending.sh 0xSafe base
+
+5. Once threshold is met, execute
+   └─ bankr call --to 0xSafe --key mykey --abi 'execTransaction(...)' ...
+      OR use Safe UI at app.safe.global
+```
+
+---
+
+## Error Reference
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `1337` (Safe TX service) | Nonce already used or invalid signature | Check nonce with `safe_info.sh`, verify signer is an owner |
+| `approveHash` reverts | Safe address not in Bankr trusted list | `bankr address add <safe_address>` |
+| `CALL_EXCEPTION` | Wrong RPC or contract address | Verify chain ID matches RPC and safe address |
+| `confirmations not met` | Not enough approvals | Check threshold vs confirmed count with `list_pending.sh` |
+
+---
+
+## Function Selectors Reference
+
+| Function | Selector |
+|----------|----------|
+| `approveHash(bytes32)` | `0xd4d9bdcd` |
+| `approvedHashes(address,bytes32)` | `0x7d832974` |
+| `execTransaction(...)` | `0x6a761202` |
+| `getOwners()` | `0xa0e67e2b` |
+| `getThreshold()` | `0xe75235b8` |
+| `nonce()` | `0xaffed0e0` |
+
+---
+
+## Notes
+
+- All transactions default to `operation=0` (CALL). Use `operation=1` for DELEGATECALL only if you know what you're doing.
+- `gasToken` and `refundReceiver` are set to zero address (no gas refund).
+- `safeTxGas`, `baseGas`, `gasPrice` are all `0` — Safe will use whatever gas is available.
+- The Safe TX Service is off-chain infrastructure — it queues proposals and tracks signatures but does NOT execute transactions itself.
+- Contract signatures (v=1) rely on the Safe checking `approvedHashes[signer][txHash] == 1` on-chain during execution.

--- a/gnosis-safe/references/safe-api.md
+++ b/gnosis-safe/references/safe-api.md
@@ -1,0 +1,343 @@
+# Safe Transaction Service API Reference
+
+Reference for the Gnosis Safe Transaction Service REST API endpoints used by this skill.
+
+Base documentation: https://safe-transaction-base.safe.global/ (replace `base` with chain name)
+
+---
+
+## Base URLs by Chain
+
+| Chain    | Chain ID | Base URL                                             |
+|----------|----------|------------------------------------------------------|
+| Base     | 8453     | `https://safe-transaction-base.safe.global`          |
+| Ethereum | 1        | `https://safe-transaction-mainnet.safe.global`       |
+| Polygon  | 137      | `https://safe-transaction-polygon.safe.global`       |
+| Arbitrum | 42161    | `https://safe-transaction-arbitrum.safe.global`      |
+| Optimism | 10       | `https://safe-transaction-optimism.safe.global`      |
+
+---
+
+## Endpoints Used by This Skill
+
+### GET /api/v1/safes/{address}/
+
+Retrieve Safe information: nonce, threshold, owners, version, master copy, etc.
+
+**Request:**
+```
+GET https://safe-transaction-base.safe.global/api/v1/safes/0xYourSafeAddress/
+Accept: application/json
+```
+
+**Response (200):**
+```json
+{
+  "address": "0xYourSafeAddress",
+  "nonce": 5,
+  "threshold": 2,
+  "owners": [
+    "0xOwner1Address",
+    "0xOwner2Address"
+  ],
+  "masterCopy": "0x...",
+  "modules": [],
+  "fallbackHandler": "0x...",
+  "guard": "0x0000000000000000000000000000000000000000",
+  "version": "1.3.0"
+}
+```
+
+**Key fields:**
+- `nonce` — use this value when proposing a new transaction
+- `threshold` — number of approvals required to execute
+- `owners` — list of authorized signers
+
+---
+
+### GET /api/v1/safes/{address}/multisig-transactions/
+
+List multisig transactions for a Safe. Supports filtering and ordering.
+
+**Query parameters:**
+
+| Parameter   | Type    | Description                                         |
+|-------------|---------|-----------------------------------------------------|
+| `executed`  | bool    | `false` for pending, `true` for executed, omit both for all |
+| `ordering`  | string  | Field to sort by. Use `-nonce` for newest first, `nonce` for oldest first |
+| `limit`     | int     | Max results to return (default 10, max 100)         |
+| `offset`    | int     | Pagination offset                                   |
+| `nonce`     | int     | Filter by exact nonce                               |
+| `nonce__gte`| int     | Filter nonce >= value                               |
+| `to`        | address | Filter by destination address                       |
+| `trusted`   | bool    | `true` to return only trusted (confirmed) proposals |
+
+**Request (pending txs):**
+```
+GET https://safe-transaction-base.safe.global/api/v1/safes/0xYourSafeAddress/multisig-transactions/?executed=false&ordering=-nonce&limit=20
+```
+
+**Response (200):**
+```json
+{
+  "count": 2,
+  "next": null,
+  "previous": null,
+  "results": [
+    {
+      "safe": "0xYourSafeAddress",
+      "to": "0xRecipientAddress",
+      "value": "10000000000000000",
+      "data": null,
+      "operation": 0,
+      "gasToken": "0x0000000000000000000000000000000000000000",
+      "safeTxGas": 0,
+      "baseGas": 0,
+      "gasPrice": "0",
+      "refundReceiver": "0x0000000000000000000000000000000000000000",
+      "nonce": 5,
+      "submissionDate": "2024-01-15T10:30:00.000000Z",
+      "modified": "2024-01-15T10:31:00.000000Z",
+      "blockNumber": null,
+      "transactionHash": null,
+      "safeTxHash": "0xabcdef...",
+      "executor": null,
+      "isExecuted": false,
+      "isSuccessful": null,
+      "ethGasPrice": null,
+      "maxFeePerGas": null,
+      "maxPriorityFeePerGas": null,
+      "gasUsed": null,
+      "fee": null,
+      "origin": null,
+      "dataDecoded": null,
+      "confirmationsRequired": 2,
+      "confirmations": [
+        {
+          "owner": "0xOwner1Address",
+          "submissionDate": "2024-01-15T10:30:00.000000Z",
+          "transactionHash": null,
+          "signature": "0x...",
+          "signatureType": "CONTRACT_SIGNATURE"
+        }
+      ],
+      "trusted": true,
+      "signatures": "0x...",
+      "isExecutable": false
+    }
+  ]
+}
+```
+
+**Key fields per transaction:**
+- `safeTxHash` — unique identifier for this proposal (EIP-712 hash)
+- `nonce` — must match current Safe nonce for execution
+- `confirmationsRequired` — threshold (from Safe config)
+- `confirmations` — list of owners who have approved
+- `isExecutable` — `true` when enough confirmations to execute
+- `isExecuted` — `true` once the tx has been sent on-chain
+
+---
+
+### POST /api/v1/safes/{address}/multisig-transactions/
+
+Propose a new multisig transaction. Requires a valid EIP-712 hash and signature.
+
+**Request:**
+```
+POST https://safe-transaction-base.safe.global/api/v1/safes/0xYourSafeAddress/multisig-transactions/
+Content-Type: application/json
+```
+
+**Request body:**
+```json
+{
+  "to": "0xRecipientAddress",
+  "value": "10000000000000000",
+  "data": null,
+  "operation": 0,
+  "safeTxGas": 0,
+  "baseGas": 0,
+  "gasPrice": "0",
+  "gasToken": "0x0000000000000000000000000000000000000000",
+  "refundReceiver": "0x0000000000000000000000000000000000000000",
+  "nonce": 5,
+  "contractTransactionHash": "0xabcdef...",
+  "sender": "0xYourSignerAddress",
+  "signature": "0x000000000000000000000000YourSignerAddress000000000000000000000000000000000000000000000000000000000000000001"
+}
+```
+
+**Field notes:**
+- `contractTransactionHash` — the EIP-712 safeTxHash (computed off-chain)
+- `sender` — address that called `approveHash` on-chain
+- `signature` — contract signature (see encoding below)
+- All non-essential fields should be zero/null
+
+**Contract signature encoding (v=1):**
+```
+r = sender_address padded to 32 bytes (64 hex chars)
+s = 32 zero bytes (64 hex chars)
+v = "01" (1 byte = contract signature type)
+full = "0x" + r + s + v  (= 130 hex chars = 65 bytes)
+```
+
+**Response:**
+- `201 Created` — success, no body
+- `200 OK` — success (some versions)
+- `422 Unprocessable Entity` — invalid data (wrong hash, invalid signer, wrong nonce)
+- `400 Bad Request` — malformed request
+
+**Common error codes:**
+- `1337` — nonce collision or invalid signature
+- Verify signer is an owner of the Safe
+- Verify nonce matches current Safe nonce (not future or past)
+
+---
+
+### GET /api/v1/safes/{address}/multisig-transactions/{safe_tx_hash}/
+
+Get details for a specific transaction by its safeTxHash.
+
+**Request:**
+```
+GET https://safe-transaction-base.safe.global/api/v1/safes/0xYourSafeAddress/multisig-transactions/0xabcdef.../
+```
+
+Returns same structure as individual item in the list endpoint.
+
+---
+
+### POST /api/v1/multisig-transactions/{safe_tx_hash}/confirmations/
+
+Add a confirmation (signature) to an existing proposal without re-proposing.
+
+Used when a second owner wants to approve an already-proposed transaction.
+
+**Request:**
+```
+POST https://safe-transaction-base.safe.global/api/v1/multisig-transactions/0xabcdef.../confirmations/
+Content-Type: application/json
+
+{
+  "signature": "0x..."
+}
+```
+
+For contract signatures (approveHash), the signature format is the same as during proposal.
+
+---
+
+## On-Chain Contract Interface
+
+These are the Safe contract functions called directly (not through the TX service).
+
+### approveHash(bytes32 hashToApprove)
+
+**Selector:** `0xd4d9bdcd`
+
+Marks a hash as approved by the caller. Sets `approvedHashes[msg.sender][hashToApprove] = 1`.
+
+```
+bankr call \
+  --to <safe_address> \
+  --key <bankr_key> \
+  --rpc <rpc_url> \
+  --abi "approveHash(bytes32)" \
+  --args '["<safe_tx_hash>"]'
+```
+
+---
+
+### approvedHashes(address owner, bytes32 hash) returns (uint256)
+
+**Selector:** `0x7d832974`
+
+Read-only check. Returns `1` if `owner` has approved `hash`, else `0`.
+
+```
+bankr call \
+  --to <safe_address> \
+  --rpc <rpc_url> \
+  --abi "approvedHashes(address,bytes32)(uint256)" \
+  --args '["<owner_address>", "<safe_tx_hash>"]'
+```
+
+---
+
+### execTransaction(address,uint256,bytes,uint8,uint256,uint256,uint256,address,address,bytes) returns (bool)
+
+**Selector:** `0x6a761202`
+
+Execute a transaction when threshold is met. Requires packed signatures sorted by owner address ascending.
+
+```
+bankr call \
+  --to <safe_address> \
+  --key <bankr_key> \
+  --rpc <rpc_url> \
+  --abi "execTransaction(address,uint256,bytes,uint8,uint256,uint256,uint256,address,address,bytes)(bool)" \
+  --args '["<to>","<value>","<data>",0,0,0,0,"0x000...000","0x000...000","<packed_sigs>"]'
+```
+
+**Packed signatures:** Concatenate contract signatures for all approvers sorted by address (ascending). Each is 65 bytes.
+
+---
+
+### getOwners() returns (address[])
+
+**Selector:** `0xa0e67e2b`
+
+Returns the list of current Safe owners.
+
+---
+
+### getThreshold() returns (uint256)
+
+**Selector:** `0xe75235b8`
+
+Returns the current confirmation threshold.
+
+---
+
+### nonce() returns (uint256)
+
+**Selector:** `0xaffed0e0`
+
+Returns the current nonce. Note: the TX service also exposes this but on-chain is the source of truth.
+
+---
+
+## EIP-712 Hash Computation
+
+The `safeTxHash` is an EIP-712 typed data hash. It uniquely identifies a transaction proposal.
+
+### Type Hashes
+
+```
+DOMAIN_SEPARATOR_TYPEHASH = keccak256("EIP712Domain(uint256 chainId,address verifyingContract)")
+
+SAFE_TX_TYPEHASH = keccak256(
+  "SafeTx(address to,uint256 value,bytes data,uint8 operation,"
+  "uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,"
+  "address gasToken,address refundReceiver,uint256 nonce)"
+)
+```
+
+### Computation Steps
+
+1. `domainSeparator = keccak256(DOMAIN_SEPARATOR_TYPEHASH || chainId || safe_address)`
+2. `safeTxHashInner = keccak256(SAFE_TX_TYPEHASH || to || value || keccak256(data) || operation || safeTxGas || baseGas || gasPrice || gasToken || refundReceiver || nonce)` (all fields padded to 32 bytes)
+3. `safeTxHash = keccak256(0x1901 || domainSeparator || safeTxHashInner)`
+
+All simple types (address, uint) are ABI-encoded as 32-byte big-endian. `bytes` type is hashed with `keccak256`.
+
+---
+
+## Notes
+
+- The Safe Transaction Service is operated by Safe{DAO}. It is off-chain infrastructure.
+- Proposals stored in the service are not binding — they're just a coordination layer.
+- The on-chain `approveHash` call is what actually records the approval on-chain.
+- During `execTransaction`, Safe checks each signature: for contract signatures (v=1), it reads `approvedHashes[r_address][txHash]`.
+- Always use checksummed addresses (EIP-55) when interacting with the service.

--- a/gnosis-safe/scripts/list_pending.sh
+++ b/gnosis-safe/scripts/list_pending.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# list_pending.sh — List pending (unexecuted) Gnosis Safe transactions
+#
+# Usage:
+#   ./list_pending.sh <SAFE_ADDRESS> <CHAIN>
+#
+# Arguments:
+#   SAFE_ADDRESS   - Safe contract address (0x...)
+#   CHAIN          - Chain name or ID: base (8453), ethereum (1), polygon (137)
+#
+# Examples:
+#   ./list_pending.sh 0xYourSafeAddress base
+#   ./list_pending.sh 0xYourSafeAddress ethereum
+#
+# Requirements: curl, python3 (optional, for pretty output)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Args
+# ---------------------------------------------------------------------------
+SAFE_ADDRESS="${1:-}"
+CHAIN="${2:-base}"
+
+if [[ -z "$SAFE_ADDRESS" ]]; then
+  echo "Usage: $0 <SAFE_ADDRESS> <CHAIN>"
+  echo "Example: $0 0xYourSafeAddress base"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve TX service URL
+# ---------------------------------------------------------------------------
+case "${CHAIN,,}" in
+  base|8453)
+    TX_SERVICE="https://safe-transaction-base.safe.global"
+    ;;
+  ethereum|mainnet|1)
+    TX_SERVICE="https://safe-transaction-mainnet.safe.global"
+    ;;
+  polygon|137)
+    TX_SERVICE="https://safe-transaction-polygon.safe.global"
+    ;;
+  *)
+    echo "ERROR: Unknown chain '${CHAIN}'. Use: base, ethereum, polygon (or 8453, 1, 137)" >&2
+    exit 1
+    ;;
+esac
+
+# pending txs: executed=false, ordered by nonce descending
+PENDING_URL="${TX_SERVICE}/api/v1/safes/${SAFE_ADDRESS}/multisig-transactions/?executed=false&ordering=-nonce&limit=20"
+
+# ---------------------------------------------------------------------------
+# Header
+# ---------------------------------------------------------------------------
+echo "⏳ Pending Gnosis Safe Transactions"
+echo "  Safe:       $SAFE_ADDRESS"
+echo "  Chain:      $CHAIN"
+echo "  TX Service: $TX_SERVICE"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Fetch
+# ---------------------------------------------------------------------------
+RESPONSE=$(curl -s -f --max-time 15 \
+  -H "Accept: application/json" \
+  "$PENDING_URL") || {
+  echo "ERROR: Failed to fetch pending transactions from: ${PENDING_URL}" >&2
+  echo "Verify the Safe address and chain are correct." >&2
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Display
+# ---------------------------------------------------------------------------
+if command -v python3 &>/dev/null; then
+  echo "$RESPONSE" | python3 -c "
+import json, sys
+from datetime import datetime
+
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError as e:
+    print(f'ERROR: Could not parse JSON: {e}')
+    sys.exit(1)
+
+results = data.get('results', [])
+count   = data.get('count', 0)
+
+if count == 0 or not results:
+    print('  No pending transactions found.')
+    print()
+    print('  Either all transactions have been executed, or none have been proposed yet.')
+    sys.exit(0)
+
+print(f'  Found {count} pending transaction(s):')
+print()
+
+for i, tx in enumerate(results, 1):
+    confirmations     = tx.get('confirmations', [])
+    confs_required    = tx.get('confirmationsRequired', tx.get('threshold', '?'))
+    confs_count       = len(confirmations)
+    safe_tx_hash      = tx.get('safeTxHash', 'N/A')
+    nonce             = tx.get('nonce', 'N/A')
+    to                = tx.get('to', 'N/A')
+    value             = tx.get('value', '0')
+    data              = tx.get('data', None)
+    modified          = tx.get('modified', tx.get('submissionDate', 'N/A'))
+    is_executable     = tx.get('isExecutable', False)
+
+    try:
+        value_eth = int(value) / 10**18
+    except (ValueError, TypeError):
+        value_eth = 0
+
+    print(f'  [{i}] Nonce: {nonce}')
+    print(f'      Hash:     {safe_tx_hash}')
+    print(f'      To:       {to}')
+    print(f'      Value:    {value_eth:.6f} ETH ({value} wei)')
+    if data and data != '0x':
+        data_preview = data[:66] + ('...' if len(data) > 66 else '')
+        print(f'      Data:     {data_preview}')
+    else:
+        print(f'      Data:     (none)')
+    print(f'      Confirms: {confs_count}/{confs_required}', end='')
+    if is_executable:
+        print(' ✅ READY TO EXECUTE', end='')
+    print()
+    if confirmations:
+        print(f'      Signers:')
+        for conf in confirmations:
+            owner     = conf.get('owner', 'N/A')
+            sig_type  = conf.get('signatureType', 'N/A')
+            print(f'        - {owner} ({sig_type})')
+    print()
+
+if count > len(results):
+    print(f'  (Showing {len(results)} of {count} total — increase limit to see more)')
+print()
+print('  Execute ready txs via: bankr call --to <safe> --abi execTransaction(...)')
+print('  Or via Safe UI: https://app.safe.global')
+"
+else
+  # Fallback: raw JSON
+  echo "$RESPONSE"
+fi

--- a/gnosis-safe/scripts/propose_tx.py
+++ b/gnosis-safe/scripts/propose_tx.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""
+propose_tx.py — Propose a Gnosis Safe transaction
+
+Steps:
+  1. Fetch current nonce from Safe Transaction Service
+  2. Compute EIP-712 safeTxHash
+  3. Call approveHash(bytes32) on-chain via Bankr
+  4. POST proposal + contract signature to Safe Transaction Service
+
+Usage:
+  python3 propose_tx.py \
+    --safe    0xYourSafeAddress \
+    --to      0xRecipientAddress \
+    --value   0.01 \
+    --chain   8453 \
+    --rpc     https://mainnet.base.org \
+    --key     your_bankr_key_name \
+    [--data   0xabcdef]    # optional calldata
+
+Requirements:
+  pip install eth-utils requests
+  bankr must be installed and the safe address must be in its trusted list:
+    bankr address add <safe_address>
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+try:
+    import requests
+except ImportError:
+    print("ERROR: 'requests' not installed. Run: pip install requests", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    from eth_utils import keccak, to_checksum_address
+except ImportError:
+    print("ERROR: 'eth_utils' not installed. Run: pip install eth-utils", file=sys.stderr)
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Chain configuration
+# ---------------------------------------------------------------------------
+
+CHAIN_CONFIG = {
+    1:    {"name": "ethereum", "tx_service": "https://safe-transaction-mainnet.safe.global"},
+    137:  {"name": "polygon",  "tx_service": "https://safe-transaction-polygon.safe.global"},
+    8453: {"name": "base",     "tx_service": "https://safe-transaction-base.safe.global"},
+}
+
+CHAIN_NAME_MAP = {
+    "ethereum": 1,
+    "mainnet":  1,
+    "polygon":  137,
+    "base":     8453,
+}
+
+
+def resolve_chain_id(chain_arg):
+    """Accept chain ID (int) or name string, return int chain_id and tx_service URL."""
+    try:
+        chain_id = int(chain_arg)
+    except ValueError:
+        chain_id = CHAIN_NAME_MAP.get(chain_arg.lower())
+        if chain_id is None:
+            print(f"ERROR: Unknown chain '{chain_arg}'. Use 1, 137, 8453, or ethereum/polygon/base.", file=sys.stderr)
+            sys.exit(1)
+    if chain_id not in CHAIN_CONFIG:
+        print(f"ERROR: Unsupported chain_id {chain_id}. Supported: {list(CHAIN_CONFIG.keys())}", file=sys.stderr)
+        sys.exit(1)
+    return chain_id, CHAIN_CONFIG[chain_id]["tx_service"]
+
+
+# ---------------------------------------------------------------------------
+# EIP-712 hash computation
+# ---------------------------------------------------------------------------
+
+def compute_safe_tx_hash(safe_address: str, to: str, value_wei: int, nonce: int,
+                          chain_id: int, data: bytes = b"") -> str:
+    """
+    Compute the EIP-712 safeTxHash for a Gnosis Safe transaction.
+
+    Parameters default to zero for: operation, safeTxGas, baseGas, gasPrice,
+    gasToken (zero address), refundReceiver (zero address).
+    """
+    # Domain separator
+    DOMAIN_SEPARATOR_TYPEHASH = keccak(b"EIP712Domain(uint256 chainId,address verifyingContract)")
+    safe_addr_bytes = bytes.fromhex(safe_address[2:].lower().zfill(64))
+    domain_data = DOMAIN_SEPARATOR_TYPEHASH + chain_id.to_bytes(32, "big") + safe_addr_bytes
+    domain_separator = keccak(domain_data)
+
+    # SafeTx struct hash
+    SAFE_TX_TYPEHASH = keccak(
+        b"SafeTx(address to,uint256 value,bytes data,uint8 operation,"
+        b"uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,"
+        b"address gasToken,address refundReceiver,uint256 nonce)"
+    )
+
+    to_bytes    = bytes.fromhex(to[2:].lower().zfill(64))
+    value_bytes = value_wei.to_bytes(32, "big")
+    data_hash   = keccak(data)
+    zeros       = bytes(32)
+
+    safe_tx_data = (
+        SAFE_TX_TYPEHASH
+        + to_bytes          # to
+        + value_bytes       # value
+        + data_hash         # keccak256(data)
+        + zeros             # operation (uint8, padded)
+        + zeros             # safeTxGas
+        + zeros             # baseGas
+        + zeros             # gasPrice
+        + zeros             # gasToken (zero address)
+        + zeros             # refundReceiver (zero address)
+        + nonce.to_bytes(32, "big")  # nonce
+    )
+    safe_tx_hash_inner = keccak(safe_tx_data)
+
+    final_hash = keccak(b"\x19\x01" + domain_separator + safe_tx_hash_inner)
+    return "0x" + final_hash.hex()
+
+
+# ---------------------------------------------------------------------------
+# Contract signature encoding
+# ---------------------------------------------------------------------------
+
+def build_contract_signature(signer_address: str) -> str:
+    """
+    Build a Safe 'contract signature' (v=1) for an address that approved on-chain.
+
+    Format: r=address_padded_32bytes | s=zeros_32bytes | v=0x01
+    Safe will verify approvedHashes[signer][txHash] == 1 on-chain.
+    """
+    r = signer_address[2:].lower().zfill(64)  # address as bytes32
+    s = "0" * 64                               # 32 zero bytes
+    v = "01"                                   # contract signature type
+    return "0x" + r + s + v
+
+
+# ---------------------------------------------------------------------------
+# Safe Transaction Service helpers
+# ---------------------------------------------------------------------------
+
+def get_safe_nonce(tx_service: str, safe_address: str) -> int:
+    """Fetch current Safe nonce from the Transaction Service."""
+    url = f"{tx_service}/api/v1/safes/{safe_address}/"
+    resp = requests.get(url, timeout=15)
+    resp.raise_for_status()
+    data = resp.json()
+    return data["nonce"]
+
+
+def get_signer_address(bankr_key: str) -> str:
+    """Resolve the Ethereum address for a Bankr key name."""
+    result = subprocess.run(
+        ["bankr", "key", "address", bankr_key],
+        capture_output=True, text=True, check=True
+    )
+    address = result.stdout.strip()
+    if not address.startswith("0x") or len(address) != 42:
+        raise ValueError(f"Unexpected address format from bankr: '{address}'")
+    return to_checksum_address(address)
+
+
+def approve_hash_on_chain(safe_address: str, safe_tx_hash: str,
+                           bankr_key: str, rpc_url: str) -> str:
+    """Call approveHash(bytes32) on the Safe contract via Bankr."""
+    print(f"[*] Calling approveHash on-chain for hash: {safe_tx_hash}")
+    result = subprocess.run(
+        [
+            "bankr", "call",
+            "--to",   safe_address,
+            "--key",  bankr_key,
+            "--rpc",  rpc_url,
+            "--abi",  "approveHash(bytes32)",
+            "--args", json.dumps([safe_tx_hash]),
+        ],
+        capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        print(f"ERROR: bankr approveHash failed:\n{result.stderr}", file=sys.stderr)
+        sys.exit(1)
+    tx_hash = result.stdout.strip()
+    print(f"[✓] approveHash tx: {tx_hash}")
+    return tx_hash
+
+
+def post_proposal(tx_service: str, safe_address: str, to: str, value_wei: int,
+                   data_hex: str, nonce: int, safe_tx_hash: str,
+                   signer_address: str, signature: str) -> dict:
+    """POST the transaction proposal to the Safe Transaction Service."""
+    url = f"{tx_service}/api/v1/safes/{safe_address}/multisig-transactions/"
+    payload = {
+        "to":                       to_checksum_address(to),
+        "value":                    str(value_wei),
+        "data":                     data_hex if data_hex else None,
+        "operation":                0,
+        "safeTxGas":                0,
+        "baseGas":                  0,
+        "gasPrice":                 "0",
+        "gasToken":                 "0x0000000000000000000000000000000000000000",
+        "refundReceiver":           "0x0000000000000000000000000000000000000000",
+        "nonce":                    nonce,
+        "contractTransactionHash":  safe_tx_hash,
+        "sender":                   to_checksum_address(signer_address),
+        "signature":                signature,
+    }
+    print(f"[*] POSTing proposal to {url}")
+    resp = requests.post(url, json=payload, timeout=15)
+    if resp.status_code not in (200, 201):
+        print(f"ERROR: Safe TX service returned {resp.status_code}:", file=sys.stderr)
+        print(resp.text, file=sys.stderr)
+        sys.exit(1)
+    return resp.json() if resp.text else {}
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Propose a Gnosis Safe transaction via approveHash + Safe TX Service"
+    )
+    parser.add_argument("--safe",  required=True, help="Safe contract address (0x...)")
+    parser.add_argument("--to",    required=True, help="Destination address (0x...)")
+    parser.add_argument("--value", required=True, type=float, help="ETH value to send (e.g. 0.01)")
+    parser.add_argument("--chain", required=True, help="Chain ID or name: 8453, 1, 137, base, ethereum, polygon")
+    parser.add_argument("--rpc",   required=True, help="RPC URL for on-chain calls (e.g. https://mainnet.base.org)")
+    parser.add_argument("--key",   required=True, help="Bankr key name for signing")
+    parser.add_argument("--data",  default="",    help="Optional calldata hex (e.g. 0xabcdef)")
+    parser.add_argument("--nonce", type=int, default=None,
+                        help="Override Safe nonce (auto-fetched if not provided)")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    # Resolve chain
+    chain_id, tx_service = resolve_chain_id(args.chain)
+    print(f"[*] Chain: {CHAIN_CONFIG[chain_id]['name']} (id={chain_id})")
+    print(f"[*] TX Service: {tx_service}")
+
+    # Normalize addresses
+    safe_address = to_checksum_address(args.safe)
+    to_address   = to_checksum_address(args.to)
+
+    # Convert ETH to wei
+    value_wei = int(args.value * 10**18)
+    print(f"[*] Safe: {safe_address}")
+    print(f"[*] To:   {to_address}")
+    print(f"[*] Value: {args.value} ETH ({value_wei} wei)")
+
+    # Calldata
+    data_hex = args.data.strip()
+    if data_hex and not data_hex.startswith("0x"):
+        data_hex = "0x" + data_hex
+    data_bytes = bytes.fromhex(data_hex[2:]) if data_hex else b""
+    print(f"[*] Data: {data_hex or '(none)'}")
+
+    # Fetch nonce
+    if args.nonce is not None:
+        nonce = args.nonce
+        print(f"[*] Nonce: {nonce} (override)")
+    else:
+        nonce = get_safe_nonce(tx_service, safe_address)
+        print(f"[*] Nonce: {nonce} (from TX service)")
+
+    # Compute EIP-712 hash
+    safe_tx_hash = compute_safe_tx_hash(
+        safe_address=safe_address,
+        to=to_address,
+        value_wei=value_wei,
+        nonce=nonce,
+        chain_id=chain_id,
+        data=data_bytes,
+    )
+    print(f"[*] safeTxHash: {safe_tx_hash}")
+
+    # Get signer address from Bankr key
+    signer_address = get_signer_address(args.key)
+    print(f"[*] Signer: {signer_address}")
+
+    # Approve on-chain
+    approve_hash_on_chain(safe_address, safe_tx_hash, args.key, args.rpc)
+
+    # Build contract signature
+    signature = build_contract_signature(signer_address)
+
+    # Post proposal to Safe TX Service
+    result = post_proposal(
+        tx_service=tx_service,
+        safe_address=safe_address,
+        to=to_address,
+        value_wei=value_wei,
+        data_hex=data_hex or None,
+        nonce=nonce,
+        safe_tx_hash=safe_tx_hash,
+        signer_address=signer_address,
+        signature=signature,
+    )
+
+    print()
+    print("=" * 60)
+    print("[✓] Transaction proposed successfully!")
+    print(f"    safeTxHash: {safe_tx_hash}")
+    print(f"    Nonce:      {nonce}")
+    print(f"    To:         {to_address}")
+    print(f"    Value:      {args.value} ETH")
+    print()
+    print("Share the safeTxHash with other owners so they can approve.")
+    print(f"Track at: https://app.safe.global/transactions/queue?safe={safe_address}")
+    print("=" * 60)
+
+
+if __name__ == "__main__":
+    main()

--- a/gnosis-safe/scripts/propose_tx.py
+++ b/gnosis-safe/scripts/propose_tx.py
@@ -5,7 +5,7 @@ propose_tx.py — Propose a Gnosis Safe transaction
 Steps:
   1. Fetch current nonce from Safe Transaction Service
   2. Compute EIP-712 safeTxHash
-  3. Call approveHash(bytes32) on-chain via Bankr
+  3. Call approveHash(bytes32) on-chain via `bankr agent`
   4. POST proposal + contract signature to Safe Transaction Service
 
 Usage:
@@ -14,14 +14,13 @@ Usage:
     --to      0xRecipientAddress \
     --value   0.01 \
     --chain   8453 \
-    --rpc     https://mainnet.base.org \
-    --key     your_bankr_key_name \
-    [--data   0xabcdef]    # optional calldata
+    [--signer 0xYourSignerAddress]  # auto-detected via 'bankr whoami' if omitted
+    [--data   0xabcdef]             # optional calldata
 
 Requirements:
   pip install eth-utils requests
-  bankr must be installed and the safe address must be in its trusted list:
-    bankr address add <safe_address>
+  bankr must be installed and authenticated (`bankr whoami` must return your address).
+  The Safe contract address must be in your Bankr trusted recipients list.
 """
 
 import argparse
@@ -154,39 +153,91 @@ def get_safe_nonce(tx_service: str, safe_address: str) -> int:
     return data["nonce"]
 
 
-def get_signer_address(bankr_key: str) -> str:
-    """Resolve the Ethereum address for a Bankr key name."""
-    result = subprocess.run(
-        ["bankr", "key", "address", bankr_key],
-        capture_output=True, text=True, check=True
+def validate_address(addr: str, label: str) -> str:
+    """Validate that addr is a 42-char hex Ethereum address and return checksummed form."""
+    if not addr or not addr.startswith("0x") or len(addr) != 42:
+        print(f"ERROR: Invalid {label} address: '{addr}' (must be 0x + 40 hex chars)", file=sys.stderr)
+        sys.exit(1)
+    try:
+        return to_checksum_address(addr)
+    except Exception as exc:
+        print(f"ERROR: Invalid {label} address: '{addr}': {exc}", file=sys.stderr)
+        sys.exit(1)
+
+
+def get_signer_address(signer_override: str = None) -> str:
+    """Resolve the signer's Ethereum address.
+
+    Priority:
+      1. signer_override (from --signer CLI arg)
+      2. `bankr whoami --json` → parse 'address' field
+      3. `bankr whoami` → scan output for a 0x... address line
+    """
+    if signer_override:
+        return validate_address(signer_override, "--signer")
+
+    # Try bankr whoami --json
+    try:
+        result = subprocess.run(
+            ["bankr", "whoami", "--json"],
+            capture_output=True, text=True, check=True, timeout=10
+        )
+        data = json.loads(result.stdout.strip())
+        # Handle various possible JSON shapes
+        address = (
+            data.get("address")
+            or (data.get("wallet") or {}).get("address")
+        )
+        if address and address.startswith("0x") and len(address) == 42:
+            return to_checksum_address(address)
+    except (subprocess.CalledProcessError, json.JSONDecodeError, KeyError, subprocess.TimeoutExpired):
+        pass
+
+    # Fall back to plain bankr whoami — scan for an address line
+    try:
+        result = subprocess.run(
+            ["bankr", "whoami"],
+            capture_output=True, text=True, check=True, timeout=10
+        )
+        for line in result.stdout.splitlines():
+            stripped = line.strip().rstrip(",;")
+            if stripped.startswith("0x") and len(stripped) == 42:
+                return to_checksum_address(stripped)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        pass
+
+    print("ERROR: Could not determine signer address from 'bankr whoami'.", file=sys.stderr)
+    print("  Pass --signer 0xYourAddress to specify it explicitly.", file=sys.stderr)
+    sys.exit(1)
+
+
+def approve_hash_on_chain(safe_address: str, safe_tx_hash: str) -> str:
+    """Call approveHash(bytes32) on the Safe contract via `bankr agent`.
+
+    Encodes the calldata as: selector 0xd4d9bdcd + hash padded to 32 bytes.
+    Uses natural-language Bankr agent to submit the raw transaction.
+    """
+    hash_no_prefix = safe_tx_hash[2:].lower().zfill(64)
+    calldata = f"0xd4d9bdcd{hash_no_prefix}"
+    prompt = (
+        f"Submit raw transaction on Base (chain 8453):\n"
+        f"- to: {safe_address}\n"
+        f"- data: {calldata}\n"
+        f"- value: 0\n"
+        f"Wait for confirmation and return the tx hash."
     )
-    address = result.stdout.strip()
-    if not address.startswith("0x") or len(address) != 42:
-        raise ValueError(f"Unexpected address format from bankr: '{address}'")
-    return to_checksum_address(address)
-
-
-def approve_hash_on_chain(safe_address: str, safe_tx_hash: str,
-                           bankr_key: str, rpc_url: str) -> str:
-    """Call approveHash(bytes32) on the Safe contract via Bankr."""
     print(f"[*] Calling approveHash on-chain for hash: {safe_tx_hash}")
+    print(f"[*] Calldata: {calldata}")
     result = subprocess.run(
-        [
-            "bankr", "call",
-            "--to",   safe_address,
-            "--key",  bankr_key,
-            "--rpc",  rpc_url,
-            "--abi",  "approveHash(bytes32)",
-            "--args", json.dumps([safe_tx_hash]),
-        ],
+        ["bankr", "agent", prompt],
         capture_output=True, text=True
     )
     if result.returncode != 0:
-        print(f"ERROR: bankr approveHash failed:\n{result.stderr}", file=sys.stderr)
+        print(f"ERROR: bankr agent approveHash failed:\n{result.stderr}", file=sys.stderr)
         sys.exit(1)
-    tx_hash = result.stdout.strip()
-    print(f"[✓] approveHash tx: {tx_hash}")
-    return tx_hash
+    output = result.stdout.strip()
+    print(f"[✓] approveHash submitted. Bankr response: {output[:300]}")
+    return output
 
 
 def post_proposal(tx_service: str, safe_address: str, to: str, value_wei: int,
@@ -197,7 +248,7 @@ def post_proposal(tx_service: str, safe_address: str, to: str, value_wei: int,
     payload = {
         "to":                       to_checksum_address(to),
         "value":                    str(value_wei),
-        "data":                     data_hex if data_hex else None,
+        "data":                     data_hex or "0x",
         "operation":                0,
         "safeTxGas":                0,
         "baseGas":                  0,
@@ -226,14 +277,14 @@ def parse_args():
     parser = argparse.ArgumentParser(
         description="Propose a Gnosis Safe transaction via approveHash + Safe TX Service"
     )
-    parser.add_argument("--safe",  required=True, help="Safe contract address (0x...)")
-    parser.add_argument("--to",    required=True, help="Destination address (0x...)")
-    parser.add_argument("--value", required=True, type=float, help="ETH value to send (e.g. 0.01)")
-    parser.add_argument("--chain", required=True, help="Chain ID or name: 8453, 1, 137, base, ethereum, polygon")
-    parser.add_argument("--rpc",   required=True, help="RPC URL for on-chain calls (e.g. https://mainnet.base.org)")
-    parser.add_argument("--key",   required=True, help="Bankr key name for signing")
-    parser.add_argument("--data",  default="",    help="Optional calldata hex (e.g. 0xabcdef)")
-    parser.add_argument("--nonce", type=int, default=None,
+    parser.add_argument("--safe",   required=True, help="Safe contract address (0x...)")
+    parser.add_argument("--to",     required=True, help="Destination address (0x...)")
+    parser.add_argument("--value",  required=True, type=float, help="ETH value to send (e.g. 0.01)")
+    parser.add_argument("--chain",  required=True, help="Chain ID or name: 8453, 1, 137, base, ethereum, polygon")
+    parser.add_argument("--signer", default=None,
+                        help="Signer address (0x...); auto-detected via 'bankr whoami' if omitted")
+    parser.add_argument("--data",   default="",    help="Optional calldata hex (e.g. 0xabcdef)")
+    parser.add_argument("--nonce",  type=int, default=None,
                         help="Override Safe nonce (auto-fetched if not provided)")
     return parser.parse_args()
 
@@ -246,9 +297,9 @@ def main():
     print(f"[*] Chain: {CHAIN_CONFIG[chain_id]['name']} (id={chain_id})")
     print(f"[*] TX Service: {tx_service}")
 
-    # Normalize addresses
-    safe_address = to_checksum_address(args.safe)
-    to_address   = to_checksum_address(args.to)
+    # Validate and normalize addresses
+    safe_address = validate_address(args.safe, "--safe")
+    to_address   = validate_address(args.to, "--to")
 
     # Convert ETH to wei
     value_wei = int(args.value * 10**18)
@@ -282,12 +333,12 @@ def main():
     )
     print(f"[*] safeTxHash: {safe_tx_hash}")
 
-    # Get signer address from Bankr key
-    signer_address = get_signer_address(args.key)
+    # Get signer address (from --signer arg or bankr whoami)
+    signer_address = get_signer_address(args.signer)
     print(f"[*] Signer: {signer_address}")
 
-    # Approve on-chain
-    approve_hash_on_chain(safe_address, safe_tx_hash, args.key, args.rpc)
+    # Approve on-chain via bankr agent
+    approve_hash_on_chain(safe_address, safe_tx_hash)
 
     # Build contract signature
     signature = build_contract_signature(signer_address)
@@ -298,7 +349,7 @@ def main():
         safe_address=safe_address,
         to=to_address,
         value_wei=value_wei,
-        data_hex=data_hex or None,
+        data_hex=data_hex,
         nonce=nonce,
         safe_tx_hash=safe_tx_hash,
         signer_address=signer_address,

--- a/gnosis-safe/scripts/safe_info.sh
+++ b/gnosis-safe/scripts/safe_info.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# safe_info.sh — Query Gnosis Safe info via Safe Transaction Service
+#
+# Usage:
+#   ./safe_info.sh <SAFE_ADDRESS> <CHAIN>
+#
+# Arguments:
+#   SAFE_ADDRESS   - Safe contract address (0x...)
+#   CHAIN          - Chain name or ID: base (8453), ethereum (1), polygon (137)
+#
+# Examples:
+#   ./safe_info.sh 0xYourSafeAddress base
+#   ./safe_info.sh 0xYourSafeAddress 8453
+#
+# Requirements: curl, python3 (optional, for pretty output)
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Args
+# ---------------------------------------------------------------------------
+SAFE_ADDRESS="${1:-}"
+CHAIN="${2:-base}"
+
+if [[ -z "$SAFE_ADDRESS" ]]; then
+  echo "Usage: $0 <SAFE_ADDRESS> <CHAIN>"
+  echo "Example: $0 0xYourSafeAddress base"
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve TX service URL
+# ---------------------------------------------------------------------------
+case "${CHAIN,,}" in
+  base|8453)
+    TX_SERVICE="https://safe-transaction-base.safe.global"
+    ;;
+  ethereum|mainnet|1)
+    TX_SERVICE="https://safe-transaction-mainnet.safe.global"
+    ;;
+  polygon|137)
+    TX_SERVICE="https://safe-transaction-polygon.safe.global"
+    ;;
+  *)
+    echo "ERROR: Unknown chain '${CHAIN}'. Use: base, ethereum, polygon (or 8453, 1, 137)" >&2
+    exit 1
+    ;;
+esac
+
+SAFE_URL="${TX_SERVICE}/api/v1/safes/${SAFE_ADDRESS}/"
+
+# ---------------------------------------------------------------------------
+# Header
+# ---------------------------------------------------------------------------
+echo "🔐 Gnosis Safe Info"
+echo "  Address:    $SAFE_ADDRESS"
+echo "  Chain:      $CHAIN"
+echo "  TX Service: $TX_SERVICE"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Fetch Safe info
+# ---------------------------------------------------------------------------
+RESPONSE=$(curl -s -f --max-time 15 \
+  -H "Accept: application/json" \
+  "$SAFE_URL") || {
+  echo "ERROR: Failed to fetch Safe info from: ${SAFE_URL}" >&2
+  echo "Verify the Safe address and chain are correct." >&2
+  exit 1
+}
+
+# ---------------------------------------------------------------------------
+# Display — pipe JSON into Python for pretty formatting
+# ---------------------------------------------------------------------------
+if command -v python3 &>/dev/null; then
+  echo "$RESPONSE" | python3 -c "
+import json, sys
+
+try:
+    data = json.load(sys.stdin)
+except json.JSONDecodeError as e:
+    print(f'ERROR: Could not parse JSON: {e}')
+    raw = sys.stdin.read()
+    print('Raw response:', raw[:500])
+    sys.exit(1)
+
+print('=' * 60)
+print(f'  Nonce:      {data.get(\"nonce\", \"N/A\")}')
+print(f'  Threshold:  {data.get(\"threshold\", \"N/A\")}')
+print(f'  Version:    {data.get(\"version\", \"N/A\")}')
+print()
+
+owners = data.get('owners', [])
+print(f'  Owners ({len(owners)}):')
+for o in owners:
+    print(f'    - {o}')
+print()
+
+modules = data.get('modules', [])
+if modules:
+    print(f'  Modules ({len(modules)}):')
+    for m in modules:
+        print(f'    - {m}')
+    print()
+
+guard = data.get('guard', '')
+if guard and guard != '0x0000000000000000000000000000000000000000':
+    print(f'  Guard:         {guard}')
+    print()
+
+print(f'  Master Copy:   {data.get(\"masterCopy\", \"N/A\")}')
+print(f'  Fallback Hdlr: {data.get(\"fallbackHandler\", \"N/A\")}')
+print('=' * 60)
+"
+else
+  # Fallback: raw JSON
+  echo "$RESPONSE"
+fi
+
+echo ""
+echo "💡 Use the 'nonce' value when proposing transactions with propose_tx.py"
+echo "💡 Threshold = number of confirmations required to execute"


### PR DESCRIPTION
## Summary

Adds a `gnosis-safe` skill for interacting with Gnosis Safe multisig wallets via the Safe Transaction Service API and Bankr.

## Operations

- **Check Safe info** — nonce, threshold, owners, ETH balance via Safe TX Service API
- **Propose transactions** — EIP-712 safeTxHash computation + Bankr `approveHash()` + off-chain proposal posting
- **List pending transactions** — show pending proposals with confirmation counts and execute-readiness
- **Check on-chain approvals** — query `approvedHashes(address,bytes32)`
- **Execute transactions** — when threshold is met, via Bankr

## Implementation approach

Since Bankr holds the private key server-side, we use on-chain `approveHash(bytes32)` instead of local ECDSA signing. The Safe Transaction Service then accepts a "contract signature" (v=0x01 type) when the proposal is posted.

### EIP-712 hash computation (Python, tested on Base):
```python
from eth_utils import keccak
# domain separator + SafeTx struct hash → final safeTxHash
```

### Contract signature encoding:
```
r = signer_address padded to 32 bytes
s = 0x00...00 (32 bytes)
v = 0x01
```

## Files

- `SKILL.md` — full documentation with workflow and examples
- `scripts/propose_tx.py` — Python CLI (argparse) for proposing txs
- `scripts/safe_info.sh` — bash script for Safe status
- `scripts/list_pending.sh` — bash script for pending tx listing
- `references/safe-api.md` — Safe Transaction Service API reference

## Chains supported

| Chain | TX Service URL |
|-------|---------------|
| Base (8453) | `safe-transaction-base.safe.global` |
| Ethereum (1) | `safe-transaction-mainnet.safe.global` |
| Polygon (137) | `safe-transaction-polygon.safe.global` |

## Note

Requires the Safe contract address to be added to Bankr's trusted addresses list before `approveHash` calls will succeed.