### PR TITLE
docs(bankr): weekly skill update — May 23

### DIFF
--- a/bankr/SKILL.md
+++ b/bankr/SKILL.md
@@ -256,12 +256,12 @@ The legacy aliases `/public/resolve-recipient` and `/public/search-users` still 
 |----------|--------|-------------|
 | `/token-launches` | GET | List recent token launches (cached, public) |
 
-#### Deprecated endpoints
+#### Removed legacy endpoints
 
-The following `/agent/*` endpoints still work but are deprecated in favor of `/wallet/*`:
+The following `/agent/*` endpoints have been removed. Use the `/wallet/*` equivalents:
 
-| Deprecated | Use Instead |
-|-----------|-------------|
+| Removed | Use Instead |
+|---------|-------------|
 | `GET /agent/me` | `GET /wallet/me` |
 | `GET /agent/balances` | `GET /wallet/portfolio` |
 | `POST /agent/sign` | `POST /wallet/sign` |

--- a/bankr/references/llm-gateway.md
+++ b/bankr/references/llm-gateway.md
@@ -47,6 +47,7 @@ bankr config get llmKey
 | `claude-sonnet-4.5` | Anthropic | Previous generation Sonnet |
 | `claude-haiku-4.5` | Anthropic | Fast, cost-effective |
 | `gemini-3-pro` | Google | Long context (2M tokens) |
+| `gemini-3.5-flash` | Google | Latest Flash, 1M context |
 | `gemini-3-flash` | Google | High throughput |
 | `gemini-2.5-pro` | Google | Long context, multimodal |
 | `gemini-2.5-flash` | Google | Speed, high throughput |

--- a/bankr/references/sign-submit-api.md
+++ b/bankr/references/sign-submit-api.md
@@ -11,7 +11,7 @@ Unlike the async prompt endpoint, these endpoints are **synchronous** and return
 | `POST /wallet/sign` | Sign messages, typed data, or transactions | Signature |
 | `POST /wallet/submit` | Submit raw transactions to chain | Transaction hash |
 
-> **Deprecation notice**: The old `/agent/sign` and `/agent/submit` endpoints still work but are deprecated. Use `/wallet/sign` and `/wallet/submit` instead.
+> **Note**: The legacy `/agent/sign` and `/agent/submit` endpoints have been removed. Use `/wallet/sign` and `/wallet/submit`.
 
 Both write endpoints require an API key with `walletApiEnabled` and will be rejected if the key is `readOnly`. IP allowlist is enforced.
 
@@ -282,7 +282,7 @@ Submit transactions built by external tools:
 
 ```javascript
 const tx = await buildSwapTransaction();
-await fetch('https://api.bankr.bot/agent/submit', {
+await fetch('https://api.bankr.bot/wallet/submit', {
   method: 'POST',
   headers: { 'X-API-Key': apiKey, 'Content-Type': 'application/json' },
   body: JSON.stringify({ transaction: tx })


### PR DESCRIPTION
## Summary

Weekly sync of the bankr skill with upstream changes.

- **Remove deprecated agent endpoints**: `/agent/{me,balances,sign,submit}` have been removed from the API — updated SKILL.md and sign-submit-api.md to reflect removal instead of deprecation
- **Add Gemini 3.5 Flash**: New model added to the LLM gateway model registry (1M context, Google)
- **Fix stale code example**: Updated a code snippet in sign-submit-api.md that still referenced the removed `/agent/submit` endpoint

## Files changed

- `bankr/SKILL.md` — "Deprecated endpoints" → "Removed legacy endpoints"
- `bankr/references/sign-submit-api.md` — Remove deprecation notice, fix code example URL
- `bankr/references/llm-gateway.md` — Add `gemini-3.5-flash` to available models table

https://claude.ai/code/session_01JnnuifW5YEcpEu1QoniTPK

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnnuifW5YEcpEu1QoniTPK)_