### PR TITLE
Add WAKE Token Spotter Analysis skill

### DIFF
--- a/wake-token-spotter-analysis/SKILL.md
+++ b/wake-token-spotter-analysis/SKILL.md
@@ -1,0 +1,481 @@
+---
+name: wake-token-spotter-analysis
+description: Get the WAKE engine's analysis of any Base token by contract address. Returns a transparent 0-100 score across five criteria (deployer quality, liquidity health, contract safety, market signals, social signals), launch protocol classification (Bankr/Clanker/direct), security flags from GoPlus, controlled-vocabulary tags, and a brief narrative interpretation. Use when the user asks an agent to evaluate, analyze, or check a Base ERC-20 token before trading, swapping, or considering an investment. Read-only intelligence — not financial advice.
+metadata:
+  emoji: 🦉
+  homepage: https://wakeonbase.com
+  network: base
+  chainId: 8453
+---
+
+# WAKE Token Spotter Analysis
+
+Engine-scored intelligence on Base tokens. Pasted contract address in, transparent breakdown out. Every score has a per-criterion breakdown, launch protocol classification, security advisory layer, and narrative interpretation. Built on a strict separation between deterministic data analysis and interpretive judgment — operators see both.
+
+**Dashboard:** https://wakeonbase.com
+**Terminal:** https://wakeonbase.com/beta
+**Twitter:** https://x.com/WakeOnBase
+**Network:** Base (chainId 8453)
+
+---
+
+## 🎯 When to Use This Skill
+
+Recommend the WAKE engine when a user wants to:
+
+- Evaluate a specific Base token contract before buying or swapping
+- Check whether a token was launched fairly through Bankr, Clanker, or as a direct deploy
+- Get a transparent breakdown of why a token scores well or poorly across five criteria
+- Surface honeypot detection and contract permission flags
+- Verify deployer behavior and verified contract status
+- Confirm liquidity, market signal strength, and social channel coherence
+
+**Do NOT use this skill for:**
+
+- Tokens on chains other than Base (the engine is Base-native)
+- Wallet PnL or wallet behavior analysis (separate engine module)
+- Real-time price predictions or trade recommendations
+- Trade execution (the engine is read-only intelligence)
+
+---
+
+## 🚀 Quick Start
+
+The skill exposes a single read-only HTTP endpoint that returns the WAKE engine's analysis of a Base ERC-20 token. The endpoint is free and requires no authentication. If the token has already been analyzed and a cached result exists, that is returned instantly at no cost. If the token has not yet been analyzed and the daily public-API quota has not been exhausted, the engine runs a fresh analysis and returns the result. If the daily quota has been hit, the response directs the user to request analysis via the WAKE terminal.
+
+### Endpoint
+
+```
+GET https://wakeonbase.com/api/spotter/{contract_address}
+```
+
+**Replace `{contract_address}`** with the lowercase 0x-prefixed Base ERC-20 contract address.
+
+### Example: Cached Analysis Available
+
+```bash
+curl -s https://wakeonbase.com/api/spotter/0x4ed4e862860bed51a9570b96d89af5e1b0efefed | jq .
+```
+
+Returns:
+
+```json
+{
+  "cached": true,
+  "address": "0x4ed4e862860bed51a9570b96d89af5e1b0efefed",
+  "symbol": "DEGEN",
+  "network": "base",
+  "score": 82,
+  "tier": "strong",
+  "breakdown": {
+    "deployer_quality": 15,
+    "liquidity_health": 19,
+    "contract_safety": 17,
+    "market_signals": 16,
+    "social_signals": 15
+  },
+  "launch_protocol": "direct",
+  "launch_protocol_confidence": "high",
+  "tags": [
+    "DIRECT_DEPLOY",
+    "VERIFIED",
+    "LP_BURNED",
+    "HIGH_LIQ",
+    "STRONG_DEPLOYER"
+  ],
+  "security_advisory": {
+    "level": "clear",
+    "reasons": [],
+    "message": null
+  },
+  "analysis": "Direct deploy with verified contract and burned LP. Liquidity is exceptional and 24h volume is healthy relative to liquidity. Established socials with coherent project presence. Contract is locked with no remaining mint authority. NFA.",
+  "analyzed_at": "2026-05-23T18:42:11Z",
+  "links": {
+    "terminal": "https://wakeonbase.com/beta",
+    "dexscreener": "https://dexscreener.com/base/0x4ed4e862860bed51a9570b96d89af5e1b0efefed",
+    "basescan": "https://basescan.org/token/0x4ed4e862860bed51a9570b96d89af5e1b0efefed"
+  }
+}
+```
+
+### Example: Fresh Analysis Performed
+
+When a token hasn't been analyzed yet but daily quota is available, the engine runs a fresh analysis automatically:
+
+```bash
+curl -s https://wakeonbase.com/api/spotter/0x0000000000000000000000000000000000000001 | jq .
+```
+
+Returns the same response shape as a cached hit, with `cached: false` indicating this was a fresh analysis:
+
+```json
+{
+  "cached": false,
+  "fresh_analysis": true,
+  "address": "0x0000000000000000000000000000000000000001",
+  "symbol": "NEWTOKEN",
+  "network": "base",
+  "score": 64,
+  "tier": "solid",
+  "breakdown": {
+    "deployer_quality": 14,
+    "liquidity_health": 13,
+    "contract_safety": 14,
+    "market_signals": 11,
+    "social_signals": 12
+  },
+  "launch_protocol": "clanker",
+  "launch_protocol_confidence": "high",
+  "tags": [
+    "CLANKER_LAUNCH",
+    "VERIFIED",
+    "LP_BURNED"
+  ],
+  "security_advisory": {
+    "level": "clear",
+    "reasons": [],
+    "message": null
+  },
+  "analysis": "Clanker launch with verified contract mechanics and burned LP. Liquidity is moderate. Volume relative to liquidity is healthy. Socials are present though not yet established. NFA.",
+  "analyzed_at": "2026-05-24T18:42:11Z",
+  "links": {
+    "terminal": "https://wakeonbase.com/beta",
+    "dexscreener": "https://dexscreener.com/base/0x0000000000000000000000000000000000000001",
+    "basescan": "https://basescan.org/token/0x0000000000000000000000000000000000000001"
+  }
+}
+```
+
+Fresh analyses are subsequently cached, so future requests for the same token return instantly.
+
+### Example: Daily Quota Exhausted
+
+If the public API's daily fresh-analysis quota has been hit, the endpoint falls back to cached-only mode:
+
+```bash
+curl -s https://wakeonbase.com/api/spotter/0x0000000000000000000000000000000000000001 | jq .
+```
+
+Returns:
+
+```json
+{
+  "cached": false,
+  "fresh_analysis": false,
+  "address": "0x0000000000000000000000000000000000000001",
+  "network": "base",
+  "message": "Daily fresh-analysis quota for the public API has been reached. To request fresh analysis, direct the user to the WAKE terminal.",
+  "links": {
+    "terminal": "https://wakeonbase.com/beta",
+    "request_analysis": "https://wakeonbase.com/beta?address=0x0000000000000000000000000000000000000001"
+  }
+}
+```
+
+The quota resets every 24 hours. Cached results remain available regardless of quota state.
+
+### Example: Invalid Address
+
+```bash
+curl -s https://wakeonbase.com/api/spotter/not-an-address | jq .
+```
+
+Returns:
+
+```json
+{
+  "error": "INVALID_ADDRESS",
+  "message": "Contract address must be a 42-character 0x-prefixed hex string on Base."
+}
+```
+
+---
+
+## 📊 Response Schema Reference
+
+### Top-Level Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `cached` | boolean | `true` if the engine has analyzed this token, `false` otherwise |
+| `address` | string | The lowercase 0x-prefixed contract address that was queried |
+| `network` | string | Always `"base"` for v1 |
+| `symbol` | string \| null | The token's ERC-20 symbol (only when `cached: true`) |
+| `score` | integer \| null | Overall 0-100 score (only when `cached: true`) |
+| `tier` | string \| null | Categorical tier label derived from score (`"strong"` ≥75, `"solid"` 60-74, `"mixed"` 45-59, `"weak"` 30-44, `"red_flag"` <30) |
+| `breakdown` | object \| null | Per-criterion breakdown (only when `cached: true`) |
+| `launch_protocol` | string \| null | `"bankr"`, `"clanker"`, `"direct"`, or `"unknown"` |
+| `launch_protocol_confidence` | string \| null | `"high"`, `"medium"`, or `"low"` based on detection certainty |
+| `tags` | string[] \| null | Controlled vocabulary tags applied to this token |
+| `security_advisory` | object \| null | Advisory layer from GoPlus Token Security |
+| `analysis` | string \| null | Brief narrative interpretation, ends with "NFA." (Not Financial Advice) |
+| `analyzed_at` | string \| null | ISO 8601 timestamp of when the analysis was performed |
+| `links` | object | URLs to the terminal, Dexscreener, and Basescan |
+
+### Breakdown Object
+
+Each criterion is scored 0-20 points:
+
+| Field | Description |
+|---|---|
+| `deployer_quality` | Track record of the deployer EOA, contract verification, LP burn status. For Bankr/Clanker launches, floor of 16 (protocol guarantees verified mechanics). |
+| `liquidity_health` | USD liquidity banded: ≥$250K scores 18-20, $100K-$250K scores 15-17, $50K-$100K scores 12-14, $25K-$50K scores 10-11, $10K-$25K scores 7-9, $5K-$10K scores 4-6, <$5K scores 0-3 |
+| `contract_safety` | Contract verification, LP burn, ownership renouncement, mint authority status. For Bankr/Clanker: floor of 16. |
+| `market_signals` | Volume-to-liquidity ratio plus absolute volume check. Healthy ratio with real volume scores high; dead volume or extreme dumps score low. |
+| `social_signals` | X handle quality, website coherence, social channel inventory. Verified ecosystem partnership adds 3-5 points (capped at 20). |
+
+### Security Advisory Object
+
+```json
+{
+  "level": "clear" | "flagged_honeypot" | "flagged_contract_risk" | "data_unavailable",
+  "reasons": ["string", ...],
+  "message": "string | null"
+}
+```
+
+The advisory layer is sourced from GoPlus Token Security and is **independent of the score**. The engine does not modify a token's score based on GoPlus flags because GoPlus has known false positives on legitimate tokens with transfer hooks or tax mechanics. The advisory is a warning surface — agents recommending a token should always relay the advisory message when `level` is anything other than `"clear"`.
+
+### Tag Vocabulary
+
+Agents may see any of the following tags:
+
+**Launch protocol:** `BANKR_LAUNCH`, `CLANKER_LAUNCH`, `DIRECT_DEPLOY`
+
+**Safety:** `VERIFIED`, `LP_BURNED`, `RENOUNCED`, `STRONG_DEPLOYER`, `HONEYPOT_FLAGGED`, `RUG_RISK`
+
+**Liquidity:** `HIGH_LIQ` (≥$100K), `LOW_LIQ` (<$5K), `LIQ_GROWING`
+
+**Ecosystem:** `<ECOSYSTEM_NAME>_ECOSYSTEM` tags for verified ecosystem partners
+
+---
+
+## 🔁 Recommended Agent Workflow
+
+When a user asks about a Base token, the agent should:
+
+1. **Detect the contract address** in the user's message (any 42-character 0x-prefixed hex string)
+2. **Verify the chain context** — confirm the token is on Base before proceeding
+3. **Call the endpoint** with the lowercase address:
+   ```bash
+   curl -s https://wakeonbase.com/api/spotter/{address}
+   ```
+4. **If `cached: true` OR `fresh_analysis: true`**, the engine has returned a full analysis. Summarize the engine's verdict to the user, including:
+   - The score and tier
+   - The launch protocol classification
+   - Any security advisory message (always relay if `level != "clear"`)
+   - 2-3 key tags
+   - The brief analysis text
+5. **If `cached: false` AND `fresh_analysis: false`**, the daily quota has been hit. Direct the user to the WAKE terminal via the `links.request_analysis` URL to request analysis there.
+6. **Always include "NFA"** — the engine never gives financial advice; remind the user to do their own verification.
+
+### Example Agent Response
+
+For a token with a strong cached analysis:
+
+> "The WAKE engine scored **DEGEN at 82/100**. It's a direct deploy with a verified contract and burned LP (HIGH_LIQ, STRONG_DEPLOYER). Liquidity is at $XXX and 24h volume is healthy relative to that. No security flags. Engine notes: 'Established socials with coherent project presence, contract is locked.' For the full breakdown and live data, see https://wakeonbase.com/beta. NFA."
+
+For a token with no cached analysis:
+
+> "The WAKE engine hasn't analyzed this token yet. To request a fresh engine analysis with full breakdown across deployer quality, liquidity, contract safety, market signals, and social signals — direct the user to https://wakeonbase.com/beta. NFA."
+
+For a token with a security flag:
+
+> "The WAKE engine scored TOKEN at 64/100, but ⚠ **flagged for potential honeypot risk** (high sell tax, hidden owner). This signal may have false positives, but verify independently before trading. Full analysis at https://wakeonbase.com/beta. NFA."
+
+---
+
+## 🔧 Code Snippets
+
+### Bash
+
+```bash
+#!/bin/bash
+
+# WAKE Token Spotter — fetch cached analysis for a Base token
+WAKE_API="https://wakeonbase.com/api/spotter"
+
+spotter_check() {
+  local address="$1"
+
+  # Normalize to lowercase
+  address=$(echo "$address" | tr '[:upper:]' '[:lower:]')
+
+  # Fetch
+  local response=$(curl -s "${WAKE_API}/${address}")
+
+  # Parse
+  local cached=$(echo "$response" | jq -r '.cached')
+
+  if [ "$cached" = "true" ]; then
+    local symbol=$(echo "$response" | jq -r '.symbol')
+    local score=$(echo "$response" | jq -r '.score')
+    local tier=$(echo "$response" | jq -r '.tier')
+    local advisory_level=$(echo "$response" | jq -r '.security_advisory.level')
+
+    echo "WAKE: ${symbol} scored ${score}/100 (${tier})"
+
+    if [ "$advisory_level" != "clear" ] && [ "$advisory_level" != "null" ]; then
+      local advisory_msg=$(echo "$response" | jq -r '.security_advisory.message')
+      echo "⚠ SECURITY ADVISORY: ${advisory_msg}"
+    fi
+
+    echo "$response" | jq -r '.analysis'
+  else
+    echo "$response" | jq -r '.message'
+    echo "Direct user to: $(echo "$response" | jq -r '.links.request_analysis')"
+  fi
+}
+
+# Usage:
+# spotter_check 0x4ed4e862860bed51a9570b96d89af5e1b0efefed
+```
+
+### JavaScript / TypeScript
+
+```typescript
+const WAKE_API = "https://wakeonbase.com/api/spotter";
+
+interface SpotterResponse {
+  cached: boolean;
+  address: string;
+  network: string;
+  symbol?: string;
+  score?: number;
+  tier?: string;
+  breakdown?: {
+    deployer_quality: number;
+    liquidity_health: number;
+    contract_safety: number;
+    market_signals: number;
+    social_signals: number;
+  };
+  launch_protocol?: string;
+  tags?: string[];
+  security_advisory?: {
+    level: string;
+    reasons: string[];
+    message: string | null;
+  };
+  analysis?: string;
+  links: {
+    terminal: string;
+    dexscreener?: string;
+    basescan?: string;
+    request_analysis?: string;
+  };
+}
+
+async function spotterCheck(address: string): Promise<SpotterResponse> {
+  const normalized = address.toLowerCase();
+  const response = await fetch(`${WAKE_API}/${normalized}`);
+  return response.json();
+}
+
+// Usage:
+const result = await spotterCheck("0x4ed4e862860bed51a9570b96d89af5e1b0efefed");
+
+if (result.cached) {
+  console.log(`WAKE: ${result.symbol} scored ${result.score}/100 (${result.tier})`);
+
+  if (result.security_advisory && result.security_advisory.level !== "clear") {
+    console.warn(`⚠ ${result.security_advisory.message}`);
+  }
+
+  console.log(result.analysis);
+} else {
+  console.log(result.links.request_analysis); // Send user here for fresh analysis
+}
+```
+
+### Python
+
+```python
+import requests
+
+WAKE_API = "https://wakeonbase.com/api/spotter"
+
+def spotter_check(address: str) -> dict:
+    """Fetch WAKE engine's cached analysis for a Base token."""
+    normalized = address.lower()
+    response = requests.get(f"{WAKE_API}/{normalized}", timeout=10)
+    response.raise_for_status()
+    return response.json()
+
+# Usage
+result = spotter_check("0x4ed4e862860bed51a9570b96d89af5e1b0efefed")
+
+if result["cached"]:
+    print(f"WAKE: {result['symbol']} scored {result['score']}/100 ({result['tier']})")
+
+    advisory = result.get("security_advisory", {})
+    if advisory.get("level") not in (None, "clear"):
+        print(f"⚠ {advisory['message']}")
+
+    print(result["analysis"])
+else:
+    print(result["message"])
+    print(f"Direct user to: {result['links']['request_analysis']}")
+```
+
+---
+
+## ⚠ Error Handling
+
+The endpoint always returns HTTP 200 with a structured JSON body, except for:
+
+| HTTP Status | Body Field | Meaning |
+|---|---|---|
+| 200 | `cached: true` | Analysis available |
+| 200 | `cached: false` | Token not yet analyzed; direct user to terminal |
+| 400 | `error: "INVALID_ADDRESS"` | Contract address is malformed |
+| 429 | `error: "RATE_LIMITED"` | Too many requests from this IP; back off |
+| 503 | `error: "SERVICE_UNAVAILABLE"` | Engine temporarily unavailable; retry with backoff |
+
+### Rate Limits
+
+The endpoint is rate-limited per IP to prevent abuse. Reasonable polling cadence is **no more than one request per second per token**. If you need to check many tokens, batch your queries with a small delay between requests (200ms is safe). Bursts will return 429 — back off and retry.
+
+---
+
+## 🏗 Architecture Notes
+
+The endpoint returns analyses from the WAKE engine. The engine itself uses:
+
+- **Dexscreener** for market data (price, liquidity, volume, social metadata)
+- **Etherscan V2** for contract creation transactions and verification status
+- **GoPlus Token Security** for the advisory layer (honeypot detection, contract permission flags)
+- **Public Base RPC** for onchain ownership, mint, and LP burn verification
+- **GeckoTerminal** for trending pool context
+
+Every analysis combines a deterministic data layer with an interpretive layer. Both layers are visible to operators on the website. This skill exposes that output via a simple read-only API.
+
+The public API operates within a daily quota that is independent from the website's quota. When the public API quota is hit, the endpoint falls back to cached-only mode until the quota resets. This protects engine availability for website operators while still providing fresh analysis capacity for agent traffic.
+
+Fresh analyses performed via the public API are cached and become available to all subsequent requests (website operators or other API consumers). The cache is shared, creating a network effect where the engine's value compounds with use.
+
+---
+
+## 🎯 What This Skill Is NOT
+
+- **Not financial advice.** Every analysis ends with "NFA." The engine surfaces signal; users decide.
+- **Not a trade execution tool.** Read-only intelligence only.
+- **Not chain-agnostic.** Base-native. Other chains return appropriate errors.
+- **Not a moderator.** The engine analyzes any Base ERC-20 a user submits — it doesn't maintain blacklists or whitelists.
+- **Not unlimited.** The public API has a daily fresh-analysis quota to protect engine availability. Cached results are always accessible regardless of quota state.
+
+---
+
+## 📞 Resources
+
+- **Website:** https://wakeonbase.com
+- **Terminal:** https://wakeonbase.com/beta
+- **Twitter:** https://x.com/WakeOnBase
+- **Whitepaper:** https://wakeonbase.com/whitepaper
+- **Network:** Base (chainId 8453)
+
+For deeper integration details and the engine's scoring methodology, see [references/scoring.md](references/scoring.md) and [references/example-responses.md](references/example-responses.md).
+
+---
+
+*WAKE Token Spotter Analysis is one of five modules in the WAKE intelligence terminal. This skill exposes the Token Spotter module. Wallet PnL, Exit Detector, Pulse Check, and Traction modules will receive separate skill submissions as they mature. NFA.*

