### PR TITLE
Add codegrid skill — multi-agent coding canvas for macOS

### DIFF
--- a/codegrid/SKILL.md
+++ b/codegrid/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: codegrid
+description: >-
+  CodeGrid is a native macOS canvas where multiple coding agents (Claude, Codex,
+  Gemini, Cursor, Grok, shells) run side by side in panes and collaborate via a
+  local agent bus — no tmux, no cloud, no account, no stored API keys. Install
+  this skill when an agent should know how to operate inside a CodeGrid pane,
+  drive the workspace from outside (control socket or codegrid:// deep links),
+  spawn or message sibling agents, or coordinate multi-agent work (delegate,
+  review, pipeline, parallel fan-out, monitor, debate). The differentiator:
+  multiple coding agents collaborating on one canvas, addressable by stable
+  session_id, with a read → message → read protocol built for orchestration.
+metadata:
+  product: CodeGrid
+  vendor: ZipLyne LLC
+  homepage: https://codegrid.app
+  docs: https://codegrid.app/docs
+  token: $GRID (Base, 0x6B456E66524aEC1792013eF9DFE87e3F84311ba3)
+  version: 1
+---
+
+# CodeGrid — agent operating manual
+
+CodeGrid runs many coding agents side by side on an infinite 2D canvas. Each
+pane is one process (`claude`, `codex`, `gemini`, `cursor-agent`, `grok`, or a
+shell) with its own working directory, git branch, and stable `session_id`. The
+agent bus lets any pane discover, read, and message any other pane locally.
+
+This skill is the umbrella entry point. Two references cover the full surface:
+
+- **[Operating CodeGrid](./references/using-codegrid.md)** — the mental model
+  (canvas / pane / workspace / agent / bus), MCP tools (`list_agents`,
+  `read_pane`, `message_agent`), the control-socket JSON-RPC API
+  (`agent_list`, `agent_read`, `agent_send`, `open_folder`, `new_session`,
+  `new_workspace`), the `codegrid://` deep-link scheme, and an operating
+  playbook with recipes.
+
+- **[Agent-bus collaboration](./references/codegrid-agent-bus.md)** — the
+  `read → message → read` protocol, identifying agents by role and
+  `session_id`, orchestration patterns (delegate, review, pipeline, parallel
+  fan-out, monitor, debate), etiquette and scope safety, loop/runaway
+  prevention, failure recovery, and worked end-to-end examples.
+
+## When to load which reference
+
+| You're about to… | Load |
+|---|---|
+| Discover what's running, open a folder, spawn a session, or drive CodeGrid from outside | `using-codegrid` |
+| Hand work to / consult / review with another agent already running in CodeGrid | `codegrid-agent-bus` |
+| Both | Load `using-codegrid` first, then `codegrid-agent-bus` |
+
+## Quickstart (inside a CodeGrid pane)
+
+```text
+list_agents()                                  # discover panes (session_id, role, status)
+read_pane(<session_id>)                        # see what they're doing — always safe
+message_agent(<session_id>, "[from <you>] <self-contained request>")
+… wait, then read_pane(<session_id>) for the reply.
+```
+
+## Quickstart (from outside CodeGrid, e.g. another tool)
+
+```bash
+SOCK="$(cat ~/.codegrid/socket-path 2>/dev/null || echo ~/.codegrid/socket)"
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"agent_list"}' | nc -U "$SOCK"
+
+# Or deep-link the installed app:
+open "codegrid://open?path=/abs/path/to/repo&type=codex"
+open "codegrid://new"
+```
+
+## Install
+
+```text
+install the codegrid skill from https://github.com/BankrBot/skills/tree/main/codegrid
+```
+
+## Source
+
+- Canonical source of truth lives in the CodeGrid repo under `skills/`
+  (`skills/using-codegrid/SKILL.md`, `skills/codegrid-agent-bus/SKILL.md`).
+  This Bankr Skills provider is a published copy kept in sync.
+- App download + full docs: <https://codegrid.app>.
+- Token (Base): `0x6B456E66524aEC1792013eF9DFE87e3F84311ba3` —
+  see <https://codegrid.app/token>.
+
+## Safety defaults an agent should respect
+
+- **Read before you write.** `read_pane` is free; never message a busy agent.
+- **Address by `session_id`**, never pane number — pane numbers shift.
+- **Be explicit about scope.** Other agents may be in YOLO/autonomous mode and
+  will act on whatever you send. Say "propose only, do not edit files" when you
+  want analysis.
+- **One message, then wait.** Multiple messages interleave into the target's
+  input box and corrupt it.
+- **Bound debates and don't spawn unbounded helpers.** Converge and report to
+  the user.
+- **Stay local.** Everything is same-machine IPC; there is no remote bus.
+
+Full guidance: see the two reference files.

--- a/codegrid/references/codegrid-agent-bus.md
+++ b/codegrid/references/codegrid-agent-bus.md
@@ -1,0 +1,225 @@
+---
+name: codegrid-agent-bus
+description: >-
+  How to collaborate with other AI agents running in CodeGrid using the
+  codegrid-agent-bus MCP tools (list_agents, read_pane, message_agent). Use this
+  skill whenever the user asks you to delegate to, consult, coordinate with,
+  review with, hand work to, or get a second opinion from another agent
+  ("ask Codex to…", "have Gemini review…", "get the other agent to…",
+  "split this up between the agents"). Covers the read→message→read protocol,
+  identifying agents, orchestration patterns (delegate, review, pipeline,
+  parallel fan-out, monitor, debate), etiquette, scope/safety, loop prevention,
+  failure recovery, and worked end-to-end examples.
+metadata:
+  product: CodeGrid
+  vendor: ZipLyne LLC
+  homepage: https://codegrid.app/agent-bus
+  docs: https://codegrid.app/docs/agent-bus
+  version: 2
+---
+
+# Collaborating with other agents in CodeGrid
+
+You are running inside **CodeGrid**, where multiple coding agents (Claude,
+Codex, Gemini, Cursor, Grok, shells) run side by side, each in its own pane. The
+**Agent Bus** lets you talk to the others — natively, over CodeGrid's local
+socket, with **no tmux**. This skill teaches you to do it *well*: not just the
+tools, but the protocol, the etiquette, and the orchestration patterns that
+make multi-agent work actually productive instead of chaotic.
+
+> Core principle: **you are an orchestrator, not a spammer.** Read first, send
+> one clear request, wait, read the reply, converge, and report to the user.
+
+---
+
+## 1. Your tools
+
+| Tool | Signature | Notes |
+|------|-----------|-------|
+| `list_agents` | `() → [{ session_id, pane_number, command, status, working_dir }]` | Discover who's available. `command` tells you the role (claude/codex/gemini/cursor/grok/…). `status` ∈ running, idle, waiting, error, dead. |
+| `read_pane` | `(session_id, max_bytes?) → text` | Recent output, ANSI-stripped, ~last 40 lines. **Always safe** — read freely. |
+| `message_agent` | `(session_id, text, submit?) → ok` | Types `text` into the target's pane; `submit` defaults to **true** (presses Enter so it acts). Set `submit:false` to stage a draft without sending. |
+
+**The `session_id` is the address.** Never target a pane by number or by
+guessing — pane numbers shift, `session_id` is stable. Get it from `list_agents`.
+
+---
+
+## 2. The protocol — read → message → read
+
+Every interaction follows the same loop. Skipping a step is the #1 cause of
+garbled, unproductive multi-agent sessions.
+
+1. **List.** `list_agents` → find the target by role (its `command`) and grab
+   its `session_id`. Confirm it isn't `dead`.
+2. **Read first.** `read_pane(target)` → make sure it's idle/ready and you
+   understand its current state. Don't talk over a busy agent.
+3. **Message once.** `message_agent(target, text)` with a **clear, self-
+   contained** request. Include:
+   - who you are (`[from Claude]`),
+   - exactly what you want done,
+   - the expected output and any constraints ("reply with a bullet list",
+     "propose only, don't edit files", "reply DONE when finished").
+4. **Wait, then read.** Give the agent time to think and work. Re-`read_pane`
+   after a pause to collect the reply. If it's still working, **read again** —
+   do **not** send another message.
+
+```text
+list_agents() → target = the "codex" pane, session acc7bc6d-…
+read_pane(acc7bc6d-…)                      # idle, ready
+message_agent(acc7bc6d-…,
+  "[from Claude] Review src/auth.ts for security issues. Reply with a short
+   bullet list of findings, ranked by severity. Do not edit any files.")
+… wait …
+read_pane(acc7bc6d-…)                      # collect the findings
+→ report to the user / act on them
+```
+
+---
+
+## 3. Identifying agents
+
+- **By role:** match the `command` field — `claude`, `codex`, `gemini`,
+  `cursor-agent`, `grok`. If several panes share a role, disambiguate by `working_dir`
+  or pane number, then keep using the `session_id`.
+- **Yourself:** you usually appear in `list_agents` too. Don't message yourself.
+- **No other agents?** If the list shows only you, there's nobody to collaborate
+  with — tell the user to open another agent pane (`⌘N`) and stop.
+
+---
+
+## 4. Orchestration patterns
+
+### Delegate (hand off a task)
+You stay the lead; another agent does a unit of work.
+```text
+read_pane(codex) → message_agent(codex, "Implement X. Reply DONE + a summary.")
+→ poll read_pane(codex) until DONE → verify → report.
+```
+
+### Review / second opinion
+Finish your own change, then have another model critique it.
+```text
+message_agent(gemini, "Review this approach: <paste/describe>. List risks and a
+better alternative if you see one. Don't change files.") → read → apply judgment.
+```
+
+### Pipeline (chained hand-offs)
+Specialize roles; each hand-off is its own read→message→read.
+```text
+Gemini researches the API → you implement → Codex reviews the diff.
+```
+
+### Parallel fan-out + gather
+Kick off independent subtasks on different agents, then collect.
+```text
+message_agent(codex, "Do subtask A. Reply DONE-A when finished.")
+message_agent(gemini, "Do subtask B. Reply DONE-B when finished.")
+… periodically read_pane each … gather both results → synthesize.
+```
+Use **git worktrees** (one per agent) so parallel file edits don't collide.
+
+### Monitor
+Watch a long-running build/test/shell pane and react.
+```text
+read_pane(shell) → if it shows a failing test, fix it (or delegate the fix).
+```
+
+### Debate / consensus (use sparingly)
+Ask two agents the same question, compare, and you decide. Cap it at one round
+each — do **not** let them argue back and forth unbounded (see §6).
+
+---
+
+## 5. Etiquette & scope safety
+
+- **One message, then wait.** Multiple messages before a reply interleave into
+  the target's input box and corrupt it. Patience beats spam.
+- **Be explicit about scope.** Many agents run in **autonomous / YOLO mode** and
+  will *act* on whatever you send — including editing files or running commands.
+  If you only want analysis, say **"propose only — do not edit files or run
+  anything."** If you want action, say so and define "done."
+- **Hand off context, not just a command.** The other agent doesn't share your
+  conversation. Include the file paths, the goal, and constraints in the message.
+- **Prefer `read_pane` when unsure.** Observing is always safe; messaging changes
+  another agent's state.
+- **Use `submit:false`** when you want to place text for the user to review/edit
+  before it runs.
+- **Respect the user's machine.** Don't instruct another agent to run
+  destructive commands (`rm -rf`, force-push, credential access) on your own
+  initiative.
+
+---
+
+## 6. Loop & runaway prevention (critical)
+
+Multi-agent setups can ping-pong forever or fork-bomb work. Guard against it:
+
+- **Converge and report.** Your job is to reach a result and tell the **user** —
+  not to keep two agents talking indefinitely.
+- **If an agent might message you back**, don't reflexively reply. Decide whether
+  another round adds value; usually it doesn't.
+- **Bound debates** to one round per side.
+- **Don't spawn unbounded helpers.** Delegate to existing panes; don't create new
+  agents in a loop.
+- **Set a step budget** in your own head (e.g. "at most 3 hand-offs"); if you're
+  not converging, summarize the state for the user and ask how to proceed.
+- **Detect stalls.** If `read_pane` shows no progress after a reasonable wait,
+  re-read once more, then report "agent X appears stuck" rather than nagging it.
+
+---
+
+## 7. Failure modes & recovery
+
+| Signal | Meaning | Do |
+|--------|---------|-----|
+| "Can't reach CodeGrid" | App not running / socket gone | Stop; tell the user CodeGrid must be open. |
+| `list_agents` shows only you | No collaborators | Tell the user to open another agent pane (`⌘N`). |
+| `message_agent` errors | Wrong/dead `session_id` | Re-run `list_agents`; the pane may have closed. |
+| Target `status: dead` | Process ended | Don't message it; tell the user (they can Restart the pane). |
+| Reply never appears | Agent is busy, waiting on a prompt, or off-track | Re-`read_pane` once; if it's stuck on a prompt, report it — don't keep sending. |
+| Garbled input in the target | You sent multiple messages | Stop; let it settle; read; resend one clean message. |
+
+---
+
+## 8. Anti-patterns (don't do these)
+
+- ❌ Messaging before reading the target's state.
+- ❌ Firing several messages in a row "to be safe."
+- ❌ Addressing by pane number instead of `session_id`.
+- ❌ Sending a bare command with no context or success criterion.
+- ❌ Letting two agents converse with no termination condition.
+- ❌ Telling another agent to do something destructive on your own initiative.
+- ❌ Assuming the other agent shares your memory/conversation.
+
+---
+
+## 9. Worked example — delegate + review
+
+> User: "Have Codex add an Export button, then check its work."
+
+```text
+1. list_agents()
+   → me (claude, pane 1), codex (acc7bc6d-…, pane 2, idle)
+2. read_pane(acc7bc6d-…)            # idle, at a prompt — ready
+3. message_agent(acc7bc6d-…,
+     "[from Claude] In this repo, add an 'Export' button to the toolbar that
+      downloads the current view as JSON. Implement it and reply 'DONE' with a
+      one-line summary of the files you changed.")
+4. … wait ~20–40s …
+   read_pane(acc7bc6d-…)            # "DONE — added ExportButton.tsx, wired onClick"
+5. (optional) read the changed files yourself / git diff, apply a fix if needed.
+6. Report to the user: what Codex did, your review, and the final state.
+```
+
+## 10. Combining with other CodeGrid features
+
+- **Broadcast (`⌘B`)** is *you → all panes*. The bus is *agent → agent*. Use
+  broadcast to fan a prompt out from yourself; use the bus to let agents
+  coordinate among themselves.
+- **Worktrees** keep parallel agents on separate branches — pair them with
+  fan-out so simultaneous edits never conflict.
+- For full control of the workspace (spawning panes, opening folders, the raw
+  socket), see the companion **`using-codegrid`** skill.
+
+Reference: <https://codegrid.app/docs/agent-bus>.

--- a/codegrid/references/using-codegrid.md
+++ b/codegrid/references/using-codegrid.md
@@ -1,0 +1,213 @@
+---
+name: using-codegrid
+description: >-
+  How an AI coding agent should operate inside CodeGrid — the macOS canvas that
+  runs Claude, Codex, Gemini, Cursor, Grok, and shells side by side and lets them
+  collaborate. Use this skill whenever you are running in a CodeGrid pane, or a
+  user asks you to spawn/list/control agents, open a project, drive the
+  workspace, or coordinate work across panes. Covers the local control socket
+  (agent_list / agent_read / agent_send, open_folder, new_session,
+  new_workspace), the codegrid:// deep-link scheme, the canvas/pane/workspace
+  model, and the operating playbook.
+metadata:
+  product: CodeGrid
+  vendor: ZipLyne LLC
+  homepage: https://codegrid.app
+  docs: https://codegrid.app/docs
+  version: 2
+---
+
+# Operating CodeGrid
+
+CodeGrid is a native macOS workspace where several coding agents run side by
+side, each in its own **pane** on an infinite 2D **canvas**. It is *local-first*:
+no cloud, no account, no stored API keys. Agents are launched as normal CLIs
+(`claude`, `codex`, `gemini`, `cursor-agent`, `grok`, or a shell) — CodeGrid does
+not wrap or replace them, so they behave exactly as they do in a terminal.
+
+This skill is your operating manual for **driving CodeGrid** — discovering what
+is running, reading and messaging other panes, and opening projects — both from
+inside a pane (via MCP tools) and from outside (via the local control socket or
+deep links).
+
+---
+
+## 1. Orientation: how to tell you're in CodeGrid
+
+You are very likely running inside CodeGrid if **any** of these hold:
+
+- The MCP server `codegrid-agent-bus` is connected (run `/mcp` to check). Its
+  tools — `list_agents`, `read_pane`, `message_agent` — are the primary way you
+  interact with sibling agents.
+- The control socket exists: `~/.codegrid/socket` (its path is also written to
+  `~/.codegrid/socket-path`).
+- You were started with a working directory chosen in CodeGrid's new-session
+  dialog.
+
+If the `codegrid-agent-bus` tools are **not** present but the user wants
+collaboration, tell them to enable it (onboarding → "Enable collaboration", or
+run `node <app>/Contents/Resources/resources/agent-bus-mcp.cjs setup`) and then
+open a **fresh** pane — tools load at pane start.
+
+---
+
+## 2. The mental model
+
+| Term | Meaning |
+|------|---------|
+| **Canvas** | An infinite 2D surface holding panes. Each workspace has its own. |
+| **Pane / Session** | One running process (an agent or shell) with a working dir, git branch, live terminal, and a stable `session_id`. The pane is its window. |
+| **Agent** | The CLI inside a session: `claude`, `codex`, `gemini`, `cursor`, `grok`, or a shell. |
+| **Workspace** | A named project context — its own panes, layout, and (optionally) bound repo. |
+| **Agent Bus** | The local channel that lets one agent read/message another's pane. |
+
+**Addressing rule:** always identify a target pane by its `session_id` (from
+`list_agents` / `agent_list`). Pane numbers can change; `session_id` is stable.
+
+---
+
+## 3. Primary interface — MCP tools (use these from inside a pane)
+
+If `codegrid-agent-bus` is connected, prefer these tools over raw sockets:
+
+- **`list_agents()`** → every pane: `session_id`, pane number, `command`,
+  `status` (`running` | `idle` | `waiting` | `error` | `dead`), working dir.
+  Call this first to discover who is available.
+- **`read_pane(session_id, max_bytes?)`** → recent output of a pane, ANSI-
+  stripped. Always safe (read-only). Default tail ~4000 bytes.
+- **`message_agent(session_id, text, submit?)`** → types `text` into the target
+  pane and (default `submit=true`) presses Enter so the agent acts on it.
+
+For deep collaboration patterns and etiquette, load the companion skill
+**`codegrid-agent-bus`**.
+
+---
+
+## 4. Control socket — the full reference (for scripts & external tools)
+
+CodeGrid serves a line-delimited JSON-RPC 2.0 API over a Unix domain socket.
+Same-machine only; the socket directory is `0700` (your user account).
+
+**Find it**
+
+```bash
+SOCK="$(cat ~/.codegrid/socket-path 2>/dev/null || echo ~/.codegrid/socket)"
+```
+
+**Call it** (one JSON object per line; one response line per request)
+
+```bash
+printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"ping"}' | nc -U "$SOCK"
+# → {"jsonrpc":"2.0","result":"pong","error":null,"id":1}
+```
+
+### Methods
+
+| Method | Params | Effect / Result |
+|--------|--------|-----------------|
+| `ping` | — | `"pong"`. Liveness check. |
+| `agent_list` | — | `{ agents: [{ id, pane_number, workspace_id, working_dir, command, git_branch, status, ... }] }` |
+| `agent_read` | `{ session_id, max_bytes? }` | `{ output }` — raw tail of the pane (contains ANSI; strip if needed). |
+| `agent_send` | `{ session_id, text, submit? }` | Writes `text` to the pane's stdin; if `submit` (default true), also sends Enter. `{ status: "ok" }`. |
+| `open_folder` | `{ path }` | Asks CodeGrid to open `path` (must be an existing dir). |
+| `new_session` | `{ path }` | Asks CodeGrid to start a new session at `path`. |
+| `new_workspace` | `{ name }` | Creates/focuses a workspace. |
+| `list_sessions` | — | Nudges the UI to surface the session list. |
+
+Errors come back as `{ "error": { "code", "message" }, "id" }` — e.g.
+`"Failed to write to session"` (bad/dead `session_id`),
+`"Session not found or has no output"`, `"Missing 'session_id'"`.
+
+### Robust one-shot client (Node, no deps)
+
+```js
+const net = require("net"), fs = require("fs"), os = require("os"), path = require("path");
+function sock() {
+  const f = path.join(os.homedir(), ".codegrid", "socket-path");
+  try { return fs.readFileSync(f, "utf8").trim(); } catch { return path.join(os.homedir(), ".codegrid", "socket"); }
+}
+function rpc(method, params = {}) {
+  return new Promise((res, rej) => {
+    const s = net.createConnection(sock()); let buf = "";
+    const t = setTimeout(() => { s.destroy(); rej(new Error("timeout")); }, 8000);
+    s.on("connect", () => s.write(JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }) + "\n"));
+    s.on("data", d => { buf += d; const i = buf.indexOf("\n"); if (i >= 0) { clearTimeout(t); s.destroy();
+      const m = JSON.parse(buf.slice(0, i)); m.error ? rej(new Error(m.error.message)) : res(m.result); } });
+    s.on("error", e => { clearTimeout(t); rej(new Error("CodeGrid not running? " + e.message)); });
+  });
+}
+// await rpc("agent_list"); await rpc("agent_send", { session_id, text, submit: true });
+```
+
+---
+
+## 5. Deep links — drive CodeGrid from anywhere
+
+CodeGrid registers the `codegrid://` URL scheme (installed app only):
+
+```bash
+open "codegrid://open?path=/abs/path/to/repo&type=codex"   # open a folder as a Codex session
+open "codegrid://new"                                       # open the new-session dialog
+```
+
+`type` accepts `claude` | `codex` | `gemini` | `cursor` | `grok` | `shell`. Use
+this for "Open in CodeGrid" buttons, scripts, and editor integrations.
+
+---
+
+## 6. Operating playbook (recipes)
+
+**Discover the workspace**
+```text
+list_agents → note each pane's session_id, command (role), and status.
+```
+
+**Read what another agent is doing (safe, non-disruptive)**
+```text
+read_pane(session_id) → inspect the tail before you act.
+```
+
+**Hand work to a sibling agent**
+```text
+1. list_agents → find the target (e.g. the `codex` pane).
+2. read_pane(target) → confirm it's idle/ready.
+3. message_agent(target, "[from <you>] <clear, self-contained request>").
+4. wait, then read_pane(target) for the reply.
+```
+(See the `codegrid-agent-bus` skill for the full collaboration protocol.)
+
+**Spin up a helper for the user**
+```text
+Prefer asking the user to press ⌘N (they see and place the pane). For automation,
+open_folder / new_session over the socket, or a codegrid:// deep link.
+```
+
+**Guide a human using CodeGrid** — key shortcuts to recommend:
+`⌘N` new agent · `⌘B` broadcast · `⌘K` command palette · `⌘⇧A` jump to the next
+agent needing attention · **AUTO**/**FIT** (top-right of the canvas) to tile or
+fit all panes.
+
+---
+
+## 7. Best practices & safety
+
+- **Address by `session_id`, never guess** a pane.
+- **Read before you write.** `read_pane` is free and prevents talking over a busy agent.
+- **Respect autonomy.** Other agents may be in autonomous/YOLO mode and will act
+  on what you send. Say "propose only / don't edit" when you only want analysis.
+- **The app must be running.** Socket/MCP calls fail with "Can't reach CodeGrid"
+  if it isn't — surface that to the user rather than retrying blindly.
+- **Stay local.** This is all same-machine IPC; there is no remote/cross-machine
+  bus. Don't assume network reachability.
+- **Don't spam.** One message, then wait and re-read — see the collaboration skill.
+
+## 8. When something's off
+
+| Symptom | Cause / fix |
+|---------|-------------|
+| `codegrid-agent-bus` tools missing | Pane started before install — enable collaboration, open a fresh pane. |
+| "Can't reach CodeGrid" | App not running, or socket stale — ensure CodeGrid is open. |
+| `agent_send` → "Failed to write" | Target `session_id` is wrong or its process ended; re-run `list_agents`. |
+| Only one pane visible to the user | Canvas is zoomed/panned — tell them to click **FIT** or **AUTO**. |
+
+Full reference: <https://codegrid.app/docs>.


### PR DESCRIPTION
## Summary

Adds a new `codegrid/` skill for **CodeGrid** — a native macOS canvas where multiple coding agents (Claude, Codex, Gemini, Cursor, Grok, shells) run side by side in panes and collaborate via a local agent bus. The differentiator: *multiple coding agents collaborating on one canvas*, addressable by stable `session_id`, with a `read → message → read` protocol built for orchestration.

- **Homepage:** https://codegrid.app
- **Token (Base):** `$GRID` — `0x6B456E66524aEC1792013eF9DFE87e3F84311ba3` ([token page](https://codegrid.app/token))
- **Launch:** https://bankr.bot/launches/0x6B456E66524aEC1792013eF9DFE87e3F84311ba3

## What's in the bundle

```
codegrid/
├── SKILL.md                              # umbrella — entry point
└── references/
    ├── using-codegrid.md                 # operating manual + control socket + deep links
    └── codegrid-agent-bus.md             # collaboration protocol + patterns + examples
```

- **`SKILL.md`** — umbrella with the differentiator front-loaded, install command, quickstarts for *inside a pane* (MCP tools: `list_agents`, `read_pane`, `message_agent`) and *outside CodeGrid* (control-socket JSON-RPC + `codegrid://` deep links), and safety defaults.
- **`references/using-codegrid.md`** — mental model (canvas / pane / workspace / agent / bus), MCP tools, full control-socket JSON-RPC API (`agent_list`, `agent_read`, `agent_send`, `open_folder`, `new_session`, `new_workspace`, `list_sessions`), the `codegrid://` URL scheme, and an operating playbook with recipes.
- **`references/codegrid-agent-bus.md`** — `read → message → read` protocol, orchestration patterns (delegate, review, pipeline, parallel fan-out, monitor, debate), etiquette & scope safety, loop/runaway prevention, failure-mode recovery, and worked end-to-end examples.

## Install

```text
install the codegrid skill from https://github.com/BankrBot/skills/tree/main/codegrid
```

## Example usage

Once installed, an agent running inside a CodeGrid pane can do:

```text
list_agents()                                       # discover sibling panes + roles
read_pane(<session_id>)                             # check state — always safe
message_agent(<session_id>,
  "[from Claude] Review src/auth.ts for security issues. Reply with a bullet
   list of findings, ranked by severity. Do not edit any files.")
… wait …
read_pane(<session_id>)                             # collect the reply
```

Or from outside CodeGrid (any tool / script):

```bash
SOCK="$(cat ~/.codegrid/socket-path 2>/dev/null || echo ~/.codegrid/socket)"
printf '%s\n' '{"jsonrpc":"2.0","id":1,"method":"agent_list"}' | nc -U "$SOCK"
open "codegrid://open?path=/abs/path/to/repo&type=codex"
```

## Test plan

- [x] `SKILL.md` validates with required `name` + `description` frontmatter
- [x] Layout matches the registry convention (`provider/SKILL.md` + optional `references/`)
- [x] Install URL resolves once merged
- [x] References documented in the umbrella
- [ ] Reviewer can install via the documented command and the agent can answer "what is CodeGrid?" / "how do I message another agent inside CodeGrid?"

Happy to iterate on the umbrella copy or split into sub-skills if the maintainers prefer that layout. Thanks!
