### PR TITLE
feat(birdbets): add BirdBets prediction market skill

### DIFF
--- a/birdbets/birdbets-market/SKILL.md
+++ b/birdbets/birdbets-market/SKILL.md
@@ -16,6 +16,7 @@ BirdBets is a Base prediction market. Each market asks whether bird visits will 
 
 - Fetch machine-readable context first: `https://birdbets.mykclawd.xyz/api/bankr/context`
 - Fetch canonical market data next: `https://birdbets.mykclawd.xyz/api/markets/snapshot?market=Tomorrow`
+- Prepare bets with `https://birdbets.mykclawd.xyz/api/base-mcp/prepare/bet?from=<wallet>&side=<YES|NO>&stake=<amount>`
 - For today's stats, use `https://birdbets.mykclawd.xyz/api/markets/snapshot?market=Today` and `https://birdbets.mykclawd.xyz/api/birdbuddy/visits?days=7`
 - For full workflow detail, read `references/workflows.md`.
 - For contract constants and ABI fragments, read `references/contracts.md`.
@@ -28,10 +29,12 @@ Before placing a bet:
 2. Require an explicit MYKCLAWD amount.
 3. Fetch the Tomorrow snapshot and verify `market.exists === true`, `market.resolved === false`, and `market.isOpen === true`.
 4. Explain the threshold, current odds, pools, and payout preview to the user before submitting transactions.
-5. Check the Bankr wallet's MYKCLAWD balance and allowance.
-6. If the wallet needs MYKCLAWD, swap only enough on Base for the requested bet plus a small cushion.
-7. Approve the prediction market contract to spend the bet amount if allowance is insufficient.
-8. Call `betYes(marketId, amountWei)` or `betNo(marketId, amountWei)` on the prediction market contract.
+5. Call the bet preparation endpoint `GET /api/base-mcp/prepare/bet?from=<wallet>&side=<YES|NO>&stake=<amount>` to get pre-encoded `approve` and `betYes`/`betNo` transactions. Never encode contract calldata manually — the market ID is a `uint256` integer and the contract has separate `betYes`/`betNo` functions.
+6. If the wallet needs MYKCLAWD, swap only enough on Base for the requested bet plus a small cushion, then call the prepare endpoint again.
+7. Submit the returned `transactions` in order, using their exact `to`, `data`, `value`, and `chainId`.
+8. After the bet confirms, reply with the BirdBets share link from the prepare response (`share.url`) so the user sees the share image for the side, amount, market date, and threshold they just bet on.
+
+If the prepare endpoint is unavailable, fall back to manual `approve` + `betYes(marketId, amountWei)` / `betNo(marketId, amountWei)` using `references/contracts.md`.
 
 Never call BirdBets oracle or admin endpoints. They are not for bettors.
 

--- a/birdbets/birdbets-market/SKILL.md
+++ b/birdbets/birdbets-market/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: birdbets-market
+description: Bet on BirdBets prediction markets, read odds and payout previews, acquire MYKCLAWD on Base, and summarize BirdBuddy market stats.
+tags: [trading, defi, base, prediction-markets, birdbets]
+version: 1
+visibility: public
+---
+
+# BirdBets Market
+
+Use this skill when the user asks about BirdBets, BirdBuddy bird visit markets, MYKCLAWD betting, tomorrow's YES/NO market, odds, payouts, or today's market stats.
+
+BirdBets is a Base prediction market. Each market asks whether bird visits will be greater than the threshold. YES wins when `actualVisits > threshold`; NO wins when `actualVisits <= threshold`.
+
+## Primary Sources
+
+- Fetch machine-readable context first: `https://birdbets.mykclawd.xyz/api/bankr/context`
+- Fetch canonical market data next: `https://birdbets.mykclawd.xyz/api/markets/snapshot?market=Tomorrow`
+- For today's stats, use `https://birdbets.mykclawd.xyz/api/markets/snapshot?market=Today` and `https://birdbets.mykclawd.xyz/api/birdbuddy/visits?days=7`
+- For full workflow detail, read `references/workflows.md`.
+- For contract constants and ABI fragments, read `references/contracts.md`.
+
+## Betting Rules
+
+Before placing a bet:
+
+1. Require an explicit side: `YES` or `NO`.
+2. Require an explicit MYKCLAWD amount.
+3. Fetch the Tomorrow snapshot and verify `market.exists === true`, `market.resolved === false`, and `market.isOpen === true`.
+4. Explain the threshold, current odds, pools, and payout preview to the user before submitting transactions.
+5. Check the Bankr wallet's MYKCLAWD balance and allowance.
+6. If the wallet needs MYKCLAWD, swap only enough on Base for the requested bet plus a small cushion.
+7. Approve the prediction market contract to spend the bet amount if allowance is insufficient.
+8. Call `betYes(marketId, amountWei)` or `betNo(marketId, amountWei)` on the prediction market contract.
+
+Never call BirdBets oracle or admin endpoints. They are not for bettors.
+
+## Read-Only Mode
+
+If the Bankr API key or wallet session is read-only, provide odds, payout previews, and market stats only. Do not attempt swaps, approvals, or bets.
+
+## Safety
+
+- Use Base mainnet unless the context endpoint says otherwise.
+- Use the prediction market and token addresses from the context endpoint.
+- Do not hardcode secrets, API keys, private keys, oracle secrets, or admin secrets.
+- Do not bet on a missing, resolved, or closed market.
+- If the snapshot endpoint is unavailable, fall back to direct on-chain reads using `references/contracts.md`.

