### PR TITLE
fix(signals): verify TX sender matches provider before publishing

### DIFF
--- a/signals/scripts/publish-signal.sh
+++ b/signals/scripts/publish-signal.sh
@@ -43,6 +43,31 @@ PROVIDER=$(echo "$RESULT" | jq -r .provider)
 MESSAGE=$(echo "$RESULT" | jq -r .message)
 SIGNATURE=$(echo "$RESULT" | jq -r .signature)
 
+# Verify TX on-chain: must exist, must have succeeded, and must have been sent
+# by this provider — prevents publishing someone else's TX as your own trade proof.
+RPC_URL="${BASE_RPC_URL:-https://mainnet.base.org}"
+RECEIPT=$(curl -sf -X POST "$RPC_URL" \
+  -H "Content-Type: application/json" \
+  -d "{\"jsonrpc\":\"2.0\",\"method\":\"eth_getTransactionReceipt\",\"params\":[\"$TX_HASH\"],\"id\":1}" 2>/dev/null || true)
+
+if [ -z "$RECEIPT" ] || echo "$RECEIPT" | jq -e '.result == null' >/dev/null 2>&1; then
+  echo "Error: TX $TX_HASH not found on Base — cannot publish unverified trade proof." >&2
+  exit 1
+fi
+
+TX_STATUS=$(echo "$RECEIPT" | jq -r '.result.status')
+TX_FROM=$(echo "$RECEIPT" | jq -r '.result.from' | tr '[:upper:]' '[:lower:]')
+
+if [ "$TX_STATUS" != "0x1" ]; then
+  echo "Error: TX $TX_HASH failed (status: $TX_STATUS) — cannot use a reverted TX as trade proof." >&2
+  exit 1
+fi
+
+if [ "$TX_FROM" != "$PROVIDER" ]; then
+  echo "Error: TX sender $TX_FROM does not match provider $PROVIDER — TX must originate from your own wallet." >&2
+  exit 1
+fi
+
 BODY=$(jq -n \
   --arg provider "$PROVIDER" \
   --arg action "$ACTION" \


### PR DESCRIPTION
## Fix: verify TX sender matches provider before publishing a signal

**Severity:** MEDIUM

### What's wrong

`signals/scripts/publish-signal.sh` accepts any TX hash as trade proof without verifying that the transaction was actually sent by the signal provider's wallet. A subscriber could pass any confirmed on-chain TX (even one from a completely unrelated address) and publish it as their own trade — fabricating a track record.

The SKILL.md guarantees *"All track records verified against blockchain data. No fake performance claims."* — but the code never enforces the one check that makes that guarantee meaningful: that the TX `from` field matches the provider address.

### Fix

Before posting the signal, fetch the on-chain receipt and check:

1. TX exists on Base
2. TX succeeded (`status == 0x1`)
3. TX `from` == provider wallet address (the missing check)

If any check fails, the script exits non-zero and the signal is **not** published.

```diff
+# Verify TX on-chain: must exist, must have succeeded, and must have been sent
+# by this provider — prevents publishing someone else's TX as your own trade proof.
+if [ "$TX_FROM" != "$PROVIDER" ]; then
+  echo "Error: TX sender $TX_FROM does not match provider $PROVIDER" >&2
+  exit 1
+fi
```

---

Found by [AntFleet](https://antfleet.dev) automated security review. Bench PR: [AntFleet/bankrskills-bench#5](https://github.com/AntFleet/bankrskills-bench/pull/5)