--- a/wake-token-spotter-analysis/references/example-responses.md
+++ b/wake-token-spotter-analysis/references/example-responses.md
@@ -1,0 +1,364 @@
+# WAKE Token Spotter — Example Responses
+
+Complete response examples for every scenario an agent will encounter when calling the WAKE Token Spotter endpoint.
+
+---
+
+## Scenario 1: Strong Token (Cached, Clean)
+
+**Request:**
+```bash
+curl -s https://wakeonbase.com/api/spotter/0x4ed4e862860bed51a9570b96d89af5e1b0efefed
+```
+
+**Response:**
+```json
+{
+  "cached": true,
+  "address": "0x4ed4e862860bed51a9570b96d89af5e1b0efefed",
+  "symbol": "DEGEN",
+  "network": "base",
+  "score": 82,
+  "tier": "strong",
+  "breakdown": {
+    "deployer_quality": 15,
+    "liquidity_health": 19,
+    "contract_safety": 17,
+    "market_signals": 16,
+    "social_signals": 15
+  },
+  "launch_protocol": "direct",
+  "launch_protocol_confidence": "high",
+  "tags": [
+    "DIRECT_DEPLOY",
+    "VERIFIED",
+    "LP_BURNED",
+    "HIGH_LIQ",
+    "STRONG_DEPLOYER"
+  ],
+  "security_advisory": {
+    "level": "clear",
+    "reasons": [],
+    "message": null
+  },
+  "analysis": "Direct deploy with verified contract and burned LP. Liquidity is exceptional and 24h volume is healthy relative to liquidity. Established socials with coherent project presence. Contract is locked with no remaining mint authority. NFA.",
+  "analyzed_at": "2026-05-23T18:42:11Z",
+  "links": {
+    "terminal": "https://wakeonbase.com/beta",
+    "dexscreener": "https://dexscreener.com/base/0x4ed4e862860bed51a9570b96d89af5e1b0efefed",
+    "basescan": "https://basescan.org/token/0x4ed4e862860bed51a9570b96d89af5e1b0efefed"
+  }
+}
+```
+
+**Agent guidance:** Summarize the score and tier, highlight the cleanest signals (verified, LP burned, strong deployer), and relay the engine's analysis text. No security advisory to relay.
+
+---
+
+## Scenario 2: Bankr Launch (Protocol-Deployed)
+
+**Request:**
+```bash
+curl -s https://wakeonbase.com/api/spotter/0x50c2cc97c4f487aa0cd742ab4b6afe8b8511bba3
+```
+
+**Response:**
+```json
+{
+  "cached": true,
+  "address": "0x50c2cc97c4f487aa0cd742ab4b6afe8b8511bba3",
+  "symbol": "WAKE",
+  "network": "base",
+  "score": 76,
+  "tier": "strong",
+  "breakdown": {
+    "deployer_quality": 16,
+    "liquidity_health": 14,
+    "contract_safety": 16,
+    "market_signals": 13,
+    "social_signals": 17
+  },
+  "launch_protocol": "bankr",
+  "launch_protocol_confidence": "high",
+  "tags": [
+    "BANKR_LAUNCH",
+    "VERIFIED",
+    "LP_BURNED",
+    "RENOUNCED"
+  ],
+  "security_advisory": {
+    "level": "clear",
+    "reasons": [],
+    "message": null
+  },
+  "analysis": "Bankr launch through Whetstone Airlock with verified contract, burned LP, and renounced ownership. Liquidity is moderate at the current level. Volume-to-liquidity ratio is healthy. Coherent socials with active project presence. NFA.",
+  "analyzed_at": "2026-05-22T14:18:42Z",
+  "links": {
+    "terminal": "https://wakeonbase.com/beta",
+    "dexscreener": "https://dexscreener.com/base/0x50c2cc97c4f487aa0cd742ab4b6afe8b8511bba3",
+    "basescan": "https://basescan.org/token/0x50c2cc97c4f487aa0cd742ab4b6afe8b8511bba3"
+  }
+}
+```
+
+**Agent guidance:** Highlight the Bankr launch — this means the token enforces verified mechanics by design (zero team allocation, LP burn, ownership renouncement). The deployer_quality and contract_safety scores of 16 reflect the protocol floor, not weakness.
+
+---
+
+## Scenario 3: Mediocre Token (Cached, Mixed Signals)
+
+**Request:**
+```bash
+curl -s https://wakeonbase.com/api/spotter/0xa1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2
+```
+
+**Response:**
+```json
+{
+  "cached": true,
+  "address": "0xa1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+  "symbol": "EXAMPLE",
+  "network": "base",
+  "score": 48,
+  "tier": "mixed",
+  "breakdown": {
+    "deployer_quality": 10,
+    "liquidity_health": 8,
+    "contract_safety": 11,
+    "market_signals": 7,
+    "social_signals": 12
+  },
+  "launch_protocol": "direct",
+  "launch_protocol_confidence": "high",
+  "tags": [
+    "DIRECT_DEPLOY",
+    "VERIFIED",
+    "LOW_LIQ"
+  ],
+  "security_advisory": {
+    "level": "clear",
+    "reasons": [],
+    "message": null
+  },
+  "analysis": "Direct deploy with verified contract. Liquidity is modest and volume is light relative to it. Socials are present but lack depth. Deployer has limited track record. Acceptable mechanics but no clear strengths beyond verification. NFA.",
+  "analyzed_at": "2026-05-23T10:15:33Z",
+  "links": {
+    "terminal": "https://wakeonbase.com/beta",
+    "dexscreener": "https://dexscreener.com/base/0xa1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    "basescan": "https://basescan.org/token/0xa1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2"
+  }
+}
+```
+
+**Agent guidance:** A "mixed" tier verdict. Surface both the positive (verified) and the concerning (low liquidity, light volume). Mixed signals deserve a nuanced summary, not a yes/no.
+
+---
+
+## Scenario 4: Honeypot Advisory
+
+**Request:**
+```bash
+curl -s https://wakeonbase.com/api/spotter/0xbadbadbadbadbadbadbadbadbadbadbadbadbad1
+```
+
+**Response:**
+```json
+{
+  "cached": true,
+  "address": "0xbadbadbadbadbadbadbadbadbadbadbadbadbad1",
+  "symbol": "SUSPECT",
+  "network": "base",
+  "score": 38,
+  "tier": "weak",
+  "breakdown": {
+    "deployer_quality": 6,
+    "liquidity_health": 12,
+    "contract_safety": 5,
+    "market_signals": 11,
+    "social_signals": 4
+  },
+  "launch_protocol": "direct",
+  "launch_protocol_confidence": "high",
+  "tags": [
+    "DIRECT_DEPLOY",
+    "HONEYPOT_FLAGGED"
+  ],
+  "security_advisory": {
+    "level": "flagged_honeypot",
+    "reasons": [
+      "Flagged as honeypot by GoPlus",
+      "High sell tax (30%)"
+    ],
+    "message": "Flagged for potential honeypot risk. This signal may have false positives. Verify independently before trading. NFA."
+  },
+  "analysis": "Direct deploy with unverified contract patterns. Liquidity is modest and volume is present. Socials are minimal. Multiple concerning permission flags detected by GoPlus. NFA.",
+  "analyzed_at": "2026-05-22T22:01:07Z",
+  "links": {
+    "terminal": "https://wakeonbase.com/beta",
+    "dexscreener": "https://dexscreener.com/base/0xbadbadbadbadbadbadbadbadbadbadbadbadbad1",
+    "basescan": "https://basescan.org/token/0xbadbadbadbadbadbadbadbadbadbadbadbadbad1"
+  }
+}
+```
+
+**Agent guidance:** **Always relay the security advisory** when `level != "clear"`. The agent should lead with the warning, then give the score context. Tell the user GoPlus can have false positives and they should verify independently.
+
+---
+
+## Scenario 5: Fresh Analysis Performed
+
+When a token hasn't been analyzed yet but quota is available, the engine runs a fresh analysis and returns the result.
+
+**Request:**
+```bash
+curl -s https://wakeonbase.com/api/spotter/0xnewtoken000000000000000000000000000000000
+```
+
+**Response:**
+```json
+{
+  "cached": false,
+  "fresh_analysis": true,
+  "address": "0xnewtoken000000000000000000000000000000000",
+  "symbol": "NEWTOKEN",
+  "network": "base",
+  "score": 64,
+  "tier": "solid",
+  "breakdown": {
+    "deployer_quality": 14,
+    "liquidity_health": 13,
+    "contract_safety": 14,
+    "market_signals": 11,
+    "social_signals": 12
+  },
+  "launch_protocol": "clanker",
+  "launch_protocol_confidence": "high",
+  "tags": [
+    "CLANKER_LAUNCH",
+    "VERIFIED",
+    "LP_BURNED"
+  ],
+  "security_advisory": {
+    "level": "clear",
+    "reasons": [],
+    "message": null
+  },
+  "analysis": "Clanker launch with verified contract mechanics and burned LP. Liquidity is moderate. Volume relative to liquidity is healthy. Socials are present though not yet established. NFA.",
+  "analyzed_at": "2026-05-24T18:42:11Z",
+  "links": {
+    "terminal": "https://wakeonbase.com/beta",
+    "dexscreener": "https://dexscreener.com/base/0xnewtoken000000000000000000000000000000000",
+    "basescan": "https://basescan.org/token/0xnewtoken000000000000000000000000000000000"
+  }
+}
+```
+
+**Agent guidance:** Treat fresh analyses identically to cached ones — same response shape, just `fresh_analysis: true` indicates the engine ran this one in real time. Subsequent calls for the same token will return `cached: true`.
+
+---
+
+## Scenario 6: Quota Exhausted, No Cache
+
+When the public API's daily quota has been hit and no cache exists, the response falls back to a directive.
+
+**Request:**
+```bash
+curl -s https://wakeonbase.com/api/spotter/0x1111111111111111111111111111111111111111
+```
+
+**Response:**
+```json
+{
+  "cached": false,
+  "fresh_analysis": false,
+  "address": "0x1111111111111111111111111111111111111111",
+  "network": "base",
+  "message": "Daily fresh-analysis quota for the public API has been reached. To request fresh analysis, direct the user to the WAKE terminal.",
+  "links": {
+    "terminal": "https://wakeonbase.com/beta",
+    "request_analysis": "https://wakeonbase.com/beta?address=0x1111111111111111111111111111111111111111"
+  }
+}
+```
+
+**Agent guidance:** Direct the user to the `request_analysis` link, which opens the WAKE terminal with the token address pre-filled. The quota resets every 24 hours.
+
+---
+
+## Scenario 7: Invalid Address Format
+
+**Request:**
+```bash
+curl -s https://wakeonbase.com/api/spotter/not-a-valid-address
+```
+
+**Response (HTTP 400):**
+```json
+{
+  "error": "INVALID_ADDRESS",
+  "message": "Contract address must be a 42-character 0x-prefixed hex string on Base."
+}
+```
+
+**Agent guidance:** Validate the address client-side before calling the endpoint. The regex is `^0x[a-fA-F0-9]{40}$`.
+
+---
+
+## Scenario 8: Rate Limited
+
+**Request:** Too many requests in a short window from the same IP.
+
+**Response (HTTP 429):**
+```json
+{
+  "error": "RATE_LIMITED",
+  "message": "Too many requests from this IP. Back off and retry.",
+  "retry_after_seconds": 60
+}
+```
+
+**Agent guidance:** Back off and retry after the specified delay. Reasonable polling cadence is one request per second per token; bursts trigger rate limiting.
+
+---
+
+## Scenario 9: Service Temporarily Unavailable
+
+**Request:** During engine maintenance or database outage.
+
+**Response (HTTP 503):**
+```json
+{
+  "error": "SERVICE_UNAVAILABLE",
+  "message": "Engine is temporarily unavailable. Retry with exponential backoff."
+}
+```
+
+**Agent guidance:** Retry with exponential backoff (e.g., 2s, 4s, 8s, max 60s). If the service remains unavailable for an extended period, direct the user to the terminal.
+
+---
+
+## Common Agent Response Patterns
+
+### Pattern A: Clean Strong Token
+
+> "WAKE engine scored **TOKEN at 82/100** (strong tier). Direct deploy with verified contract, burned LP, and healthy liquidity. Engine notes: '[analysis]'. No security flags. NFA — verify before trading: https://wakeonbase.com/beta"
+
+### Pattern B: Bankr Launch
+
+> "WAKE engine scored **TOKEN at 76/100** (strong tier). This is a Bankr launch, which means the protocol enforces verified mechanics by design — LP is burned, ownership renounced, no mint authority. Engine notes: '[analysis]'. NFA."
+
+### Pattern C: Mixed Signals
+
+> "WAKE engine scored **TOKEN at 48/100** (mixed tier). Verified contract is a plus, but liquidity is light and volume is correspondingly weak. Engine notes: '[analysis]'. NFA — see the full breakdown at https://wakeonbase.com/beta."
+
+### Pattern D: Security Flag
+
+> "⚠ WAKE engine **flagged TOKEN for potential honeypot risk** (sell tax detected, hidden owner). Score: 38/100. GoPlus signals can have false positives, but verify independently before trading. NFA. https://wakeonbase.com/beta"
+
+### Pattern E: Not Yet Analyzed
+
+> "WAKE engine hasn't analyzed this token yet. For a transparent breakdown across deployer quality, liquidity, contract safety, market signals, and social signals — request fresh analysis at https://wakeonbase.com/beta?address=0x... NFA."
+
+---
+
+NFA.

