### PR TITLE
fix(gitlawb): replace curl|sh installer with npm install -g @gitlawb/gl

### DIFF
--- a/gitlawb/scripts/setup.sh
+++ b/gitlawb/scripts/setup.sh
@@ -9,7 +9,7 @@ echo "=== gitlawb setup ==="
 # Install gl CLI if not present
 if ! command -v gl &>/dev/null; then
   echo "Installing gl CLI..."
-  curl -sSf https://gitlawb.com/install.sh | sh
+  npm install -g @gitlawb/gl
 else
   echo "gl CLI already installed: $(which gl)"
 fi


### PR DESCRIPTION
## Security fix — supply-chain attack vector in setup.sh

**Severity:** HIGH

### What's wrong

`gitlawb/scripts/setup.sh` installs the `gl` CLI by fetching and executing a remote shell script with no integrity check:

```bash
curl -sSf https://gitlawb.com/install.sh | sh
```

Anyone who can compromise `gitlawb.com` or intercept the connection (MITM, CDN compromise) achieves **arbitrary code execution** on every user or AI agent running the skill. Because `setup.sh` is called automatically as part of skill onboarding, the blast radius extends to all downstream consumers.

### Fix

Replace the `curl | sh` pattern with the npm install path that is **already documented in `SKILL.md`**:

```bash
npm install -g @gitlawb/gl
```

npm verifies the package against the registry's cryptographic signatures — no remote shell execution over an unverified channel.

### Diff

```diff
-  curl -sSf https://gitlawb.com/install.sh | sh
+  npm install -g @gitlawb/gl
```

---

Found by [AntFleet](https://antfleet.dev) automated security review. Bench PR: [AntFleet/bankrskills-bench#3](https://github.com/AntFleet/bankrskills-bench/pull/3)
