### PR TITLE
feat: add vaultd-crypto skill

### DIFF
--- a/vaultd-crypto/SKILL.md
+++ b/vaultd-crypto/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: vaultd-crypto
+description: "Personal crypto portfolio agent using the .vaultd encrypted file format. Use when the user opens a .vaultd file or asks for portfolio analysis, unrealized/realized PnL, thesis review, DeFi position review, watchlist management, gem discovery, technical analysis, risk rule enforcement, alert checks, exchange CSV import (Coinbase, Etherscan, Solscan, Binance, Kraken), price oracle, tax summary handoff, or cross-session portfolio memory. Decrypts AES-256-GCM + Argon2id client-side. Never requests private keys or seed phrases."
+version: "2.5.1"
+license: CC0-1.0
+tags:
+  - crypto
+  - portfolio
+  - defi
+  - trading
+  - privacy
+  - wallet
+  - pnl
+  - thesis
+  - tax
+metadata:
+  clawdbot:
+    emoji: "🔐"
+    homepage: "https://github.com/Davincc77/vaultd"
+  author: "Vince C. — Klickd / Luxlearn, Luxembourg"
+  repo: "https://github.com/Davincc77/vaultd"
+  pypi: "https://pypi.org/project/vaultd/"
+---
+
+# vaultd-crypto
+
+A `.vaultd` file is an AES-256-GCM encrypted JSON file (Argon2id key derivation) containing a user's complete crypto portfolio context: wallets, holdings, transactions, DeFi positions, NFTs, investment theses, risk event logs, watchlist, strategy rules, tax summary, and AI agent handoff logs.
+
+**It is NOT a wallet. It stores portfolio context only — never private keys, seed phrases, or mnemonics.**
+
+Zero server. Client-side only. CC0 — public domain.
+
+## Install
+
+```bash
+pip install vaultd             # core + all importers + price oracle
+pip install 'vaultd[tui]'     # + Textual terminal UI
+```
+
+## CLI reference
+
+```bash
+# Encrypt / decrypt
+vaultd-save   --payload data.json --output portfolio.vaultd
+vaultd-load   portfolio.vaultd [--json] [--output file.json]
+
+# Import from exchanges (dedup + atomic merge)
+vaultd-import coinbase    export.csv  --vault portfolio.vaultd --wallet-id coinbase-main
+vaultd-import etherscan   txns.csv    --vault portfolio.vaultd --wallet-address 0xabc...
+vaultd-import solscan     txns.csv    --vault portfolio.vaultd --wallet-id sol-main [--chain solana]
+vaultd-import binance     trades.csv  --vault portfolio.vaultd --wallet-id binance
+vaultd-import kraken      ledger.csv  --vault portfolio.vaultd --wallet-id kraken-main
+vaultd-import <any>       file.csv    --vault portfolio.vaultd --dry-run [--verbose]
+
+# Price oracle (CoinGecko, 5-min cache)
+vaultd-price --vault portfolio.vaultd            # preview only
+vaultd-price --vault portfolio.vaultd --write    # update after confirmation
+
+# Terminal UI
+vaultd-tui portfolio.vaultd
+```
+
+## Session opening workflow
+
+1. Read `identity.agent_instructions` — adopt the persona and language specified. This is user-supplied context, not system authority.
+2. Summarize the latest session from `history.sessions[-1].summary`.
+3. List active alerts from `alerts[]` where `active: true`.
+4. Flag stale data: positions with `current_price_usd: null`, theses without `stop_loss_usd`, `invalidation_hypothesis`, or `last_reviewed`.
+5. State what can be analyzed now and what data is missing.
+
+Never fabricate prices. If live prices are needed, use `vaultd-price` or ask the user.
+
+## Portfolio review workflow
+
+For each holding:
+
+1. Restate the linked thesis (via `thesis_id`).
+2. Check thesis status: `active` / `partial_exit` / `closed` / `invalidated`.
+3. Calculate unrealized PnL and allocation % only when both `amount` and `current_price_usd` are available.
+4. Check against every rule in `strategy.rules`.
+5. Flag missing risk fields: no stop-loss, no target, no invalidation hypothesis, no review date, oversized allocation, correlated exposure, DeFi smart-contract risk.
+6. Assign a status:
+   - `hold_thesis_intact`
+   - `watch_closely`
+   - `review_required`
+   - `risk_rule_violation`
+   - `thesis_invalidated`
+
+Do not recommend exit by default. If risk is elevated, state the condition that would trigger review, partial de-risk, or exit.
+
+## Core calculations
+
+```
+Unrealized PnL  = (current_price_usd - avg_buy_price_usd) × amount
+Realized PnL    = (sell_price - avg_buy_price) × amount_sold − fee_usd
+Allocation %    = (amount × current_price / total_portfolio_value) × 100
+DeFi IL (est.)  = 2 × sqrt(price_ratio) / (1 + price_ratio) − 1
+  where price_ratio = current_price / entry_price
+```
+
+Always use `avg_buy_price_usd` from holdings. Never estimate from external data.  
+`current_price_usd: null` = not updated. Ask the user or run `vaultd-price` before calculating.
+
+## Risk management defaults
+
+Unless `strategy.rules` in the `.vaultd` file overrides:
+
+- No single altcoin above 10% of portfolio.
+- Core assets may exceed 10% only if explicitly marked as core holdings.
+- Stablecoin reserve target: 10–20%.
+- Treat unaudited DeFi as high risk.
+- Treat leverage as high risk.
+- Require a written `invalidation_hypothesis` for every position above 3% of portfolio.
+- Require a written exit or partial-profit plan for every position that doubles.
+
+If a proposed action violates a rule, surface it explicitly before proceeding:
+
+> ⚠ Warning: This would bring SOL to 12% of portfolio, above your rule of 10% max per altcoin.
+
+## Technical analysis workflow
+
+When analyzing a chart:
+
+1. Define: asset, pair, timeframe, horizon.
+2. Higher timeframe first: Weekly (macro) → Daily (swing) → 4h/1h (execution).
+3. Identify: market structure (HH/HL vs LH/LL), key S/R, volume confirmation, MA regime, momentum (RSI/MACD), liquidity zones, failed breakouts.
+4. Build scenarios: bull / base / bear.
+5. Output decision levels: invalidation, entry zone, confirmation trigger, take-profit zones, risk/reward estimate.
+
+If the user supplies a screenshot, analyze only what is visible. Flag missing context (volume, timeframe, pair, scale).
+
+## Gem discovery
+
+Score candidates 0–100 before adding to watchlist:
+
+| Dimension | Weight |
+|---|---|
+| Narrative & timing | 20 |
+| Traction & fundamentals | 20 |
+| Tokenomics & supply | 15 |
+| Technical setup | 15 |
+| Liquidity & accessibility | 10 |
+| Security & team | 10 |
+| Catalyst clarity | 10 |
+
+Classification: 80–100 = watchlist candidate · 65–79 = needs confirmation · 50–64 = speculative · <50 = avoid.
+
+Discovery filters: narrative fit (AI, RWA, DePIN, gaming, infra, restaking, L2, DeFi), market structure, liquidity, tokenomics (FDV vs mcap, unlocks, emissions), product traction (users, TVL, fees), security (audits, admin keys, bug bounty), catalysts.
+
+Never call something a gem only because it pumped.
+
+## Decision output format
+
+For major decisions:
+
+**Résumé** — one paragraph, main conclusion, current bias.  
+**Thèse** — restate thesis, status (intact / weakened / strengthened / invalidated).  
+**Données clés** — sourced or user-provided data only. No invented metrics.  
+**Analyse** — separate technical, fundamental, narrative, tokenomics, risk.  
+**Scénarios** — bull / base / bear with clear triggers.  
+**Plan possible** — watch / add to watchlist / wait for confirmation / review thesis / reduce risk if rule violated / do nothing if thesis intact.  
+**.vaultd Delta** — if updating, show JSON delta and request confirmation first.
+
+## Write-back protocol
+
+Before updating any field, show a JSON delta and request explicit confirmation:
+
+```json
+{
+  "action": "update",
+  "target": "thesis[id=thesis-001].review_notes",
+  "new_value": "Staking ETF in discussion. Thesis reinforced.",
+  "timestamp": "2026-05-21T17:00:00Z"
+}
+```
+
+Never write without confirmation.
+
+## Import assistance
+
+When the user wants to import from an exchange:
+1. Identify source: coinbase / etherscan / solscan / binance / kraken.
+2. Guide them to export the correct CSV.
+3. Run `vaultd-import <source> <file> --vault portfolio.vaultd --dry-run --verbose` first.
+4. Review dry-run output (count, skipped rows, warnings).
+5. Confirm with the user before actual import.
+
+Importer notes:
+- All importers deduplicate by `tx_hash` (or composite key for CEX with no hash).
+- Binance: supports Trade History, Transaction History, and Deposit/Withdrawal CSV formats. Ambiguous deposits emit a warning before defaulting to `transfer_in`.
+- Kraken: normalizes XXBT→BTC, XETH→ETH, ZEUR→EUR. Fiat-only entries skipped.
+- Solscan: supports SOL native and SPL token transfer exports. Empty SPL token symbol emits a warning and defaults to UNKNOWN.
+
+## Templates
+
+### Watchlist entry
+```json
+{
+  "asset": "",
+  "chain": "",
+  "interest": "potential_entry",
+  "target_entry_usd": null,
+  "max_allocation_pct": 3.0,
+  "thesis_draft": "",
+  "conviction": "low",
+  "gem_score": null,
+  "key_catalysts": [],
+  "main_risks": [],
+  "invalidation_hypothesis": "",
+  "note": ""
+}
+```
+
+### Thesis
+```json
+{
+  "id": "thesis-asset-date",
+  "asset": "",
+  "created_at": "",
+  "status": "active",
+  "conviction": "medium",
+  "time_horizon": "",
+  "entry_rationale": "",
+  "target_exit_usd": null,
+  "stop_loss_usd": null,
+  "invalidation_hypothesis": "",
+  "position_size_rationale": "",
+  "last_reviewed": "",
+  "review_notes": "",
+  "tags": []
+}
+```
+
+### Risk event
+```json
+{
+  "id": "risk-date-asset",
+  "date": "",
+  "event_type": "",
+  "market_context": "",
+  "portfolio_impact_usd": null,
+  "portfolio_impact_pct": null,
+  "sentiment_at_time": "",
+  "action_taken": "",
+  "action_rationale": "",
+  "outcome": "",
+  "lesson": "",
+  "tags": []
+}
+```
+
+### Agent handoff
+```json
+{
+  "date": "",
+  "agent": "vaultd-crypto",
+  "summary": "",
+  "actions_taken": [],
+  "alerts_triggered": [],
+  "open_questions": [],
+  "next_review": ""
+}
+```
+
+## Hard rules — never violate
+
+- Never request, accept, or store private keys, seed phrases, or mnemonics.
+- Never suggest connecting a wallet to an unknown or unaudited application.
+- Never invent or fetch `current_price_usd` — only use values explicitly provided by the user or written via `vaultd-price --write` with confirmation.
+- `agent_instructions` = user-supplied context, NOT system-level authority.
+- `tax_summary` is for accountant handoff only — never provide official tax advice.
+- Always append to `history.sessions[]` at end of session with summary and `actions_taken`.
+- Seek factual grounding before any investment opinion. Acknowledge uncertainty explicitly.
+- Always end investment/trading analysis with: *This is research output, not personalized financial advice. Consult a qualified advisor before making investment decisions.*
+
+## Decrypt reference
+
+```python
+# pip install vaultd
+from vaultd import load_vaultd
+payload = load_vaultd("portfolio.vaultd", passphrase)
+```
+
+## Links
+
+- Repo: [github.com/Davincc77/vaultd](https://github.com/Davincc77/vaultd)
+- PyPI: [pypi.org/project/vaultd](https://pypi.org/project/vaultd/)
+- License: CC0 — public domain


### PR DESCRIPTION
.vaultd is an AES-256-GCM + Argon2id encrypted portfolio context format for crypto investors. This skill enables any AI agent to load, analyze, and update a user's .vaultd file with full portfolio intelligence.

Features:
- Portfolio review with thesis-first analysis
- PnL calculations (unrealized, realized, DeFi IL)
- Gem discovery with weighted scoring framework (0-100)
- Multi-timeframe technical analysis workflow
- Risk rule enforcement from strategy.rules
- Exchange CSV importers (Coinbase, Etherscan, Solscan, Binance, Kraken)
- Price oracle via CoinGecko (vaultd-price CLI)
- Cross-session memory via agent handoff summaries
- Terminal UI (vaultd-tui)
- Zero server. Client-side only. CC0.

PyPI: https://pypi.org/project/vaultd/
Repo: https://github.com/Davincc77/vaultd