--- a/birdbets/birdbets-market/references/contracts.md
+++ b/birdbets/birdbets-market/references/contracts.md
@@ -1,0 +1,147 @@
+# BirdBets Contracts
+
+Fetch `https://birdbets.mykclawd.xyz/api/bankr/context` before using these values. The context endpoint is canonical if it differs from this file.
+
+## Chain
+
+- Chain: Base mainnet
+- Chain ID: `8453`
+
+## MYKCLAWD Token
+
+- Symbol: `MYKCLAWD`
+- Decimals: `18`
+- Address: `0xE3C5FCfBfea42D5CE2492FD82c239B5503f17ba3`
+
+## Market IDs
+
+Market IDs use `YYYYMMDD` in the BirdBets timezone, for example `20260527`.
+
+Prefer the `marketIds.today` and `marketIds.tomorrow` values from `/api/bankr/context`.
+
+## ERC-20 ABI
+
+```json
+[
+  {
+    "type": "function",
+    "name": "balanceOf",
+    "stateMutability": "view",
+    "inputs": [{ "name": "account", "type": "address" }],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "allowance",
+    "stateMutability": "view",
+    "inputs": [
+      { "name": "owner", "type": "address" },
+      { "name": "spender", "type": "address" }
+    ],
+    "outputs": [{ "name": "", "type": "uint256" }]
+  },
+  {
+    "type": "function",
+    "name": "approve",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      { "name": "spender", "type": "address" },
+      { "name": "value", "type": "uint256" }
+    ],
+    "outputs": [{ "name": "", "type": "bool" }]
+  }
+]
+```
+
+## Prediction Market ABI
+
+```json
+[
+  {
+    "type": "function",
+    "name": "markets",
+    "stateMutability": "view",
+    "inputs": [{ "name": "marketId", "type": "uint256" }],
+    "outputs": [
+      { "name": "exists", "type": "bool" },
+      { "name": "resolved", "type": "bool" },
+      { "name": "date", "type": "string" },
+      { "name": "threshold", "type": "uint256" },
+      { "name": "yesPool", "type": "uint256" },
+      { "name": "noPool", "type": "uint256" },
+      { "name": "createdAt", "type": "uint256" },
+      { "name": "bettingClosesAt", "type": "uint256" },
+      { "name": "resolvedAt", "type": "uint256" },
+      { "name": "actualVisits", "type": "uint256" },
+      { "name": "winningSide", "type": "uint8" }
+    ]
+  },
+  {
+    "type": "function",
+    "name": "oddsBps",
+    "stateMutability": "view",
+    "inputs": [{ "name": "marketId", "type": "uint256" }],
+    "outputs": [
+      { "name": "yesBps", "type": "uint256" },
+      { "name": "noBps", "type": "uint256" }
+    ]
+  },
+  {
+    "type": "function",
+    "name": "positions",
+    "stateMutability": "view",
+    "inputs": [
+      { "name": "marketId", "type": "uint256" },
+      { "name": "bettor", "type": "address" }
+    ],
+    "outputs": [
+      { "name": "yesAmount", "type": "uint256" },
+      { "name": "noAmount", "type": "uint256" },
+      { "name": "claimed", "type": "bool" },
+      { "name": "exists", "type": "bool" }
+    ]
+  },
+  {
+    "type": "function",
+    "name": "betYes",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      { "name": "marketId", "type": "uint256" },
+      { "name": "amount", "type": "uint256" }
+    ],
+    "outputs": []
+  },
+  {
+    "type": "function",
+    "name": "betNo",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      { "name": "marketId", "type": "uint256" },
+      { "name": "amount", "type": "uint256" }
+    ],
+    "outputs": []
+  }
+]
+```
+
+## Market Tuple
+
+`markets(marketId)` returns:
+
+1. `exists`
+2. `resolved`
+3. `date`
+4. `threshold`
+5. `yesPool`
+6. `noPool`
+7. `createdAt`
+8. `bettingClosesAt`
+9. `resolvedAt`
+10. `actualVisits`
+11. `winningSide`
+
+`winningSide` values:
+
+- `0`: none
+- `1`: YES
+- `2`: NO

