### PR TITLE
feat: add multimodal skill for image, meme, PFP and NFT generation

### DIFF
--- a/multimodal/README.md
+++ b/multimodal/README.md
@@ -1,0 +1,81 @@
+# Multimodal
+
+Executable scripts and workflows for image, meme, PFP, banner, and visual generation using Bankr’s x402 system + sandbox execution.
+
+## Overview
+
+This skill gives Bankr agents **real executable tools** (thin shell scripts) for high-quality visual creation and NFT workflows.
+
+**Best for:**
+- Token PFPs & avatars
+- Community memes & viral content
+- Launch banners & marketing visuals
+- End-to-end on-chain minting
+
+## Installation
+
+```bash
+install the multimodal skill from https://github.com/BankrBot/skills/tree/main/multimodal
+## Installation
+
+Install the skill using the following command in Bankr:
+
+```bash
+install the multimodal skill from https://github.com/BankrBot/skills/tree/main/multimodal
+
+Quick Start
+
+After installing, you can ask the agent to use the skill. Example prompts:
+
+• "Generate a cyberpunk PFP for my token using the multimodal skill"
+• "Create 4 meme variations about Base memecoins"
+• "Improve this prompt and generate an image: a futuristic cat"
+
+Available Scripts
+
+┌───────────────────┬───────────────────────────────────────────────────────────────────┐
+│ Script            │ Description                                                       │
+├───────────────────┼───────────────────────────────────────────────────────────────────┤
+│ generate.sh       │ Main generation script with style templates and variation support │
+├───────────────────┼───────────────────────────────────────────────────────────────────┤
+│ enhance-prompt.sh │ Standalone tool for rewriting and improving prompts               │
+├───────────────────┼───────────────────────────────────────────────────────────────────┤
+│ discover.sh       │ Discovers available x402 visual generation endpoints              │
+├───────────────────┼───────────────────────────────────────────────────────────────────┤
+│ mint.sh           │ Prepares rich NFT metadata and minting instructions               │
+└───────────────────┴───────────────────────────────────────────────────────────────────┘
+
+Usage Examples
+
+# Generate images with variations
+bash /skills/multimodal/scripts/generate.sh \
+  --prompt "cyberpunk cat" \
+  --template cyberpunk \
+  --count 4 \
+  --variations
+
+# Enhance a prompt before generation
+bash /skills/multimodal/scripts/enhance-prompt.sh \
+  -p "a cat" -t cyberpunk --strength high
+
+# Discover current visual x402 services
+bash /skills/multimodal/scripts/discover.sh
+
+Requirements
+
+This skill depends on the following Bankr skills:
+
+• bankr (for x402 execution, wallet operations, and the LLM gateway)
+• opensea or onchainkit (for NFT minting)
+
+The scripts require bash, curl, and jq to be available in the environment.
+
+Notes
+
+• The scripts do not handle payments or store any secrets.
+• All actual image generation and wallet interactions are delegated to the core bankr skill.
+• Always confirm with the user before making paid calls or spending gas.
+
+Repository
+
+Source: github.com/0xcalibrated/skills (https://github.com/0xcalibrated/skills/tree/multimodal-skill/multimodal)

--- a/multimodal/SKILL.md
+++ b/multimodal/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: multimodal
+description: Executable scripts and workflows for image, meme, PFP, and visual generation using Bankr’s x402 system and LLM gateway. Includes prompt engineering, visual discovery, and NFT minting support via opensea and onchainkit.
+tags: [image, meme, pfp, x402, generation, nft, prompt-engineering, bankr]
+version: 1.5
+visibility: public
+metadata:
+  clawdbot:
+    emoji: "🎨"
+    homepage: "https://github.com/0xcalibrated/skills/tree/multimodal-skill/multimodal"
+    requires:
+      skills: ["bankr", "opensea", "onchainkit"]
+      bins: ["bash", "curl", "jq"]
+---
+
+# Multimodal — Image, Meme & NFT Generation
+
+**Skill name:** `multimodal`
+
+This skill provides executable shell scripts that Bankr agents can run directly. It focuses on high-quality prompt engineering, structured visual generation workflows, and preparing assets for NFT minting using Bankr’s x402 system.
+
+It is well suited for token PFPs, community memes, launch visuals, and on-chain minting.
+
+## Scripts
+
+The agent should execute the following scripts:
+
+| Script                        | Purpose                                              | Key Parameters |
+|-------------------------------|------------------------------------------------------|----------------|
+| `scripts/generate.sh`         | Main generation tool with templates and variations   | `--prompt`, `--template`, `--aspect`, `--count`, `--variations` |
+| `scripts/enhance-prompt.sh`   | Standalone prompt improvement and rewriting tool     | `--prompt`, `--template`, `--strength` |
+| `scripts/discover.sh`         | Discover available x402 visual generation endpoints  | — |
+| `scripts/mint.sh`             | Generate rich NFT metadata and minting instructions  | `--image`, `--name`, `--description`, `--royalty`, `--attributes` |
+
+## Recommended Workflow
+
+1. (Optional) Use `enhance-prompt.sh` to improve a weak or vague prompt.
+2. Run `generate.sh` with a chosen template and parameters.
+3. Execute the suggested command through the `bankr` skill to generate images.
+4. Use `mint.sh` to prepare NFT metadata for any outputs the user wants to mint.
+
+## Style Templates
+
+Supported templates: `cyberpunk`, `meme`, `banner`, `pfp`, `logo`, `retro`, `abstract`, `general`.
+
+## Example Usage
+
+```bash
+# Generate 4 variations of a cyberpunk PFP
+bash /skills/multimodal/scripts/generate.sh \
+  --prompt "cyberpunk cat wearing sunglasses" \
+  --template cyberpunk \
+  --aspect 1:1 \
+  --count 4 \
+  --variations
+
+# Improve a basic prompt before generation
+bash /skills/multimodal/scripts/enhance-prompt.sh \
+  -p "a cat" -t cyberpunk --strength high
+
+# Check available visual x402 endpoints
+bash /skills/multimodal/scripts/discover.sh
+
+Best Practices
+
+• Always obtain explicit user confirmation before making paid x402 calls or spending gas.
+• Use --variations when the user is unsure about the creative direction.
+• Combine this skill with the bankr skill for wallet operations and x402 execution.
+• Use the opensea or onchainkit skill for actual NFT minting.
+
+Dependencies
+
+• bankr skill (required for x402 payments, wallet operations, and the LLM gateway)
+• opensea or onchainkit skill (for NFT minting)
+• Network access (required for endpoint discovery)
+
+The scripts do not perform payments or store secrets. They generate prompts, structured data, and guidance for the agent to execute using Bankr’s existing capabilities.


### PR DESCRIPTION
## Summary

Adds the `multimodal` skill, which provides executable shell scripts for image, meme, PFP, and visual generation using Bankr’s x402 system.

Unlike most skills that are instruction-only, this skill ships real scripts that the agent can execute directly in the sandbox. It focuses on structured prompt engineering, visual generation workflows, and preparing assets for NFT minting.

## Key Features

- **Executable scripts** the agent can run:
  - `generate.sh` — Main generation tool with style templates and variation support
  - `enhance-prompt.sh` — Standalone prompt rewriting and improvement tool
  - `discover.sh` — Discovers available x402 visual endpoints
  - `mint.sh` — Generates rich NFT metadata and minting instructions

- Built-in support for style templates (cyberpunk, meme, pfp, banner, etc.)
- Designed to work cleanly with the core `bankr`, `opensea`, and `onchainkit` skills

## Installation

```bash
install the multimodal skill from https://github.com/BankrBot/skills/tree/main/multimodal

Testing

The skill can be tested with prompts such as:

• "Generate a cyberpunk cat PFP using the multimodal skill"
• "Create 4 meme variations about Base memecoins"
• "Improve this prompt and generate an image: a futuristic cat"

Dependencies

• bankr skill (for x402 execution and wallet operations)
• opensea or onchainkit skill (for NFT minting)

Notes

• The scripts do not handle payments or store secrets. All actual generation and wallet interactions are delegated to the bankr skill.
• This skill is intended to complement existing NFT and wallet capabilities rather than replace them.

Feedback and suggestions from the Bankr team are very welcome.