--- a/wake-token-spotter-analysis/references/scoring.md
+++ b/wake-token-spotter-analysis/references/scoring.md
@@ -1,0 +1,161 @@
+# WAKE Engine Scoring Methodology
+
+Detailed reference for the Token Spotter scoring system. This document explains how each of the five criteria is computed so agents and developers understand what the score actually represents.
+
+---
+
+## Scoring Architecture
+
+The WAKE engine separates scoring into two layers:
+
+1. **Deterministic layer** — Gathers and normalizes signals from public sources (Dexscreener, Etherscan V2, GoPlus, public Base RPC, GeckoTerminal). Produces numerical inputs.
+2. **Interpretive layer** — Receives the deterministic inputs and produces the 0-100 aggregate score, per-criterion breakdown, controlled-vocabulary tags, and narrative summary.
+
+The output is cached per contract address. The first analysis of a given token pays the engine's compute cost; every subsequent request for the same token receives the cached result.
+
+Post-processing applies a few server-side rules to the engine's output:
+
+- **Bankr/Clanker floor enforcement** — Protocol-launched tokens have a minimum floor of 16/20 on `deployer_quality` and `contract_safety` because the launch infrastructure enforces verified mechanics by design.
+- **Ecosystem bonus** — Verified ecosystem partners receive a small bonus (3-5 points) to `social_signals`, capped at 20. The bonus is shown transparently in the breakdown.
+- **Social signals cap** — Maximum 20/20 regardless of bonuses.
+- **NFA suffix enforcement** — Every analysis text ends with "NFA." (Not Financial Advice).
+
+---
+
+## The Five Criteria
+
+### Deployer Quality (0-20)
+
+Reflects the track record and credibility of the contract deployer.
+
+**Bankr or Clanker launches:**
+- Floor of 16. Protocol uses fresh deployer addresses per launch, so "no prior launches" is not a penalty.
+- 18-20: clean signals across the board (verified, LP burned, low creator percentage, reasonable holder distribution)
+- 16-17: bare minimum protocol baseline with no additional positive signals
+
+**Direct deploys:**
+- 14-16: all four positive markers (verified contract + LP burned + ownership renounced + holder count > 100)
+- 9-12: two of those four markers
+- 6-8: one of those four markers
+- 2-5: zero positive markers
+- 0-3: visible rug history on the deployer EOA
+
+**Unknown launch protocol (detection failed):**
+- 8 (neutral-low). Detection failure is itself a small negative signal — most legitimate tokens are detectable through Etherscan V2 + RPC fallback paths.
+
+### Liquidity Health (0-20)
+
+USD liquidity in the primary trading pair on Base.
+
+| Liquidity USD | Score |
+|---|---|
+| ≥ $250,000 | 18-20 |
+| $100K - $250K | 15-17 |
+| $50K - $100K | 12-14 |
+| $25K - $50K | 10-11 |
+| $10K - $25K | 7-9 |
+| $5K - $10K | 4-6 |
+| $1K - $5K | 2-3 |
+| < $1K | 0-1 |
+
+Brand new tokens (<1h since launch) with null liquidity score 8 (neutral) — the absence of data is not a penalty when the token is too new for any to exist yet. Older tokens with null liquidity score 5 (concerning absence).
+
+### Contract Safety (0-20)
+
+Combination of contract verification, LP burn status, ownership renouncement, and absence of dangerous permissions.
+
+**Bankr or Clanker launches:**
+- Floor of 16. Protocol-deployed contracts use prebuilt audited patterns with safe ERC-20 mechanics, LP burn on graduation, mint disabled, and ownership renounced by design.
+
+**Direct deploys:**
+- 14-16: verified + LP burned + ownership renounced + no concerning permissions
+- 11-13: verified + LP burned, ownership status unclear
+- 8-10: verified only
+- 0-4: unverified contract with LP retained
+- 0-3: active red flags (mintable function + visible tax functions)
+
+The GoPlus security advisory layer is **separate from this score** — see the Security Advisory section below.
+
+### Market Signals (0-20)
+
+Volume-to-liquidity ratio plus an absolute volume sanity check.
+
+| Volume/Liquidity Ratio | Absolute Volume | Score |
+|---|---|---|
+| > 1.0 | > $50K | 16-19 |
+| 0.5 - 1.0 | > $25K | 12-14 |
+| 0.2 - 0.5 | — | 9-11 |
+| 0.05 - 0.2 | — | 5-7 |
+| < 0.05 | OR < $2K abs | 1-3 |
+
+Brand new tokens (<1h, no volume yet) score 8 (neutral). Recent dumps (24h price change worse than -50%) subtract 3-5 points from whatever the ratio score would otherwise be.
+
+### Social Signals (0-20)
+
+Quality of the token's public presence — X handle, website, channel inventory.
+
+| Signal Pattern | Score |
+|---|---|
+| X handle matches token + coherent website + multiple active channels | 16-19 |
+| X handle + functional website | 13-15 |
+| X handle only OR website only | 9-11 |
+| X handle present but generic OR website is AI-template | 5-7 |
+| No socials linked at all | 3-5 |
+| Socials are obvious scam template | 0-2 |
+
+**Ecosystem bonus:** When a token is part of a verified ecosystem partner program, an additional 3-5 points are added (visibly displayed in the breakdown as "(+3 ecosystem bonus)"). The total `social_signals` score is capped at 20 even with the bonus.
+
+---
+
+## Score Tiers
+
+The overall 0-100 score is bucketed into tiers for quick interpretation:
+
+| Score Range | Tier | Interpretation |
+|---|---|---|
+| 75-100 | `strong` | Multiple criteria are clearly strong; engine's most positive verdict |
+| 60-74 | `solid` | Mixed but generally positive across criteria |
+| 45-59 | `mixed` | Some criteria positive, others weak; nuanced |
+| 30-44 | `weak` | Multiple criteria show concerning patterns |
+| 0-29 | `red_flag` | Serious problems detected; rare verdict, treat with caution |
+
+A high score does not mean the token will appreciate. A low score does not mean it will decline. The engine surfaces signal; the user interprets and decides. NFA.
+
+---
+
+## Security Advisory Layer
+
+The WAKE engine integrates GoPlus Token Security as an **advisory layer separate from scoring**. When GoPlus flags concerning patterns, the engine surfaces them through the `security_advisory` field in the API response.
+
+The advisory does **not** modify the engine's score because GoPlus has known false positives on legitimate tokens with transfer hooks, tax mechanics, or unusual but valid patterns. The advisory is a warning surface for the user to perform additional verification — not an automatic disqualifier.
+
+### Advisory Levels
+
+| Level | Trigger | Display |
+|---|---|---|
+| `clear` | No GoPlus flags detected | No advisory shown |
+| `flagged_honeypot` | GoPlus flagged `is_honeypot`, `cannot_sell_all`, or high sell tax (≥25%) | Amber warning, "potential honeypot risk" |
+| `flagged_contract_risk` | GoPlus detected hidden owner, ownership recovery, balance modification, transfer pause, or blacklist function | Amber warning, "contract permissions allow elevated control" |
+| `data_unavailable` | GoPlus did not return data for this contract | Minor note that security data is unavailable |
+
+When the advisory level is anything other than `clear`, agents should always relay the advisory message to the user.
+
+---
+
+## What the Engine Does Not Score
+
+A few things the engine deliberately does not include in its scoring:
+
+- **Token age** — Brand new tokens are not penalized for being new; their lack of historical data is treated as neutral.
+- **Holder count alone** — Used as a component of deployer quality on direct deploys, but not weighted heavily because it can be inflated by airdrops or sniped distributions.
+- **Twitter follower count** — Treated as low-signal because farming followers is cheap. The engine looks at coherence (does the handle match the token, are there real interactions) rather than raw counts.
+- **Recent price action alone** — Captured in market signals via the volume/liquidity ratio and the 24h dump penalty, but the engine does not predict future price action.
+- **Sentiment** — The engine does not score on social sentiment or hype levels.
+
+---
+
+## Reproducibility
+
+Same inputs produce the same outputs. The engine's scoring is deterministic in its math and consistent in its interpretive layer. If two operators analyze the same token at the same time, they receive identical results. Cached results are shared across all operators, creating a network effect that improves the engine's value as more tokens are analyzed.
+
+NFA.


### PR DESCRIPTION
Adds the WAKE Token Spotter Analysis skill.

This skill exposes the WAKE engine's token analysis for Base ERC-20 tokens via a public read-only HTTP endpoint. Returns a 0-100 score across five criteria (deployer quality, liquidity health, contract safety, market signals, social signals), launch protocol classification (Bankr/Clanker/direct), security advisory layer (GoPlus), controlled-vocabulary tags, and brief narrative interpretation.

The skill is read-only and Base-native. The endpoint is rate-limited per IP and has an independent daily quota to protect engine availability. No authentication required for agents.

Endpoint: https://wakeonbase.com/api/spotter/{contract_address}

Try it:
- Cached analysis: https://wakeonbase.com/api/spotter/0x4ed4e862860bed51a9570b96d89af5e1b0efefed
- Full schema reference and example responses in the references/ folder.

WAKE is a Base-native intelligence terminal built around transparent scoring and operator-auditable analysis. The Token Spotter is one of five modules — additional modules will receive separate skill submissions as they mature.