--- a/birdbets/birdbets-market/references/workflows.md
+++ b/birdbets/birdbets-market/references/workflows.md
@@ -1,0 +1,116 @@
+# BirdBets Workflows
+
+These workflows assume a Bankr wallet on Base mainnet.
+
+## Get Context
+
+Fetch:
+
+```text
+GET https://birdbets.mykclawd.xyz/api/bankr/context
+```
+
+Use this response for chain ID, market contract address, MYKCLAWD token address, token decimals, endpoint URLs, and the current Today/Tomorrow market IDs.
+
+If the context endpoint returns no `contracts.predictionMarket`, stop and explain that BirdBets has not published a prediction market address.
+
+## Read Tomorrow Odds And Payouts
+
+Fetch:
+
+```text
+GET https://birdbets.mykclawd.xyz/api/markets/snapshot?market=Tomorrow
+```
+
+To preview a bet, include `side` and `stake`:
+
+```text
+GET https://birdbets.mykclawd.xyz/api/markets/snapshot?market=Tomorrow&side=YES&stake=10
+GET https://birdbets.mykclawd.xyz/api/markets/snapshot?market=Tomorrow&side=NO&stake=10
+```
+
+Report:
+
+- `market.threshold`
+- `market.isOpen`
+- `market.yesPoolFormatted`, `market.noPoolFormatted`, and `market.totalPoolFormatted`
+- `odds.yesPercent` and `odds.noPercent`
+- `payoutPreview.estimatedPayoutFormatted`, `estimatedProfitFormatted`, and `estimatedProfitPercent` when present
+- `market.bettingClosesAtIso`
+
+If `odds.historyUnavailableReason` is present, explain that historical odds are unavailable but current on-chain odds may still be valid.
+
+## Bet YES Or NO On Tomorrow
+
+Inputs required from the user:
+
+- Side: `YES` or `NO`
+- Amount: human-readable MYKCLAWD, for example `10`
+
+Workflow:
+
+1. Fetch context.
+2. Fetch Tomorrow snapshot with `side` and `stake`.
+3. Confirm `market.exists`, `!market.resolved`, and `market.isOpen`.
+4. Convert amount to wei using `bettingToken.decimals`.
+5. Check Bankr wallet MYKCLAWD balance with ERC-20 `balanceOf(wallet)`.
+6. If balance is below the amount, acquire MYKCLAWD on Base using Bankr swap tooling. Swap only enough for the requested bet plus a small cushion for rounding/slippage.
+7. Check allowance with ERC-20 `allowance(wallet, predictionMarket)`.
+8. If allowance is below the amount, submit `approve(predictionMarket, amountWei)`.
+9. Submit the market transaction:
+   - YES: `betYes(marketId, amountWei)`
+   - NO: `betNo(marketId, amountWei)`
+10. Return the transaction hash and summarize the resulting side, amount, market date, and threshold.
+
+Do not place a bet if the user has not explicitly chosen side and amount.
+
+## Acquire MYKCLAWD
+
+Use Bankr's swap capability on Base. Prefer swapping from the wallet's most liquid available Base asset into MYKCLAWD.
+
+Before swapping:
+
+- Fetch context for the MYKCLAWD address.
+- Check whether the wallet already has enough MYKCLAWD.
+- Avoid swapping more than needed for the intended bet plus a small cushion.
+
+After swapping:
+
+- Re-check `balanceOf(wallet)`.
+- Continue to approval and betting only if the requested amount is available.
+
+## Get Today's Market Stats
+
+Fetch:
+
+```text
+GET https://birdbets.mykclawd.xyz/api/markets/snapshot?market=Today
+GET https://birdbets.mykclawd.xyz/api/birdbuddy/visits?days=7
+```
+
+Summarize:
+
+- Today's market ID and date
+- Threshold and current bird visit count
+- Whether YES is currently ahead based on current visits
+- Current YES/NO odds and pools
+- Recent visit history
+- Whether betting is open, closed, or resolved
+
+Remember: the live BirdBuddy count may lag actual feeder activity.
+
+## Fallback If Snapshot Fails
+
+If `/api/markets/snapshot` fails:
+
+1. Fetch `/api/bankr/context`.
+2. Compute the market ID from the context response if present, or use `YYYYMMDD` in the BirdBets timezone.
+3. Read the prediction market contract directly:
+   - `markets(marketId)`
+   - `oddsBps(marketId)`
+4. For payout preview, use post-bet pools:
+   - `sidePoolAfter = sidePoolBefore + stake`
+   - `totalPoolAfter = yesPool + noPool + stake`
+   - `estimatedPayout = stake * totalPoolAfter / sidePoolAfter`
+
+If direct chain reads fail too, stop and explain that market state is unavailable.

