### PR TITLE
Add empire-builder skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Bankr Skills equip builders with plug-and-play tools to build more powerful agen
 | [Axiom](https://clawbots.org) | [signals](signals/) | Transaction-verified trading signals on Base. Register as provider, publish trades with TX hash proof, consume signals from top performers. |
 | botchan | [botchan](botchan/) | On-chain agent messaging on Base. Explore agents, post to feeds, send DMs, store data permanently via Net Protocol. |
 | [Endaoment](https://endaoment.org) | [endaoment](endaoment/) | Charitable donations on-chain. Look up 501(c)(3) organizations by EIN, donate crypto, deploy donor-advised fund entities. |
+| [Empire Builder](https://empirebuilder.world) | [empire-builder](empire-builder/) | SmartVault community treasuries on Base/Arbitrum. Leaderboard payouts, burns, airdrops, boosters, and Clanker→deploy-empire flows via HTTP API + owner-signed executeBatch. |
 | [ENS](https://ens.domains) | [ens-primary-name](ens-primary-name/) | ENS name management. Set primary names, update avatars, manage reverse resolution across L1 and L2. |
 | [8004.org](https://8004.org) | [erc-8004](erc-8004/) | On-chain agent identity registry. ERC-721 NFTs representing agent identities with metadata, capabilities, and trust scores. |
 | [Coinbase](https://onchainkit.xyz) | [onchainkit](onchainkit/) | React component library for on-chain interactions. Wallet connectors, swap widgets, identity components, and NFT displays for Base. |

--- a/empire-builder/SKILL.md
+++ b/empire-builder/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: Empire Builder
+description: Empire Builder AI skill — SmartVault treasuries, leaderboards, boosters, prepare→executeBatch→store distributions, burns, airdrops, Clanker deploys. Self-contained in this skill folder; follow references/http-api.md and references/workflows.md exactly.
+version: 1.3.0
+lastUpdated: 2026-05-18
+homepage: https://empirebuilder.world/skill/SKILL.md
+dependencies: [clanker-sdk@4.2.16, viem@2.48.0]
+metadata: {"clawdbot":{"emoji":"👑","homepage":"https://empirebuilder.world","requires":{"env":["EMPIRE_API_KEY"],"bins":["curl"]}}}
+---
+
+# Empire Builder Skill
+
+**Empires** are community treasuries (ERC-4337 SmartVaults on Base `8453` and Arbitrum `42161`) paired with an identity (**Empire ID**). Agents orchestrate HTTP APIs plus wallet-signed txs (`executeBatch` for payouts).
+
+**Base URL:** `https://empirebuilder.world` — **mainnet only.** There is no testnet or sandbox API documented here.
+
+**Packages (pinned):** `npm install clanker-sdk@4.2.16 viem@2.48.0` — versions match the YAML frontmatter; use a lockfile in automation; avoid `@latest` for reproducibility.
+
+**Skill copies:** If you sync from `homepage`, diff against a trusted checkout before relying on it in scripts.
+
+<a id="intentional-product-behavior"></a>
+
+## Intentional product behavior (not documentation bugs)
+
+The integration surface is **meant** to hit **production** chains with **vault `owner()`** authority. “Hardening” belongs in **product code, infra, and operator tooling**—this skill only describes the API/contract shape.
+
+- **All writes are live** on Base `8453` / Arbitrum `42161` unless you stick to reads.
+- **`distribute-prepare`** + owner-broadcast **`executeBatch`** is the designed API path; SmartVault **`owner()`** is required on-chain (see [`references/contracts.md`](references/contracts.md)).
+- **`POST /api/store-distribution`** persists from **mined `transactionHashes`** (receipt-backed): recorded payouts follow **on-chain execution**, not prepare JSON alone. You still must pass correct **`empireAddress`**, **`baseToken`** (Empire ID), and leaderboard fields so rows attach to the right empire ([`http-api.md`](references/http-api.md#post-apistore-distribution)).
+- Registry/scanner warnings about “agent + wallet + mainnet” reflect **that intentional design**, not missing caveats in this file.
+
+---
+
+## How agents should use this skill
+
+Models usually load **`SKILL.md` first** only. Treat this file as **routing + constraints**. Before writing HTTP bodies, signing flows, or multi-step flows, **open the reference files** listed below—otherwise you will guess missing fields (`signer` vs `signerAddress`, `leaderboardType` values, booster payloads). For **one pipeline story** (especially payouts), follow [`references/workflows.md`](references/workflows.md) step order.
+
+---
+
+## When NOT to use this skill
+
+Stop and pick a different approach if any of these apply:
+
+- **End-user wallet UX inside the Empire web app.** The website signs **sponsored ERC‑4337 UserOperations** (paymaster-funded `executeBatch` via EntryPoint) for co-signers — **not** the prepare → owner-broadcast → store path this skill describes. Use the in-app flow (or its dedicated front-end client code), not these HTTP routes.
+- **Co-signer / "authorized signer" automation.** Co-signers **cannot** call vault `execute`/`executeBatch` directly (reverts `Unauthorized`) and **cannot** drive `POST /api/distribute-prepare` — that route requires `owner()`. If you are a co-signer, either (a) trigger a UserOp through the web app, or (b) escalate to the vault owner.
+- **Generic ERC-4337 / paymaster / bundler tutorials.** This skill does not teach you to build a sponsor, bundler, or EntryPoint integration. Don't graft `/alchemy-sponsor-userop`-style helpers or legacy `distribute-v3` endpoints onto these flows.
+- **Non-Empire token deploys.** Plain Clanker SDK deploys without an Empire are out of scope — use the Clanker docs directly. This skill only covers Clanker → `deploy-empire` wiring.
+- **Testnets / local dev.** No sandbox endpoint exists. If you need a dry-run, read-only GETs are safe; do not invent `/sepolia/...`, `chainId: 84532`, or staging hosts.
+- **Mass user-to-user transfers from random EOAs.** Use a normal ERC-20 `transfer` from the holding wallet — vault roles, prepare/store, and distribution routes don't apply.
+
+---
+
+## Empire ID vs SmartVault address (read this first)
+
+Three input shapes resolve to **one Empire**, but they are **not** the SmartVault address:
+
+| Shape | Looks like | Where it appears |
+|-------|------------|------------------|
+| Token empire | `0x` + 40 hex (the ERC‑20 base token) | most `tokenAddress` / `baseToken` params |
+| Farcaster tokenless | `fid` + digits (e.g. `fid12345`) | tokenless empires anchored to a Farcaster fid |
+| Custom tokenless slug | alphanumeric slug | tokenless empires with a custom identity |
+
+- **Empire ID** is identity. Often spelled `tokenAddress`, `baseToken`, `empire_id`, or sits in the path segment `/api/empires/[empire_id]`.
+- **SmartVault address** is the on-chain treasury contract. Spelled `empire_address` / `empireAddress` / `treasuryAddress`. Resolve it from `GET /api/empires/[empire_id]`.
+- They are **never interchangeable** unless an endpoint explicitly takes both. Do not pass an `fid…` Empire ID where a contract address is required, and do not pass the SmartVault address where Empire ID is required (e.g. `store-distribution` wants both, with distinct field names).
+
+See [`references/http-api.md` → Empire ID](references/http-api.md#empire-id-base_token) for the full type table.
+
+---
+
+## How this skill is structured
+
+Everything agents need lives **inside this skill folder** — no dependency on other folders.
+
+| File | Role |
+|------|------|
+| **`SKILL.md`** (this file) | Scope, rules, orientation |
+| [`references/http-api.md`](references/http-api.md) | Canonical HTTP routes, auth, Empire ID, key JSON shapes |
+| [`references/workflows.md`](references/workflows.md) | End-to-end sequences (deploy, distribute, burn, …) |
+| [`references/contracts.md`](references/contracts.md) | SmartVault `execute` / `executeBatch`, chains |
+
+---
+
+## Agent constraints (mandatory)
+
+1. **Catalog fidelity.** Only use routes and semantics described in [`references/http-api.md`](references/http-api.md). Do not invent paths or composite undocumented URLs.
+
+2. **Authentication.** Send **`x-api-key`** where [`references/http-api.md`](references/http-api.md) says so. Writes often require EIP-191 **`signature`**, **`message`**, and **`signer`** or **`signerAddress`** — match field names per route.
+
+3. **Treasury payouts.** Integration flow only: **`POST /api/distribute-prepare`** → vault **`owner()`** wallet submits vault **`executeBatch`** txs (**you pay gas**) → **`POST /api/store-distribution`**. Do not substitute random sponsor/UserOp tutorials unless working purely inside the official web app (different pipeline).
+
+4. **`POST /api/distribute-prepare`** signer must equal **`owner()`** on the vault — **not** co-signers / “authorized” SmartVault signers. Those addresses can authorize **UserOperations** in the web app (sponsored **`executeBatch`** via EntryPoint), but they **cannot** use this API path and **cannot** **`execute`** or **`executeBatch`** on the vault with a normal EOA transaction — the contract reverts **`Unauthorized`**. See [`references/contracts.md`](references/contracts.md). On **other** routes, recovered **`signer`** may be checked against **`owner`** / **`co_emperors`** per backend rules — do not assume the same rule as **`distribute-prepare`**.
+
+5. **Empire ID vs SmartVault address.** Per the dedicated section above, `tokenAddress` / `baseToken` / `empire_id` is **identity** (ERC‑20, `fid…`, or slug); `empireAddress` / `treasuryAddress` is the **on-chain vault**. Confusing them is the most common skill-failure mode — re-check field names against [`references/http-api.md`](references/http-api.md) before sending any write.
+
+6. **Burns.** Decoded from the burn tx receipt: ERC‑20 **Transfer** to **`0x000…0000`** or **`0x000…dEaD`** for the empire **base** (or attached base if tokenless), then **`POST /api/store-burn`**. If tokens sit **in the SmartVault**, only **`owner()`** can fire a direct vault **`execute`** / **`executeBatch`**; co-signers burn from the treasury in the **website** via sponsored **`executeBatch`** UserOps (Base / Arbitrum). If tokens sit in **any other wallet**, that wallet **`transfer`**s to a burn address — no vault role needed.
+
+---
+
+## At-a-glance: integration surfaces
+
+| Area | Mechanism |
+|------|-----------|
+| Reads | Mostly open GETs; some routes require API key (see [`references/http-api.md`](references/http-api.md)) |
+| Leaderboard payouts | prepare (owner-signed) → `transactions[]` → owner broadcasts `executeBatch` → store-distribution |
+| Burns | Eligible **Transfer** in mined tx → store-burn; treasury burns: owner self-paid **`execute`**, or web app UserOp **`executeBatch`** for co-signers |
+| Boosters | [`references/http-api.md`](references/http-api.md) — `/api/boosters/...` |
+| Token deploy | `get-token-config` → Clanker SDK deploy → `deploy-empire` |
+
+---
+
+## Example prompts
+
+- Walk distribution preparation using leaderboard **`main`** and two ERC‑20s from [`references/workflows.md`](references/workflows.md).
+- Build **`curl`** skeletons for `store-distribution` given mined hashes.
+- Explain why **`baseToken`** in storage payloads differs from **`empireAddress`**.
+
+---
+
+## Error handling
+
+| HTTP | Meaning |
+|------|--------|
+| `400` | Bad parameters |
+| `401` | API key / signature invalid |
+| `403` | Forbidden |
+| `404` | Not found |
+| `429` | Rate limited |
+| `500` | Server error — retry with backoff |
+
+---
+
+## Detail sections — open references next
+
+- **Routes & payloads:** [`references/http-api.md`](references/http-api.md)
+- **Step-by-step flows:** [`references/workflows.md`](references/workflows.md)
+- **On-chain primitives:** [`references/contracts.md`](references/contracts.md)

--- a/empire-builder/references/contracts.md
+++ b/empire-builder/references/contracts.md
@@ -1,0 +1,181 @@
+# SmartVault — integration reference
+
+Empire treasuries are **ERC‑4337 SmartVault** contracts — same logical vault address on **Base (`8453`)** and **Arbitrum (`42161`)**.
+
+---
+
+## Addresses
+
+Resolve **`empire_address`** from **`GET /api/empires/[empire_id]`**. Use that address as **`treasuryAddress`/`empireAddress`** when calling **`executeBatch`** returned by **`POST /api/distribute-prepare`**.
+
+---
+
+## Core ABI fragments
+
+```solidity
+struct Call {
+    address target;
+    uint256 value;
+    bytes data;
+}
+
+function execute(Call calldata call_) external payable;
+
+function executeBatch(Call[] calldata calls_) external payable;
+
+function owner() external view returns (address);
+```
+
+Prepared payouts encode ERC‑20 **`transfer`** calls inside **`calls_`** — **`target`** = token contract, **`value`** = `0`, **`data`** = encoded **`transfer(recipient, amount)`**.
+
+---
+
+## Owner vs co-signers (on-chain)
+
+**Integration semantics:** successful **API integration** payouts require an EOA that is the vault **`owner()`** to broadcast **`execute(...)`** / **`executeBatch(...)`** with the prepare response calldata — that access rule is enforced **on-chain** (see table below).
+
+SmartVault **`execute`** and **`executeBatch`** are **not** “any signer may call.” A normal transaction **from a co-signer EOA** to the vault **`execute(...)`** or **`executeBatch(...)`** reverts with **`Unauthorized`** — the same check applies to both selectors.
+
+| Role | Direct vault tx (`execute` / `executeBatch`) | ERC‑4337 UserOp |
+|------|-----------------------------------------------|------------------|
+| **`owner()`** | Allowed (typical integration + owner wallet) | Allowed (web app; signatures may be required per flow) |
+| **Co-signer** (vault signer for **`validateUserOp`**) | **Not allowed** | Allowed when **`callData`** is validated **`executeBatch`** (e.g. website sponsored flow) |
+
+Co-signers act **only** through **EntryPoint → `validateUserOp`** for batched execution, not by calling the vault directly.
+
+---
+
+## Two execution contexts
+
+| Context | Who submits | Gas |
+|---------|-------------|-----|
+| **Website** UserOperation | Bundler + paymaster sponsorship | Covered by product **TX credits** ( **`executeBatch`**-shaped calldata ) |
+| **API integration** (`distribute-prepare`) | **Vault `owner()`** wallet sends **`executeBatch`** txs using returned calldata | **You pay** native gas |
+
+Agent integrations **must** follow the second row unless explicitly automating the native web UI. **Co-signers cannot substitute** for the owner on the API path.
+
+---
+
+## Burns vs vault sends
+
+| Goal | Mechanism |
+|------|-----------|
+| Treasury → many recipients | **`executeBatch`** — prepare → **owner** broadcasts, or website UserOp for co-signers |
+| Supply burn tracked in Empire analytics | Receipt must show eligible **Transfer** to burn address; **`POST /api/store-burn`**. Tokens **held outside** the vault: any wallet **`transfer`**. Tokens **in the vault**: **owner** **`execute`**, token **`burn`**, or website **`executeBatch`** UserOp for co-signers |
+
+---
+
+## Ordering multi-batch distributions
+
+When **`transactions[]`** contains multiple rows sharing **`chainId`**, honor **`batchIndex`** ascending so nonce-dependent splits stay deterministic.
+
+---
+
+## StakingLocker (native staking)
+
+Optional per-empire feature — only active when `empires.staking_activated == true` (see [`http-api.md` → Native staking](./http-api.md#native-staking)). The contract is **immutable**, has **no admin / upgrade path**, and is called **directly from the staker's EOA** — never through the empire SmartVault.
+
+### Addresses (placeholders)
+
+| Network | Chain ID | Address |
+|---------|----------|---------|
+| Base | 8453 | `<STAKING_LOCKER_BASE>` *(env: `NEXT_PUBLIC_STAKING_LOCKER_8453`)* |
+| Arbitrum | 42161 | `<STAKING_LOCKER_ARBITRUM>` *(env: `NEXT_PUBLIC_STAKING_LOCKER_42161`)* |
+
+Resolve at runtime via `getStakingLockerAddress(chainId)` (`src/config/staking-locker.ts`); when the env var is unset the helper returns `null` and `isStakingChainSupported(chainId)` is `false` — the activate-staking API will refuse with a clear error. Mainnet (chain `1`) is **not** supported.
+
+### Lock duration
+
+`lockDuration` is **any integer number of seconds** in `[0, 315_360_000]` (`0` = flexible, max = 10 years = `3650 days`). The on-chain check is `duration <= MAX_LOCK_DURATION`. There are no fixed tiers; UI presets exist only for convenience. `unlockTime` is `uint40` so 10 years fits.
+
+### Operational caps + minimums
+
+- `MAX_STAKES_PER_USER = 100` active positions per (user, token).
+- `getMinimumStake(token)` is token-dependent: WETH → `0.001 ether`, USDC → `1e6` (USDC is 6-decimal), default → `100 * 1e18`.
+- Fee-on-transfer tokens are **not supported**.
+
+### Stake (two-step ERC-20 approve + stake)
+
+```solidity
+// Token: standard ERC-20 approve
+function approve(address spender, uint256 amount) external returns (bool);
+
+// StakingLocker
+function stake(
+    address token,
+    uint256 amount,         // >= getMinimumStake(token)
+    uint256 lockDuration    // any seconds in [0, 315_360_000]; 0 = flexible
+) external returns (uint256 stakeId);
+
+event Staked(
+    uint256 indexed stakeId,
+    address indexed token,
+    address indexed owner,
+    uint256 amount,
+    uint40  unlockTime
+);
+```
+
+Approve `amount` on the ERC-20 to the StakingLocker, then call `stake`. `lockDuration == 0` produces a "flexible" stake, unstakeable at any time.
+
+### Unstake by global stake id
+
+```solidity
+function unstake(uint256 stakeId) external;
+
+event Unstaked(
+    uint256 indexed stakeId,
+    address indexed token,
+    address indexed owner,
+    uint256 amount
+);
+```
+
+Pass the **global** `stakeId`. `getUserStakeIds(user, token)` returns ids in the same order as `getActiveStakes` — index by id, never by array position.
+
+### Reads used by Empire's pipelines
+
+```solidity
+function getMinimumStake(address token)        external pure returns (uint256);
+function isValidLockDuration(uint256 duration) external pure returns (bool);
+
+function getRawStake(address user, address token)        external view returns (uint256);
+function getActiveStakeCount(address user, address token) external view returns (uint256);
+
+struct Stake {
+    address token;
+    address owner;
+    uint40  startTime;
+    uint40  unlockTime;
+    bool    unstaked;
+    uint256 amount;
+}
+
+function getActiveStakes(address user, address token) external view returns (Stake[] memory);
+function getUserStakeIds(address user, address token) external view returns (uint256[] memory);
+
+function getStakerCount(address token) external view returns (uint256);
+function getStakersPage(address token, uint256 page)
+    external view
+    returns (
+        address[] memory stakers,
+        uint256[] memory rawStakes,
+        uint256          totalStakers,
+        uint256          totalPages    // 250 stakers per page
+    );
+
+function getLockUpRemaining(uint256 stakeId) external view returns (uint256 remaining);
+function getLockUpDuration(uint256 stakeId)  external view returns (uint256 duration);
+
+function tokenStakers(address token, uint256 index) external view returns (address);
+```
+
+Where these are used:
+
+- **Stakers leaderboard:** `getStakersPage` enumerates every staker; the pipeline pages `0..totalPages-1`.
+- **`tokenHolders` / `farToken` augmentation:** the per-staker `rawStakes` are added on top of Ankr-derived holder balances before scoring.
+- **STAKING booster qualification:** sums `getActiveStakes(user, token).amount` where each stake's `unlockTime - startTime >= booster.min_lockup_seconds`, then compares against `booster.min_amount`.
+
+### After staking on-chain
+
+There's no required server callback — refresh on the existing `PATCH /api/leaderboards/refresh/<type>` route (30s cooldown). The frontend `StakingModal` re-reads `getActiveStakes` + `getUserStakeIds` after every successful stake/unstake.

--- a/empire-builder/references/http-api.md
+++ b/empire-builder/references/http-api.md
@@ -1,0 +1,1096 @@
+# Empire Builder — HTTP API (skill-local reference)
+
+**Base URL:** `https://empirebuilder.world`
+
+**Production mainnet:** Hosts and chains are **live** (Base `8453`, Arbitrum `42161`). **`distribute-prepare`** and broadcasting **`executeBatch`** update on-chain balances. **`POST /api/store-distribution`** persists from **mined `transactionHashes`** (receipt-backed), so stored distributions align with **what executed on-chain**, not unconstrained re-submission of prepare JSON alone.
+
+**Errors:** JSON `{ "error": "message" }` with usual HTTP codes (`400`, `401`, `403`, `404`, `429`, `500`).
+
+---
+
+## Authentication modes
+
+| Mode | When |
+|------|------|
+| None | Many GET routes |
+| **`x-api-key`** header (or `api_key` query) | Server-enforced partner/read/write routes — send unless the row says “—” |
+| **`x-api-key` + EIP‑191 personal sign** | Body includes **`signature`**, **`message`**, plus **`signer`** or **`signerAddress`** depending on route |
+
+API keys may also be validated via **`validateRequest`** (allowed origins + key). Assume **`Content-Type: application/json`** on POST/PATCH/DELETE bodies.
+
+---
+
+<a id="empire-id-base_token"></a>
+
+## Empire ID (`base_token`)
+
+Many parameters labeled **`tokenAddress`** or **`baseToken`** mean **Empire ID**, not always an ERC‑20:
+
+| Kind | Example |
+|------|---------|
+| Token empire | `0x` + 40 hex |
+| Farcaster tokenless | `fid` + digits |
+| Custom tokenless slug | alphanumeric slug from product rules |
+
+**SmartVault address** = **`empire_address`** from empire payloads — distinct from Empire ID.
+
+Resolve empire rows via **`GET /api/empires/[empire_id]`** (`empire_id` path segment = Empire ID).
+
+---
+
+## Endpoint catalog
+
+### Reads (typical)
+
+| Method | Path | Auth |
+|--------|------|------|
+| GET | `/api/top-empires` | — |
+| GET | `/api/empires` | — |
+| GET | `/api/empires/[empire_id]` | — |
+| GET | `/api/empires/search?q=` | — |
+| GET | `/api/empires/owner/[wallet]` | — |
+| GET | `/api/empires/ranking` | — |
+| GET | `/api/empires/check` | — |
+| GET | `/api/leaderboards?tokenAddress=<empire_id>` | — |
+| GET | `/api/leaderboards/[id]` | — |
+| GET | `/api/leaderboards/consolidated?tokenAddress=` | — |
+| GET | `/api/boosters/[address]` | — |
+| GET | `/api/staking-boosters/[address]` | — |
+| GET | `/api/empires/activate-staking?tokenAddress=` | — |
+| GET | `/api/empire-rewards/[token]` | — |
+| GET | `/api/empire-rewards/[token]/[type]` | — |
+| GET | `/api/rewards/recipients/[txHash]` | — |
+| GET | `/api/distribution-records/[empireAddress]` | — |
+| GET | `/api/airdrops/[tokenAddress]` | API key |
+| GET | `/api/empire-airdrop-total` | — |
+
+### Writes — distributions & accounting
+
+| Method | Path | Auth |
+|--------|------|------|
+| POST | `/api/distribute-prepare` | API key + sig (**signer = vault `owner()`**) |
+| POST | `/api/store-distribution` | API key |
+| POST | `/api/store-burn` | API key |
+| POST | `/api/store-airdrop` | API key |
+
+### Writes — deploy & empire lifecycle
+
+| Method | Path | Auth |
+|--------|------|------|
+| POST | `/api/get-token-config` | API key |
+| POST | `/api/deploy-empire` | API key + sig |
+| POST | `/api/deploy-empire-tokenless` | API key + sig |
+
+### Writes — leaderboards & boosters
+
+| Method | Path | Auth |
+|--------|------|------|
+| PATCH | `/api/leaderboards/refresh/[type]` | API key |
+| POST | `/api/leaderboards/[type]` | API key + sig |
+| POST | `/api/leaderboards/delete` | API key |
+| POST | `/api/boosters/[empire_id]` | API key + sig |
+| DELETE | `/api/boosters/[empire_id]` | API key + sig |
+| POST | `/api/staking-boosters/[empire_id]` | API key + sig |
+| DELETE | `/api/staking-boosters/[empire_id]` | API key + sig |
+| POST | `/api/empires/activate-staking` | API key + sig |
+
+---
+
+## Leaderboard create paths (`POST /api/leaderboards/...`)
+
+Creation is **never** a generic POST to `/api/leaderboards` alone — always a **type suffix**:
+
+| Type | Path suffix |
+|------|-------------|
+| Token holders | `tokenHoldersLeaderboards` |
+| Stakers (StakingLocker on Base / Arbitrum) | `stakersLeaderboards` |
+| NFT | `nftLeaderboards` |
+| External JSON API | `apiLeaderboards` |
+| CSV upload body | `csvLeaderboards` |
+| FarToken | `farTokenLeaderboards` |
+| Tipn | `tipnLeaderboards` |
+| Farcaster cast | `farcasterCastLeaderboards` |
+| Farcaster channel | `farcasterChannelLeaderboards` |
+| Farcaster interaction | `farcasterInteractionLeaderboards` |
+| Quotient | `quotientLeaderboards` |
+
+Example: **`POST https://empirebuilder.world/api/leaderboards/csvLeaderboards`**
+
+### Auth + signing (all leaderboard creates)
+
+- Requires **API key + signature**.
+- **Signature fields are always**: `signature`, `message`, **`signerAddress`**.
+- The server verifies `verifyMessage({ address: signerAddress, message, signature })` and then checks the signer is a **guardian** of the empire:
+  - `signerAddress` must equal `empires.owner` **or** be included in `empires.co_emperors` for the target empire.
+- **Message format:** for leaderboard creates the backend **does not enforce a specific template**; it only verifies the signature against the provided `message`.
+
+**Recommended canonical message template (agent-side):**
+
+Use a consistent, human-readable message to make signatures auditable and easy to debug. Suggested format:
+
+```text
+Empire Builder — Create Leaderboard
+type: <leaderboard_path_suffix>
+empireId: <tokenAddress>
+name: <name>
+timestamp: <ISO-8601>
+nonce: <random-uuid>
+```
+
+Notes:
+
+- `leaderboard_path_suffix`: e.g. `csvLeaderboards`, `tokenHoldersLeaderboards`, `farcasterChannelLeaderboards`
+- Include `timestamp` + `nonce` to reduce replay risk and make logs unambiguous (server currently does not enforce these, but they help operators).
+
+### `POST /api/leaderboards/tokenHoldersLeaderboards`
+
+Creates a “token holders” leaderboard for an empire. **`tokenAddress` is the Empire ID** (base token or tokenless ID), and **`erc20Address` is the ERC‑20 you’re ranking**.
+
+**Request body schema (JSON):**
+
+```json
+{
+  "tokenAddress": "<empire_id>",
+  "erc20Address": "0x...",
+  "erc20ChainId": 8453,
+  "erc20Name": "optional string",
+  "erc20Symbol": "optional string",
+  "erc20ImageUrl": "optional string",
+  "applyBoosters": true,
+  "signature": "0x...",
+  "message": "plain text that was signed",
+  "signerAddress": "0xGuardian"
+}
+```
+
+**Required fields:** `tokenAddress`, `erc20Address`, `signature`, `message`, `signerAddress`.
+
+Working example:
+
+```json
+{
+  "tokenAddress": "fid123",
+  "erc20Address": "0x1111111111111111111111111111111111111111",
+  "erc20ChainId": 8453,
+  "applyBoosters": true,
+  "signature": "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "message": "Create token holders leaderboard for fid123 ranking 0x1111111111111111111111111111111111111111",
+  "signerAddress": "0x2222222222222222222222222222222222222222"
+}
+```
+
+### `POST /api/leaderboards/stakersLeaderboards`
+
+Creates a "stakers" leaderboard ranked by on-chain stake in the immutable **StakingLocker** contract. **`tokenAddress` is the Empire ID**, and **`erc20Address` is the ERC‑20 you're ranking by stake**. Available on Base (`8453`) and Arbitrum (`42161`) only.
+
+The empire's strip auto-creates this when a guardian calls `POST /api/empires/activate-staking`, but the route can be invoked directly for any ERC‑20 the contract has stakers for.
+
+**Request body schema (JSON):**
+
+```json
+{
+  "tokenAddress": "<empire_id>",
+  "erc20Address": "0x...",
+  "erc20ChainId": 8453,
+  "erc20Name": "optional string",
+  "erc20Symbol": "optional string",
+  "erc20ImageUrl": "optional string",
+  "applyBoosters": true,
+  "applyReputationBoosters": true,
+  "applyStakingBoosters": true,
+  "signature": "0x...",
+  "message": "plain text that was signed",
+  "signerAddress": "0xGuardian"
+}
+```
+
+**Required fields:** `tokenAddress`, `erc20Address`, `signature`, `message`, `signerAddress`.
+
+Notes:
+
+- Reads stakers + balances directly from the StakingLocker (paginated `getStakersPage`).
+- Boosters apply additively on top of staked balance: token, reputation, and STAKING boosters (capped at +5x for the staking portion).
+- Refresh via `PATCH /api/leaderboards/refresh/stakersLeaderboards`.
+
+### `POST /api/leaderboards/csvLeaderboards`
+
+Creates a custom leaderboard from an explicit list of address→score rows. **`tokenAddress` is the Empire ID** (supports tokenless).
+
+**Request body schema (JSON):**
+
+```json
+{
+  "tokenAddress": "<empire_id>",
+  "name": "string (≤ 20 chars)",
+  "description": "string (≤ 180 chars)",
+  "csvEntries": [{ "address": "0x...", "score": 1.23 }],
+  "applyBoosters": true,
+  "apply_reputation_boosters": true,
+  "icon": "optional string",
+  "signature": "0x...",
+  "message": "plain text that was signed",
+  "signerAddress": "0xGuardian"
+}
+```
+
+**Required fields:** `tokenAddress`, `name`, `description`, `signature`, `message`, `signerAddress`. (`csvEntries` is required for a useful leaderboard; invalid entries are rejected server-side.)
+
+Working example:
+
+```json
+{
+  "tokenAddress": "0x3333333333333333333333333333333333333333",
+  "name": "Top 10",
+  "description": "Manual scores.",
+  "csvEntries": [
+    { "address": "0x4444444444444444444444444444444444444444", "score": 10 },
+    { "address": "0x5555555555555555555555555555555555555555", "score": 5.5 }
+  ],
+  "applyBoosters": true,
+  "apply_reputation_boosters": true,
+  "icon": "https://example.com/icon.png",
+  "signature": "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "message": "Create CSV leaderboard Top 10 for 0x3333333333333333333333333333333333333333",
+  "signerAddress": "0x2222222222222222222222222222222222222222"
+}
+```
+
+### `POST /api/leaderboards/nftLeaderboards`
+
+Creates a leaderboard based on NFT ownership checks.
+
+- **`tokenAddress` must be an ERC‑20 address** (tokenless empires are not accepted for this type).
+- **`nftAddress` is required**. `tokenId` is optional (used for ERC‑1155 / specific series).
+
+**Request body schema (JSON):**
+
+```json
+{
+  "tokenAddress": "0x...",
+  "name": "string (≤ 20 chars)",
+  "description": "string (≤ 180 chars)",
+  "nftAddress": "0x...",
+  "tokenId": "optional string|number",
+  "chainId": 8453,
+  "nftImage": "optional string",
+  "applyBoosters": true,
+  "apply_reputation_boosters": true,
+  "signature": "0x...",
+  "message": "plain text that was signed",
+  "signerAddress": "0xGuardian"
+}
+```
+
+**Required fields:** `tokenAddress`, `name`, `description`, `nftAddress`, `signature`, `message`, `signerAddress`.
+
+Working example:
+
+```json
+{
+  "tokenAddress": "0x3333333333333333333333333333333333333333",
+  "name": "NFT Holders",
+  "description": "Holders of the collection.",
+  "nftAddress": "0x6666666666666666666666666666666666666666",
+  "chainId": 8453,
+  "applyBoosters": true,
+  "apply_reputation_boosters": true,
+  "signature": "0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "message": "Create NFT leaderboard for 0x3333333333333333333333333333333333333333 using 0x6666666666666666666666666666666666666666",
+  "signerAddress": "0x2222222222222222222222222222222222222222"
+}
+```
+
+### `POST /api/leaderboards/apiLeaderboards`
+
+Creates a leaderboard by fetching and parsing an external JSON API.
+
+- **`tokenAddress` must be an ERC‑20 address** (tokenless empires are not accepted for this type).
+- `apiEndpoint` must be a valid URL.
+- `privateKey` exists in the request body but is **unused** server-side.
+
+**Request body schema (JSON):**
+
+```json
+{
+  "tokenAddress": "0x...",
+  "name": "string (≤ 20 chars)",
+  "description": "string (≤ 180 chars)",
+  "apiEndpoint": "https://example.com/leaderboard.json",
+  "applyBoosters": true,
+  "apply_reputation_boosters": true,
+  "icon": "optional string",
+  "signature": "0x...",
+  "message": "plain text that was signed",
+  "signerAddress": "0xGuardian",
+  "privateKey": "optional string (unused)"
+}
+```
+
+**Required fields:** `tokenAddress`, `name`, `description`, `apiEndpoint`, `signature`, `message`, `signerAddress`.
+
+Working example:
+
+```json
+{
+  "tokenAddress": "0x3333333333333333333333333333333333333333",
+  "name": "API Scores",
+  "description": "Pulled from our API.",
+  "apiEndpoint": "https://example.com/scores.json",
+  "applyBoosters": true,
+  "apply_reputation_boosters": true,
+  "signature": "0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "message": "Create API leaderboard for 0x3333333333333333333333333333333333333333 using https://example.com/scores.json",
+  "signerAddress": "0x2222222222222222222222222222222222222222"
+}
+```
+
+### `POST /api/leaderboards/farTokenLeaderboards`
+
+Creates a FarToken leaderboard.
+
+- **`tokenAddress` must be an ERC‑20 address** (tokenless empires are not accepted for this type).
+
+**Request body schema (JSON):**
+
+```json
+{
+  "tokenAddress": "0x...",
+  "name": "string (≤ 20 chars)",
+  "description": "string (≤ 180 chars)",
+  "applyBoosters": true,
+  "apply_reputation_boosters": true,
+  "signature": "0x...",
+  "message": "plain text that was signed",
+  "signerAddress": "0xGuardian"
+}
+```
+
+Working example:
+
+```json
+{
+  "tokenAddress": "0x3333333333333333333333333333333333333333",
+  "name": "FarToken",
+  "description": "FarToken scores.",
+  "applyBoosters": true,
+  "apply_reputation_boosters": true,
+  "signature": "0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  "message": "Create FarToken leaderboard for 0x3333333333333333333333333333333333333333",
+  "signerAddress": "0x2222222222222222222222222222222222222222"
+}
+```
+
+### `POST /api/leaderboards/tipnLeaderboards`
+
+Creates a TIPN leaderboard (NFT-driven; similar payload to `nftLeaderboards`).
+
+- **`tokenAddress` must be an ERC‑20 address** (tokenless empires are not accepted for this type).
+- **`nftAddress` is required**.
+
+**Request body schema (JSON):**
+
+```json
+{
+  "tokenAddress": "0x...",
+  "name": "string (≤ 20 chars)",
+  "description": "string (≤ 180 chars)",
+  "nftAddress": "0x...",
+  "tokenId": "optional string|number",
+  "chainId": 8453,
+  "nftImage": "optional string",
+  "applyBoosters": true,
+  "apply_reputation_boosters": true,
+  "signature": "0x...",
+  "message": "plain text that was signed",
+  "signerAddress": "0xGuardian"
+}
+```
+
+Working example:
+
+```json
+{
+  "tokenAddress": "0x3333333333333333333333333333333333333333",
+  "name": "TIPN",
+  "description": "TIPN eligibility.",
+  "nftAddress": "0x6666666666666666666666666666666666666666",
+  "chainId": 8453,
+  "applyBoosters": true,
+  "apply_reputation_boosters": true,
+  "signature": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "message": "Create TIPN leaderboard for 0x3333333333333333333333333333333333333333 using 0x6666666666666666666666666666666666666666",
+  "signerAddress": "0x2222222222222222222222222222222222222222"
+}
+```
+
+### `POST /api/leaderboards/farcasterCastLeaderboards`
+
+Creates a leaderboard based on engagement with a specific cast.
+
+- **`tokenAddress` is the Empire ID** (supports tokenless).
+- `castScoreIncludes` defaults each field to `true` unless explicitly set to `false`. At least one include must be enabled.
+
+**Request body schema (JSON):**
+
+```json
+{
+  "tokenAddress": "<empire_id>",
+  "name": "string (≤ 20 chars)",
+  "description": "string (≤ 180 chars)",
+  "castHash": "string",
+  "castScoreIncludes": { "likes": true, "recasts": true, "comments": true, "quotes": true },
+  "applyBoosters": true,
+  "apply_reputation_boosters": true,
+  "icon": "optional string",
+  "signature": "0x...",
+  "message": "plain text that was signed",
+  "signerAddress": "0xGuardian"
+}
+```
+
+Working example:
+
+```json
+{
+  "tokenAddress": "fid123",
+  "name": "Cast",
+  "description": "Engagement leaderboard.",
+  "castHash": "0xabc123",
+  "castScoreIncludes": { "likes": true, "recasts": true, "comments": true, "quotes": false },
+  "applyBoosters": true,
+  "apply_reputation_boosters": true,
+  "signature": "0x11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111",
+  "message": "Create cast leaderboard for fid123 cast 0xabc123",
+  "signerAddress": "0x2222222222222222222222222222222222222222"
+}
+```
+
+### `POST /api/leaderboards/farcasterChannelLeaderboards`
+
+Creates a leaderboard from Farcaster channel activity.
+
+- **`tokenAddress` is the Empire ID** (supports tokenless).
+- `filterType`: `"images"` or `"all"` (defaults to `"all"`).
+- `minNeynarScore`: clamped to \([0, 1]\) (defaults to `0`).
+- `timeframeDays`: one of `7 | 14 | 30 | 90 | 180 | 365` (defaults to `30`).
+
+**Request body schema (JSON):**
+
+```json
+{
+  "tokenAddress": "<empire_id>",
+  "name": "string (≤ 20 chars)",
+  "description": "string (≤ 180 chars)",
+  "channelId": "string",
+  "filterType": "all",
+  "minNeynarScore": 0,
+  "timeframeDays": 30,
+  "applyBoosters": true,
+  "apply_reputation_boosters": true,
+  "icon": "optional string",
+  "signature": "0x...",
+  "message": "plain text that was signed",
+  "signerAddress": "0xGuardian"
+}
+```
+
+Working example:
+
+```json
+{
+  "tokenAddress": "fid123",
+  "name": "Channel",
+  "description": "Channel leaderboard.",
+  "channelId": "base",
+  "filterType": "images",
+  "minNeynarScore": 0.2,
+  "timeframeDays": 30,
+  "applyBoosters": true,
+  "apply_reputation_boosters": true,
+  "signature": "0x22222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222222",
+  "message": "Create channel leaderboard for fid123 channel base",
+  "signerAddress": "0x2222222222222222222222222222222222222222"
+}
+```
+
+### `POST /api/leaderboards/farcasterInteractionLeaderboards`
+
+Creates a leaderboard based on interactions by a Farcaster user (likes, recasts, replies) over a lookback window.
+
+- **`tokenAddress` is the Empire ID** (supports tokenless).
+- `farcasterInput` may be an `fid` (numeric string) or a username (optionally prefixed with `@`).
+- `timeframeDays` allowed: `30 | 60 | 90 | 180 | 365` (defaults to `30` if omitted/invalid).
+
+**Request body schema (JSON):**
+
+```json
+{
+  "tokenAddress": "<empire_id>",
+  "name": "string (≤ 20 chars)",
+  "description": "string (≤ 180 chars)",
+  "farcasterInput": "string",
+  "timeframeDays": 30,
+  "applyBoosters": true,
+  "apply_reputation_boosters": true,
+  "icon": "optional string",
+  "signature": "0x...",
+  "message": "plain text that was signed",
+  "signerAddress": "0xGuardian"
+}
+```
+
+Working example:
+
+```json
+{
+  "tokenAddress": "fid123",
+  "name": "Interactions",
+  "description": "Interacted-with users.",
+  "farcasterInput": "@vitalik",
+  "timeframeDays": 90,
+  "applyBoosters": true,
+  "apply_reputation_boosters": true,
+  "signature": "0x33333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333333",
+  "message": "Create interaction leaderboard for fid123 for @vitalik (90d)",
+  "signerAddress": "0x2222222222222222222222222222222222222222"
+}
+```
+
+### `POST /api/leaderboards/quotientLeaderboards`
+
+Creates a Quotient leaderboard (requires a `leaderboardName` selector).
+
+- **`tokenAddress` must be an ERC‑20 address** (tokenless empires are not accepted for this type).
+
+**Request body schema (JSON):**
+
+```json
+{
+  "tokenAddress": "0x...",
+  "name": "string (≤ 20 chars)",
+  "description": "string (≤ 180 chars)",
+  "leaderboardName": "string",
+  "applyBoosters": true,
+  "apply_reputation_boosters": true,
+  "icon": "optional string",
+  "signature": "0x...",
+  "message": "plain text that was signed",
+  "signerAddress": "0xGuardian"
+}
+```
+
+Working example:
+
+```json
+{
+  "tokenAddress": "0x3333333333333333333333333333333333333333",
+  "name": "Quotient",
+  "description": "Quotient leaderboard.",
+  "leaderboardName": "top_users",
+  "applyBoosters": true,
+  "apply_reputation_boosters": true,
+  "signature": "0x44444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444444",
+  "message": "Create quotient leaderboard top_users for 0x3333333333333333333333333333333333333333",
+  "signerAddress": "0x2222222222222222222222222222222222222222"
+}
+```
+
+---
+
+## Leaderboard refresh paths (`PATCH /api/leaderboards/refresh/...`)
+
+| Leaderboard kind | `[type]` segment |
+|-------------------|------------------|
+| Token holders | `tokenHoldersLeaderboards` |
+| Stakers | `stakersLeaderboards` |
+| NFT | `nftLeaderboards` |
+| API | `apiLeaderboards` |
+| CSV | `csvLeaderboards` |
+| Far token | `farTokenLeaderboards` |
+| Tipn | `tipnLeaderboards` |
+| Farcaster cast / channel / interaction | matching `farcaster*Leaderboards` |
+| Quotient | `quotientLeaderboards` |
+| Legacy holders slot | `holdersLeaderboards` |
+
+Typical body (exact schema enforced server-side):
+
+```json
+{
+  "leaderboardId": "<uuid>",
+  "tokenAddress": "<empire_id>"
+}
+```
+
+Cool-down (~30s) applies per leaderboard.
+
+---
+
+## `POST /api/distribute-prepare`
+
+Builds payout batches: reads leaderboard (`leaderboardId`: **`"main"`** or custom UUID), splits **`selectedTokenAddresses`** balances across Base + Arbitrum, returns **`transactions[]`**. Returned calldata is meant for vault **`executeBatch`** once broadcast by **`owner()`** on the integration path (see [`contracts.md`](./contracts.md)).
+
+**Auth:** API key + EIP‑191 fields — **`signer`** must be **`owner()`** on the vault. **Co-signers** cannot pass this check and must use the **product UI** (sponsored **`executeBatch`** UserOps) instead of self-broadcasting prepare output.
+
+Representative body:
+
+```json
+{
+  "treasuryAddress": "0xVault",
+  "baseToken": "<empire_id>",
+  "selectedTokenAddresses": ["0xTokenA"],
+  "distributionMode": "even",
+  "leaderboardId": "main",
+  "distributePercentage": 100,
+  "recipientCount": 100,
+  "signature": "0x…",
+  "message": "plain text that was signed",
+  "signer": "0xOwner"
+}
+```
+
+Modes: **`even`**, **`weighted`**, **`raffle`** (optional **`raffleWinnerCount`**).
+
+**Response:** includes **`transactions`** — each item has **`chainId`**, vault **`contractAddress`**, **`calls`**, ABI-encoded **`data`** for **`executeBatch`**.
+
+### Transaction submission expectations (agent-ready)
+
+The response is intentionally redundant: you can submit each transaction using either:
+
+- **`calls`**: ABI-encode `executeBatch(calls)` client-side.
+- **`data`**: send the already-encoded calldata directly.
+
+Both represent the same call. The server also includes `functionName: "executeBatch"` and `value: "0"` (native ETH to send).
+
+**Required fields per transaction item:**
+
+- `chainId`: chain to broadcast on (e.g. `8453` Base, `42161` Arbitrum)
+- `batchIndex`: 0-based index within that chain’s batches
+- `contractAddress`: the SmartVault address (same as `treasuryAddress`/`empireAddress`)
+- `value`: `"0"` (string)
+- `calls`: array of `{ target, value, data }` where `value` is a string integer (wei)
+- `data`: full calldata for `executeBatch(calls)`
+
+**Ordering rules:**
+
+- Broadcast transactions **per chain** in ascending `batchIndex` order.
+- Within a transaction’s `calls[]`, preserve the order exactly as returned.
+
+**Detecting success/failure:**
+
+- A batch is **successful** when the transaction is mined and the receipt has `status === 1`.
+- A batch is **failed** if it reverts (receipt `status === 0`) or never gets mined.
+- Only call `POST /api/store-distribution` after you have the mined hashes for the batches you consider “done” (typically: all batches across all chains).
+
+Does **not** charge web “TX credits” — credits attach to sponsored **`executeBatch`** UserOp flows inside the product UI.
+
+**Broadcasting:** The EOA that sends each **`executeBatch`** tx to the vault must be able to authorize it on-chain — only **`owner()`** for direct calls. Co-signer EOAs reverts **`Unauthorized`** if they try the same calldata as a normal transaction. Confirm **`chainId`**, vault **`contractAddress`**, and that **`calls`/`data`** match the prepare response before sending.
+
+---
+
+<a id="post-apistore-distribution"></a>
+
+## `POST /api/store-distribution`
+
+Record confirmed **`executeBatch`** txs after prepare. The server **anchors** this record to **mined** transactions you supply in **`transactionHashes`** (with **`chainId`**): distribution accounting is **derived from on-chain execution** (receipts), not from re-trusting the prepare response as the ground truth for token movements. You still supply **`empireAddress`**, **`baseToken`** (Empire ID), and leaderboard discriminator fields so the event **attributes** correctly; wrong metadata can mis-label an otherwise valid chain tx. Wrong **`executeBatch`** remains irreversible on-chain regardless of store.
+
+```json
+{
+  "transactionHashes": [{ "hash": "0x…", "chainId": 8453 }],
+  "empireAddress": "0xVault",
+  "baseToken": "<empire_id>",
+  "distributionMode": "weighted",
+  "leaderboardType": "main",
+  "leaderboardNumber": 0,
+  "empireDisplayName": "optional"
+}
+```
+
+**`baseToken`** here is Empire ID, **not** vault address. Duplicate hashes / stale txs may be skipped — exact behavior enforced server-side.
+
+---
+
+## `POST /api/store-burn`
+
+After a mined transaction whose receipt includes the empire base (or attached base) ERC‑20 **Transfer** to **`0x0`** / **`0x…dEaD`** — from any holder wallet, from the vault via **`owner()`** **`execute`**, or from a **UserOp** **`executeBatch`** in the web app:
+
+```json
+{
+  "transactionHash": "0x…",
+  "empireAddress": "0xVault",
+  "chainId": 8453
+}
+```
+
+---
+
+## `POST /api/get-token-config`
+
+Generates a Clanker v4 `tokenConfig` object server-side (including optional airdrop tree dump) for client-side deployment.
+
+**Auth:** API key (via `x-api-key` header or `api_key` query). No wallet signature is required by this route handler.
+
+**Request body schema (JSON):**
+
+```json
+{
+  "name": "string",
+  "symbol": "string",
+  "imageUrl": "string",
+  "creatorAddress": "0x...",
+
+  "vaultPercentage": 10,
+  "vaultDays": 180,
+
+  "poolType": "standard",
+  "feeType": "dynamic",
+  "initialMarketCap": 10,
+
+  "staticClankerFee": 1,
+  "staticPairedFee": 1,
+  "dynamicBaseFee": 1,
+  "dynamicMaxLpFee": 2.2,
+
+  "enableDevBuy": false,
+  "devBuyAmount": 0,
+
+  "enableAirdrop": false,
+  "airdropEntries": [{ "address": "0x...", "amount": 123 }],
+  "airdropLockupDays": 30,
+  "airdropVestingDays": 0,
+
+  "enableSniperFees": false,
+  "sniperFeeDuration": 15,
+
+  "tokenDescription": "string",
+  "socialTwitter": "string",
+  "socialFarcaster": "string",
+  "socialWebsite": "string",
+  "socialTelegram": "string"
+}
+```
+
+**Required fields:** `name`, `symbol`, `imageUrl`, `creatorAddress`.
+
+**Response (JSON):**
+
+```json
+{
+  "success": true,
+  "tokenConfig": { "name": "…", "symbol": "…", "tokenAdmin": "0x…", "image": "…", "pool": {}, "fees": {}, "rewards": {} },
+  "airdropTree": null
+}
+```
+
+Notes:
+- If `enableAirdrop` is `true`, `airdropLockupDays` must be `>= 1` or the server returns `400`.
+- When an airdrop is enabled and entries exist, the route returns `airdropTree` as `tree.dump()` separately from `tokenConfig`.
+
+---
+
+## `POST /api/deploy-empire`
+
+Registers an empire (deploys SmartVaults on Base + Arbitrum and stores the empire row).
+
+**Auth:** API key (via `validateRequest`). Wallet signature is required **only** for the “existing token” attach flow (no `txHash`).
+
+### Request body — Clanker “fresh deploy” flow (recommended)
+
+If `txHash` is provided, the server validates the transaction receipt (successful, creator match via `tx.from` or ERC-4337 log topic match) and enforces that the token deployment allocated 2000 bps LP rewards to the Empire reward wallet.
+
+```json
+{
+  "baseToken": "0xDeployedToken",
+  "name": "Empire display name",
+  "owner": "0xCreatorWallet",
+  "txHash": "0xDeployTxHash",
+  "chainId": 8453,
+  "clankerVersion": "clanker_v4",
+  "tokenInfo": { "symbol": "SYMB", "name": "Token Name", "logoURI": "https://..." },
+  "empireMetadata": {
+    "bio": "optional",
+    "website_url": "optional",
+    "twitter_url": "optional",
+    "warpcast_url": "optional",
+    "telegram_url": "optional"
+  }
+}
+```
+
+### Request body — “attach to existing token” flow (signature required)
+
+If `txHash` is **omitted**, `signature` and `message` are required and verified against `owner` on Base then Arbitrum.
+The backend auto-classifies token ownership using a clanker → zora → top-holder heuristic.
+
+```json
+{
+  "baseToken": "0xExistingToken",
+  "name": "Empire display name",
+  "owner": "0xGuardianWallet",
+  "signature": "0x...",
+  "message": "plain text to sign",
+  "tokenInfo": { "symbol": "SYMB", "name": "Token Name", "logoURI": "https://..." },
+  "chainId": 8453
+}
+```
+
+**Important:**
+- Never send `tokenType` in the body — requests containing `tokenType` are rejected (`400`).
+- `message` format is **not** server-enforced for this route; it only verifies `verifyMessage({ address: owner, message, signature })`.
+
+**Response:** includes `empireAddress`/`treasuryAddress`, per-chain deploy hashes, and an `empire` object.
+
+---
+
+## `POST /api/deploy-empire-tokenless`
+
+Creates a SmartVault-backed empire without an ERC-20 base token.
+
+**Auth:** API key + EIP-191 signature by `owner`.
+
+**Signature enforcement:** `message` must match **exactly** the template implemented in `src/utils/tokenless-deploy-message.ts`:
+
+- Farcaster mode:
+  - `I am deploying a tokenless Farcaster Empire with Farcaster ID {fid} and name {nameTrimmed}`
+- Custom mode:
+  - `I am deploying a custom tokenless Empire named {nameTrimmed}`
+
+**Request body schema (JSON):**
+
+```json
+{
+  "mode": "farcaster",
+  "owner": "0x...",
+  "name": "Display name (<=100 chars)",
+  "logoUri": "https://... (optional)",
+  "signature": "0x...",
+  "message": "exact template text",
+
+  "fid": 12345,
+  "farcasterUsername": "optional",
+  "bio": "optional (<=2000 chars)",
+
+  "website_url": "optional (custom mode only)",
+  "warpcast_url": "optional (custom mode only)",
+  "twitter_url": "optional (custom mode only)",
+  "telegram_url": "optional (custom mode only)"
+}
+```
+
+Notes:
+- `fid` is required when `mode === "farcaster"` and must match Neynar’s FID for `owner`.
+- Signature verification tries Base then Arbitrum.
+
+---
+
+## `POST /api/store-airdrop`
+
+Registers a Clanker launch airdrop (Merkle-claim style) after on-chain deployment.
+
+**Auth:** API key.
+
+**Request body schema (JSON):**
+
+```json
+{
+  "tokenAddress": "0x...",
+  "tokenName": "string",
+  "tokenSymbol": "string",
+  "creatorAddress": "0x...",
+  "airdropEntries": [{ "address": "0x...", "amount": 1000 }],
+  "lockupDays": 30,
+  "vestingDays": 0,
+  "totalAmount": 1500,
+  "deploymentTxHash": "0x...",
+  "merkleRoot": "0x... (optional)",
+  "airdropContractAddress": "0x... (optional)"
+}
+```
+
+Notes:
+- `tokenAddress`, `tokenName`, `creatorAddress`, `airdropEntries`, and `deploymentTxHash` are required.
+- The backend **rounds** entry amounts for storage: `amount > 0.1 → 1`, otherwise `0` (and zero-amount entries are not stored).
+
+---
+
+## Boosters
+
+### `GET /api/boosters/[empire_id]`
+
+Returns `{ boosters: Booster[] }` (and injects a default Quotient booster if missing).
+
+### `POST /api/boosters/[empire_id]` (add booster)
+
+**Auth:** API key + one of:
+- **Signature auth**: include `signature` + `message` + `signer`, and `signer` must be an empire guardian (owner or co-emperor), or
+- **Transaction auth**: include `txHash` (mint.club create flow). Server verifies the tx is recent (<= 2 minutes), successful, and the sender is a guardian.
+
+**Request body schema (JSON):**
+
+```json
+{
+  "booster": {
+    "type": "ERC20",
+    "contractAddress": "0x...",
+    "multiplier": 1.5,
+    "requirement": { "minAmount": "1" },
+    "tokenId": "1",
+    "chainId": 8453,
+    "custom_link": "https://..."
+  },
+  "signer": "0xGuardian",
+  "signature": "0x... (signature auth)",
+  "message": "plain text to sign (signature auth)",
+  "txHash": "0x... (tx auth; optional alternative)",
+  "tokenInfo": { "symbol": "optional", "name": "optional", "logoURI": "optional" }
+}
+```
+
+Validation notes:
+- `multiplier` must be between `1.1` and `5.0` and have **max one decimal place**.
+- For `booster.type === "NFT"`, ERC-1155 requires `tokenId` (except OG-dickbutt special case).
+
+### `DELETE /api/boosters/[empire_id]` (remove booster)
+
+**Auth:** API key + signature.
+
+```json
+{
+  "boosterId": "uuid",
+  "signature": "0x...",
+  "message": "plain text to sign",
+  "signer": "0xGuardian"
+}
+```
+
+**Note:** This route only manages ERC‑20 / NFT / QUOTIENT boosters. STAKING boosters use the dedicated `/api/staking-boosters/[empire_id]` route below — you cannot create or delete them through this endpoint.
+
+---
+
+## Native staking
+
+Native staking is opt-in per empire. Once activated, it's available on Base (`8453`) and Arbitrum (`42161`) and uses the immutable **StakingLocker** contract (read its address from `NEXT_PUBLIC_STAKING_LOCKER_<chainId>` envs / the `getStakingLockerAddress` helper).
+
+**Lock-up on-chain:** Users stake via `stake(token, amount, lockDuration)` with `lockDuration` in **seconds**, any value **`0` … `315_360_000`** (`0` = flexible; max = 10 years). The contract does not use preset month tiers — only `duration <= MAX_LOCK_DURATION`. STAKING booster `minLockupSeconds` filters stakes by **committed** lock length per position (`unlockTime - startTime` ≥ threshold). Full ABI notes: [`references/contracts.md` → StakingLocker](./contracts.md#stakinglocker-native-staking).
+
+### `POST /api/empires/activate-staking`
+
+Flips the empire's `staking_activated` flag and auto-creates a `stakers` leaderboard. **No on-chain transaction** — guardian signature only.
+
+**Auth:** API key + EIP‑191 signature. `signer` (request body) must be a guardian for the empire.
+
+**Canonical signed message** (the server reconstructs and verifies this exact string):
+
+```
+Activate staking for empire <empire_id_lowercase> at <timestamp_ms>
+```
+
+**Request body schema (JSON):**
+
+```json
+{
+  "tokenAddress": "<empire_id>",
+  "signer": "0xGuardian",
+  "signature": "0x...",
+  "timestamp": 1759353600000
+}
+```
+
+**Required fields:** `tokenAddress`, `signer`, `signature`, `timestamp`. `timestamp` must be within the last 5 minutes.
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "stakingToken": "0xDeployedErc20",
+  "chainId": 8453,
+  "leaderboardId": "uuid-of-auto-created-stakers-leaderboard"
+}
+```
+
+If staking was already on: `{ "success": true, "alreadyActive": true }`.
+
+### `GET /api/empires/activate-staking?tokenAddress=<empire_id>`
+
+Returns `{ staking_activated, stakingToken, chainId }` — used by the front-end to decide between "Stake" and "Activate Staking" buttons.
+
+### `GET /api/staking-boosters/[empire_id]`
+
+Returns `{ stakingBoosters: Booster[] }` — the same Booster shape as `GET /api/boosters/[empire_id]`, filtered to `type === "STAKING"`.
+
+### `POST /api/staking-boosters/[empire_id]` (add staking booster)
+
+**Auth:** API key + signature. `signer` must be a guardian. The empire must already have `staking_activated = true` — otherwise this returns `403`.
+
+**Request body schema (JSON):**
+
+```json
+{
+  "minStake": "1000",
+  "minLockupSeconds": 7776000,
+  "multiplier": 1.5,
+  "signer": "0xGuardian",
+  "signature": "0x...",
+  "message": "plain text to sign"
+}
+```
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `minStake` | string | Integer string in **wei** (18‑dec base units). Sums `amount` on stakes whose lock length ≥ `minLockupSeconds` (flexible → `0` sec; locked → `unlockTime - startTime`). Web app sends wei after converting whole-token input × `10^18`. |
+| `minLockupSeconds` | number | Any integer in **`[0, 315360000]`** (matches StakingLocker `MAX_LOCK_DURATION`). `0` = any lock qualifies (including flexible stakes). |
+| `multiplier` | number | `1.1` ≤ x ≤ `5.0`, **at most one decimal** |
+
+A user qualifies for the booster when their staked balance — restricted to stakes whose lock duration ≥ `minLockupSeconds` — is ≥ `minStake`. Multiple staking boosters stack additively, capped at +5x total from staking.
+
+Validation notes:
+
+- Booster cap is shared with ERC‑20 / NFT / QUOTIENT boosters.
+- Booster row stores `booster_type = "STAKING"`, `booster_address` = empire's deployed ERC‑20.
+
+**Response:** `{ stakingBoosters: Booster[], boosters: Booster[] }`.
+
+### `DELETE /api/staking-boosters/[empire_id]` (remove staking booster)
+
+**Auth:** API key + signature. Same guardian + activated-empire check.
+
+```json
+{
+  "boosterId": "uuid",
+  "signer": "0xGuardian",
+  "signature": "0x...",
+  "message": "plain text to sign"
+}
+```
+
+`boosterId` must reference a row with `booster_type = "STAKING"` for this empire — the route ignores other booster rows.
+
+**Response:** `{ stakingBoosters: Booster[], boosters: Booster[] }`.
+
+---
+
+## Signing spec (agent-ready)
+
+### Which field name?
+
+- **Most guardian writes:** use `signature`, `message`, and **`signerAddress`** (leaderboard create routes).
+- **Boosters:** uses `signer` (not `signerAddress`) in the handler.
+- **`distribute-prepare`:** uses `signer` and additionally requires the signer to equal `SmartVault.owner()`.
+
+### What is `message`?
+
+- Unless an endpoint explicitly enforces an exact template (currently **only** `deploy-empire-tokenless`), `message` can be any plain text.
+- Recommended pattern (to prevent replay confusion): include endpoint + empire id + a short nonce/timestamp, e.g.
+
+```text
+Empire Builder: create leaderboard for <empire_id> at 2026-04-30T00:00:00Z
+```
+
+### How to sign
+
+Use EIP-191 personal-sign.
+
+```ts
+const message = "…";
+const signature = await walletClient.signMessage({ message });
+```

--- a/empire-builder/references/workflows.md
+++ b/empire-builder/references/workflows.md
@@ -1,0 +1,143 @@
+# Empire Builder — End-to-End Workflows
+
+Companion to [`SKILL.md`](../SKILL.md). Routes + payloads also spelled out in [`http-api.md`](./http-api.md).
+
+**Base URL:** `https://empirebuilder.world` — Base `8453` and Arbitrum `42161` mainnet only (see [`SKILL.md`](../SKILL.md#intentional-product-behavior)).
+
+---
+
+## Workflow 1 — Launch Clanker token + Empire
+
+1. **`POST /api/get-token-config`** with API key (**no wallet signature**) → **`tokenConfig`**, **`rpcUrl`**.
+2. **`Clanker.deploy(tokenConfig)`** via a wallet the **operator controls**, using pinned **`clanker-sdk`** / **`viem`** versions from [`SKILL.md` frontmatter](../SKILL.md) (not `@latest`).
+3. **`POST /api/deploy-empire`** — **`baseToken`**, **`owner`**, **`tokenInfo`**, **`txHash`** from deploy, **`chainId`** (`8453` / `42161`). Receipt validates LP wiring when native.
+4. **`GET /api/empires/<empire_id>`** → read **`empire_address`** (vault), **`base_token`**, metadata.
+5. Optional leaderboards: **`POST /api/leaderboards/<type>`** (guardian-signed JSON; signature fields use **`signerAddress`**).
+6. Optional refresh: **`PATCH /api/leaderboards/refresh/<type>`** with API key (`leaderboardId` + `tokenAddress` empire id).
+
+---
+
+## Workflow 2 — Attach Empire to existing token
+
+1. Prove custody off-chain/on-chain per backend checks.
+2. **`POST /api/deploy-empire`** — guardian signature pattern; **omit** `tokenType` input field — backend chooses **`token_type`**.
+
+---
+
+## Workflow 3 — Treasury distribution (integration path)
+
+1. **`GET /api/leaderboards?tokenAddress=<empire_id>`** → choose **`leaderboardId`** UUID **or** literal **`"main"`** default tab resolution.
+2. **`POST /api/distribute-prepare`** — API key + **`signature`/`message`/`signer`** where **`signer`** is **`owner()`** vault address.
+3. Iterate **`transactions[]`** in **`batchIndex`** order per **`chainId`**: submit **`executeBatch`** on **`contractAddress`** using supplied **`calls`** or raw **`data`** — caller pays gas. Confirm **`chainId`**, vault **`contractAddress`**, and calldata match the prepare response before broadcasting.
+4. **`POST /api/store-distribution`** — API key + mined **`transactionHashes`** array + **`empireAddress`** + **`baseToken` empire id** + leaderboard discriminator fields. The backend **derives** distribution accounting from those **mined** txs (receipts), not from prepare JSON alone; still **verify** metadata matches the vault and empire you intended.
+
+Batch submit checklist (per `transactions[]` item):
+
+- Use the given **`chainId`** + **`contractAddress`**.
+- **Verify** `chainId` is `8453` or `42161`, and **`contractAddress`** matches `GET /api/empires/[empire_id]`; compare recipients and amounts to the prepare payload.
+- Call `executeBatch` with either:
+  - the provided `calls[]` (encode client-side), **or**
+  - the provided `data` (already ABI-encoded calldata).
+- Submit batches in ascending `batchIndex` order **per chain**.
+- **Operator** wallet signs and broadcasts (or tooling it controls).
+- Consider a batch successful only when mined and the receipt has `status === 1`.
+
+Do **not** substitute legacy **`distribute-v3`** endpoints or random **`/alchemy-sponsor-userop`** helpers unless explicitly debugging **website** flows — integration uses prepare + self-broadcast + store.
+
+---
+
+## Workflow 4 — Register airdrop metadata
+
+1. Finish merkle / contract deployment using whatever launch pipeline applies.
+2. **`POST /api/store-airdrop`** with API key — attach **`tokenAddress`**, deployment proofs, recipient roots/lists per backend validation.
+
+---
+
+## Workflow 5 — Fund treasury
+
+Transfer ERC‑20 (or native routing via wrapped ETH patterns) **to `empire_address`** from any wallet. Accounting surfaces via **`GET /api/empires/...`**, consolidated leaderboard reads, distribution prep balances — **do not assume undocumented PATCH treasury ledger endpoints.**
+
+---
+
+## Workflow 6 — Tracked burn
+
+1. On-chain: include an ERC‑20 **Transfer** of the empire **base** (or attached base) to **`0x000…0000`** or **`0x000…dEaD`** (e.g. wallet **`transfer`**, or vault **`owner()`** **`execute`** / **`executeBatch`**, or vault **co-signer** path in the web app: sponsored UserOp **`executeBatch`** with the same inner transfer/burn encoding).
+2. **`POST /api/store-burn`** with **`transactionHash`**, **`empireAddress`**, **`chainId`** — server decodes the receipt.
+
+Co-signers **cannot** mint that transfer by calling **`execute`** / **`executeBatch`** on the vault directly; use the **website** (Base / Arbitrum UserOp flow) or burn from a wallet that already holds the tokens.
+
+---
+
+## Workflow 7 — Boosters
+
+1. **`GET /api/boosters/[vaultOrTokenContext]`** — inspect multipliers.
+2. **`POST /api/boosters/[empire_id]`** — add booster (API key + guardian-signed payload).
+3. **`DELETE /api/boosters/[empire_id]`** — remove booster entry.
+
+This route only manages ERC‑20 / NFT / QUOTIENT boosters. STAKING boosters live behind a dedicated CRUD — see Workflow 8.
+
+---
+
+## Workflow 8 — Native staking + STAKING boosters
+
+Available on Base (`8453`) and Arbitrum (`42161`). The StakingLocker is immutable; activation is a single DB flag plus an auto-created leaderboard.
+
+1. **Activate staking** (guardian-only, no on-chain tx):
+
+   ```text
+   POST /api/empires/activate-staking
+   { tokenAddress, signer, signature, timestamp }
+   ```
+
+   Sign the **exact** canonical message:
+
+   ```text
+   Activate staking for empire <empire_id_lowercase> at <timestamp_ms>
+   ```
+
+   The route flips `empires.staking_activated = true`, auto-creates a `stakers` leaderboard, and returns `{ stakingToken, chainId, leaderboardId }`.
+
+2. **Inspect activation state** at any time:
+   **`GET /api/empires/activate-staking?tokenAddress=<empire_id>`** → `{ staking_activated, stakingToken, chainId }`.
+
+3. **List existing staking boosters**: **`GET /api/staking-boosters/[empire_id]`**.
+
+4. **Add a staking booster** (guardian-signed):
+
+   ```text
+   POST /api/staking-boosters/[empire_id]
+   { minStake (whole tokens, string), minLockupSeconds, multiplier, signer, signature, message }
+   ```
+
+   - `minLockupSeconds` is any integer in **`[0, 315360000]`** (same upper bound as StakingLocker’s `MAX_LOCK_DURATION`). Guardians often pick a value that matches a **committed** stake lock (`unlockTime - startTime` per position), but the API does **not** require fixed month tiers — e.g. `7776000` (90 days) is illustrative only.
+   - `multiplier` ∈ `[1.1, 5.0]`, at most one decimal.
+   - Counts against the empire's per-empire booster cap.
+
+5. **Remove a staking booster**:
+
+   ```text
+   DELETE /api/staking-boosters/[empire_id]
+   { boosterId, signer, signature, message }
+   ```
+
+6. **Stakers leaderboard**:
+   - Create explicitly with **`POST /api/leaderboards/stakersLeaderboards`** (`erc20Address` + `erc20ChainId` are required; staking auto-create already gave you one for the empire token).
+   - Refresh with **`PATCH /api/leaderboards/refresh/stakersLeaderboards`** (same `{ leaderboardId, tokenAddress }` shape; same 30s cooldown as other refresh routes).
+
+7. **Side-effects on existing leaderboards** once staking is active:
+   - `tokenHolders` and `farToken` refresh routes fold staked balances into Ankr-derived holder balances before scoring.
+   - **Every** refresh route (`api`, `csv`, `nft`, `tipn`, `farcasterCast`, `farcasterChannel`, `farcasterInteraction`, `quotient`, `holders`) applies STAKING-booster multipliers additively when `leaderboard.apply_staking_boosters !== false` (defaults to true).
+   - The contributing staking-multiplier portion is capped at **+5x** total per user.
+
+---
+
+## Signing matrix
+
+| Step | Requirement |
+|------|-------------|
+| Leaderboard mutators (`POST /api/leaderboards/*`, boosters add/remove) | Guardian signature bundle; signature fields use **`signerAddress`** for leaderboards, and **`signer`** for boosters |
+| `activate-staking` | Guardian signature bundle; `signer`. **Canonical message is template-checked** — `Activate staking for empire <id_lower> at <timestamp_ms>` |
+| `staking-boosters` add/remove | Guardian signature bundle; `signer`. Empire must have `staking_activated = true` |
+| `distribute-prepare` | **`signer`** must equal on-chain **`owner()`** — not co-signer |
+| Direct `executeBatch` to vault (integration) | **EOA tx** must be from **`owner()`** — same calldata from co-signer EOA reverts **`Unauthorized`**. |
+| `store-distribution` / `store-burn` | API key only (no fresh signature unless backend adds) |


### PR DESCRIPTION
## Summary

Adds the Empire Builder skill for SmartVault community treasuries on Base (8453) and Arbitrum (42161). Covers HTTP APIs for empires, leaderboards, boosters, burns, airdrops, and token → deploy-empire flows, plus the owner-signed prepare → executeBatch → store-distribution payout pipeline.

## Example prompts

- “How do I distribute treasury rewards to our main leaderboard holders on Base? We have two ERC-20s in the vault.”
- “I want to launch a token and wire it up as an Empire on Base. How do I do it?”
- "We have an empire on Base, I want to pay out to the top 100 holders on the staking leaderboard."

## Test checklist

- [x] Verified `SKILL.md` and `references/*.md` links
- [x] Skill folder matches Bankr structure
- [x] Agent smoke test: 12/12 prompts answered from local references (distribution, deploy, burns, boosters, co-signer rules)
- [x] README Available Skills table updated