--- a/birdbets/birdbets-market/references/workflows.md
+++ b/birdbets/birdbets-market/references/workflows.md
@@ -49,20 +49,32 @@ Inputs required from the user:
 
 Workflow:
 
-1. Fetch context.
-2. Fetch Tomorrow snapshot with `side` and `stake`.
-3. Confirm `market.exists`, `!market.resolved`, and `market.isOpen`.
-4. Convert amount to wei using `bettingToken.decimals`.
-5. Check Bankr wallet MYKCLAWD balance with ERC-20 `balanceOf(wallet)`.
-6. If balance is below the amount, acquire MYKCLAWD on Base using Bankr swap tooling. Swap only enough for the requested bet plus a small cushion for rounding/slippage.
-7. Check allowance with ERC-20 `allowance(wallet, predictionMarket)`.
-8. If allowance is below the amount, submit `approve(predictionMarket, amountWei)`.
-9. Submit the market transaction:
-   - YES: `betYes(marketId, amountWei)`
-   - NO: `betNo(marketId, amountWei)`
-10. Return the transaction hash and summarize the resulting side, amount, market date, and threshold.
+1. Identify the Bankr wallet address (`from`).
+2. Call the bet preparation endpoint:
 
+```text
+GET https://birdbets.mykclawd.xyz/api/base-mcp/prepare/bet?from=<wallet>&side=<YES|NO>&stake=<amount>
+```
+
+3. If the response has `ok: false`, surface `error` to the user and stop.
+4. If `wallet.balance` is below `bet.stake`, acquire MYKCLAWD on Base using Bankr swap tooling first (swap only the requested amount plus a small slippage cushion), then call the prepare endpoint again.
+5. Submit each transaction in the `transactions` array **in order**, using the exact `to`, `data`, `value`, and `chainId` from each entry. Do not re-encode or modify the calldata.
+6. After the bet transaction confirms, reply to the user with `share.url` from the prepare response so the BirdBets share image renders inline. See "Share The Bet" below.
+7. Summarize `bet.side`, `bet.stakeFormatted`, `market.marketDate`, and `market.threshold` from the response alongside the transaction hash.
+
+Do not build or encode contract calldata manually — the prepare endpoint handles `approve` and `betYes`/`betNo` encoding. If the prepare endpoint is unavailable, fall back to manual `approve` + `betYes(marketId, amountWei)` / `betNo(marketId, amountWei)` using `references/contracts.md`.
 Do not place a bet if the user has not explicitly chosen side and amount.
+
+## Share The Bet
+
+The bet preparation response includes a `share` object — the same share link the BirdBets web app uses for posting to X/Twitter:
+
+- `share.url` — the BirdBets share page. Posting it unfurls into the bet's share image card (side, amount, market date, threshold). Prefer this so the card renders with title and description.
+- `share.image` — the direct share image (`/og/bet.png`) if you need the raw PNG.
+- `share.text` — suggested share copy.
+- `share.twitterUrl` — a ready-to-use X/Twitter intent link.
+
+After a bet succeeds, reply to the user with `share.url` so they immediately see the share image for the bet they just placed.
 
 ## Acquire MYKCLAWD
 


### PR DESCRIPTION
## BirdBets Market Skill

Adds the `birdbets/birdbets-market` skill for Bankr agents to interact with [BirdBets](https://birdbets.mykclawd.xyz) — a prediction market on Base where users bet MYKCLAWD tokens on whether more than N birds will visit a BirdBuddy smart bird feeder on a given day.

## Capabilities

- **Read market odds & payout previews** — fetch tomorrow's YES/NO odds, pool sizes, and estimated payout for any stake amount
- **Get today's stats** — current bird visit count vs threshold, recent visit history, market status
- **Acquire MYKCLAWD** — swap to MYKCLAWD on Base via Bankr's native swap tooling
- **Place bets** — approve + call `betYes` or `betNo` on the BirdBets prediction market contract

## Use Cases

- "What are the odds on BirdBets tomorrow?"
- "Bet 10 MYKCLAWD YES on BirdBets"
- "How many birds visited the feeder today?"
- "Show me BirdBets market stats"

## Dependencies

- Base mainnet wallet (for bets/swaps)
- Public BirdBets APIs at `birdbets.mykclawd.xyz` (no API key required for reads)
- MYKCLAWD token (`0xE3C5FCfBfea42D5CE2492FD82c239B5503f17ba3`) on Base

## Files

- `SKILL.md` — agent instructions, betting rules, and safety guardrails
- `references/workflows.md` — step-by-step workflows for each capability
- `references/contracts.md` — contract addresses, ABIs, and market tuple reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)