### PR TITLE
feat: add Blue Agent skills — Blue Hub (40 tools) + 5 core founder commands

### DIFF
--- a/blue-audit/SKILL.md
+++ b/blue-audit/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: blue-audit
+description: AI security audit for Base smart contracts — critical issues, suggested fixes, go/no-go verdict. $1.00 x402.
+triggers: "audit this contract", "security review", "is this safe to use", "check this code", "smart contract audit", "rug check"
+payment: x402
+price_usdc: "1.00"
+network: base
+---
+
+# blue-audit — Smart Contract Security Review on Base
+
+Performs AI-powered security and product risk review of Base smart contracts or project code. Returns: critical issues, severity ratings, suggested fixes, and a go/no-go verdict.
+
+## Trigger Conditions
+
+Activate on:
+- "Audit this contract" / "security review"
+- "Is this safe to interact with"
+- "Check this Solidity code / Base contract"
+- "Rug check" / "honeypot check"
+- Any request to review smart contract security before deploying or interacting
+
+## How to Call
+
+```
+POST https://blueagent.dev/api/x402/blue-audit
+X-Payment: <EIP-3009 USDC, amount: 1000000 (1.00 USDC)>
+Content-Type: application/json
+
+{
+  "prompt": "Audit this contract: <contract address or paste Solidity code>"
+}
+```
+
+**Price:** $1.00 USDC  
+**Pay to:** `0xb058a1e305d9c720aa5b1bf42b6f2f6294b03b5f`  
+**Manifest:** `https://blueagent.dev/.well-known/ai-tool/blue-audit.json`
+
+## Output Structure
+
+1. **VERDICT** — GO / NO-GO / CONDITIONAL
+2. **Critical issues** — severity (CRITICAL / HIGH / MEDIUM / LOW), description, line reference if available
+3. **Suggested fixes** — concrete code changes per issue
+4. **Risk summary** — rug vectors, ownership risks, upgrade risks, liquidity risks
+5. **What to verify onchain** — Basescan checks, ownership renounce, liquidity lock
+
+## Key Rules
+
+- All contract addresses must be Base Mainnet — flag if mainnet vs testnet unclear
+- Never confirm a contract is "safe" — return "no critical issues found" with explicit caveats
+- For address-only input: fetch from Basescan for analysis (note: bytecode-only = limited analysis)
+- Distinguish between AI analysis and formal audit — always caveat that this is not a formal security audit
+
+## Output Modes
+
+**GO**: No critical/high issues found. List mediums and lows with fix suggestions.
+
+**CONDITIONAL**: High issues found with clear fix path. Detail what must change before deploying/interacting.
+
+**NO-GO**: Critical issues. Clearly state what the vulnerability is and potential exploit scenario.
+
+## Integration
+
+Pairs with: `contract-trust` (quick trust score), `protocol-risk-monitor` (ongoing risk tracking), `blue-build` (architecture review before audit)

--- a/blue-build/SKILL.md
+++ b/blue-build/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: blue-build
+description: Architecture, stack, folder structure, integrations, and test plan for a Base project. $0.50 x402.
+triggers: "blue build", "architect this", "what stack should I use", "help me build", "technical plan", "folder structure", "how to build this on Base"
+payment: x402
+price_usdc: "0.50"
+network: base
+---
+
+# blue-build — Architecture & Stack for Base Builders
+
+Produces a complete technical blueprint for a Base project: recommended stack, folder structure, key integrations, file-by-file breakdown, and test plan. Powered by Blue Agent via x402.
+
+## Trigger Conditions
+
+Activate on:
+- "Help me architect this on Base"
+- "What stack should I use for X"
+- "Blue build: <project description>"
+- "Give me the technical plan / folder structure"
+- Any request for technical architecture of a Base project
+
+## How to Call
+
+```
+POST https://blueagent.dev/api/x402/blue-build
+X-Payment: <EIP-3009 USDC, amount: 500000 (0.50 USDC)>
+Content-Type: application/json
+
+{
+  "prompt": "Description of what you want to build"
+}
+```
+
+**Price:** $0.50 USDC  
+**Pay to:** `0xb058a1e305d9c720aa5b1bf42b6f2f6294b03b5f`  
+**Manifest:** `https://blueagent.dev/.well-known/ai-tool/blue-build.json`
+
+## Output Structure
+
+1. **Stack** — frontend, backend, smart contracts, infra (specific libs + versions)
+2. **Folder structure** — full directory tree with file-level annotations
+3. **Key integrations** — Base RPC, Coinbase Wallet SDK, x402, Uniswap v4, etc.
+4. **Core files** — what each critical file does and rough implementation notes
+5. **Test plan** — unit, integration, and onchain test strategy
+6. **Deployment** — Vercel / Railway / Cloudflare + contract deploy flow
+
+## Key Rules
+
+- Stack must be **Base-native**: Wagmi/Viem over Ethers, Base RPC endpoints, Base-deployed contracts
+- No Ethereum mainnet assumptions — flag if a dependency isn't available on Base
+- Folder structure must be production-ready, not tutorial-level
+- Include `.env.example` variables list
+- Test plan must cover at minimum: happy path, edge cases, onchain fork tests
+
+## Integration
+
+This is step 2 of the founder workflow:
+- Before: `blue-idea` — validate the concept ($0.05)
+- After: `blue-audit` — security review ($1.00) → `blue-ship` — deploy checklist ($0.10)

--- a/blue-hub/SKILL.md
+++ b/blue-hub/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: blue-hub
+description: Discover and call any of 40 AI tools on Blue Hub — Base-native tool marketplace with x402 pay-per-call in USDC
+triggers: "use blue hub", "call a blue hub tool", "what tools does blue agent have", "blue hub ls", "find a tool for", "blue hub info", "token pick on Base", "what narratives are running", "Base token alpha", "CT narrative", "what's pumping on Base"
+payment: x402
+network: base
+---
+
+# Blue Hub — AI Tool Marketplace for Base
+
+Blue Hub is a curated marketplace of 40 AI tools built on Base, accessible to any agent via x402 micropayments in USDC. No API key required — pay per call onchain.
+
+## Trigger Conditions
+
+Activate when:
+- User asks to "use a blue hub tool" or "find a tool for X"
+- Request matches a capability in the tool catalog (token intel, security audit, builder tools, investor tools)
+- Agent needs Base ecosystem intelligence, onchain analysis, or founder workflows
+- "Give me a token pick on Base" → use `token-pick-signal` ($0.25)
+- "What narratives are running on CT" → use `narrative-position` ($0.20)
+- "What's the Base meta / what's pumping" → use `narrative-position` or `ecosystem-digest`
+
+## Tool Catalog
+
+**Catalog endpoint:** `GET https://blueagent.dev/api/catalog`
+
+**Categories and representative tools:**
+
+| Category | Tools | Price range |
+|---|---|---|
+| intelligence | token-pick-signal, narrative-position, ecosystem-digest, market-fit | $0.10–$0.25 |
+| builder | blue-idea, blue-build, blue-audit, blue-ship, blue-raise | $0.05–$1.00 |
+| trading | whale-copy-signal, token-momentum-scanner, portfolio-rebalancer | $0.20–$0.35 |
+| security | contract-trust, protocol-risk-monitor, builder-deep-dd | $0.15–$0.35 |
+| investor | investor-memo, fundraise-timing, pitch-intelligence | $0.20–$0.30 |
+| agent-economy | agent-performance, agent-collab-match, agent-revenue-optimizer | $0.25–$0.30 |
+| base-ecosystem | base-grant-finder, base-protocol-comparison, base-builder-network-match | $0.20–$0.25 |
+| on-chain | wallet-strategy-analyzer, defi-opportunity, launch-simulator | $0.25–$0.35 |
+| content | thread-intelligence, builder-brand-score, community-growth-playbook | $0.20–$0.25 |
+
+## How to Call a Tool (x402)
+
+All tools follow the x402 protocol on Base Mainnet (chain ID 8453).
+
+**Endpoint pattern:**
+```
+POST https://blueagent.dev/api/x402/{tool-id}
+X-Payment: <EIP-3009 USDC TransferWithAuthorization>
+Content-Type: application/json
+
+{ "input1": "value", "input2": "value" }
+```
+
+**Payment asset:** USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` on Base  
+**Pay to:** `0xb058a1e305d9c720aa5b1bf42b6f2f6294b03b5f`
+
+**Tool manifest:** `GET https://blueagent.dev/.well-known/ai-tool/{tool-id}.json`  
+→ Returns ERC-8257 compliant manifest with inputs schema, pricing, endpoint
+
+## Discovery Workflow
+
+```
+1. GET /api/catalog                    → list all 40 tools with prices + inputs
+2. GET /.well-known/ai-tool/{id}.json  → tool manifest with input schema
+3. POST /api/x402/{id} + X-Payment     → call tool, receive result
+```
+
+## Output Modes
+
+**TOOL_FOUND**: Return tool result directly. Include tool name, price paid, and result.
+
+**NO_TOOL**: If no tool matches the request, suggest the closest match from catalog and explain the gap.
+
+## Key Rules
+
+- Always verify tool existence via catalog before calling
+- Parse input schema from manifest before constructing request body
+- All payments in USDC on Base — never use ETH or other chains
+- Tools return structured text results — parse and present cleanly
+
+## Integration
+
+Pairs with: `aeon-token-pick`, `aeon-narrative-tracker`, `aeon-deep-research`  
+Registry: ERC-8257 ToolRegistry `0x265BB2DBFC0A8165C9A1941Eb1372F349baD2cf1` (Base)  
+Discovery: agentic.market (`blueagent-dev`), CDP Bazaar  
+MCP: `https://blueagent.dev/api/mcp`

--- a/blue-idea/SKILL.md
+++ b/blue-idea/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: blue-idea
+description: Turn a rough concept into a fundable Base builder brief — problem, why now, why Base, MVP scope, risks, 24h plan. $0.05 x402.
+triggers: "blue idea", "validate my idea", "help me build on Base", "turn this into a brief", "founder brief", "is this worth building"
+payment: x402
+price_usdc: "0.05"
+network: base
+---
+
+# blue-idea — Fundable Builder Brief for Base
+
+Transforms a rough concept into a structured, fundable brief for Base builders. Covers: problem framing, why now, why Base, MVP scope, key risks, and a concrete 24-hour action plan.
+
+## Trigger Conditions
+
+Activate on:
+- "Help me turn this idea into a brief"
+- "Is this worth building on Base"
+- "Blue idea: <concept>"
+- "Validate my builder idea"
+- Any rough concept that needs shaping into a Base project brief
+
+## How to Call
+
+```
+POST https://blueagent.dev/api/x402/blue-idea
+X-Payment: <EIP-3009 USDC, amount: 50000 (0.05 USDC)>
+Content-Type: application/json
+
+{
+  "prompt": "Brief description of the idea"
+}
+```
+
+**Price:** $0.05 USDC  
+**Pay to:** `0xb058a1e305d9c720aa5b1bf42b6f2f6294b03b5f`  
+**Manifest:** `https://blueagent.dev/.well-known/ai-tool/blue-idea.json`
+
+## Output Structure
+
+1. **Problem** — what specific pain is this solving, for whom
+2. **Why now** — what changed (tech, market, regulatory, cultural) that makes this timely
+3. **Why Base** — specific Base advantages (low fees, Coinbase distribution, onchain economy, ecosystem)
+4. **MVP scope** — 3 features maximum, what's explicitly out of scope
+5. **Key risks** — top 3 risks with mitigation for each
+6. **24h plan** — concrete first steps: what to build, what to validate, who to talk to
+
+## Key Rules
+
+- Always tie the idea to a **specific Base advantage** — not generic blockchain benefits
+- MVP must be shippable in 2 weeks or less by 1-2 devs
+- Risks must be real and specific — not generic "market risk"
+- 24h plan must be actionable with zero ambiguity
+
+## Output Modes
+
+**BRIEF**: Full 6-section brief ready to share with cofounders or investors.
+
+**NOT_VIABLE**: If the concept has fundamental blockers — explain clearly what would need to change.
+
+## Integration
+
+Next steps after blue-idea:
+- `blue-build` — architecture + stack for the MVP ($0.50)
+- `blue-audit` — security review before launch ($1.00)
+- `blue-ship` — deployment checklist ($0.10)
+- `blue-raise` — pitch narrative for investors ($0.20)
+
+Full workflow: `blue-idea → blue-build → blue-audit → blue-ship → blue-raise`

--- a/blue-raise/SKILL.md
+++ b/blue-raise/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: blue-raise
+description: Pitch narrative for Base founders — market framing, why this wins, traction, ask, target investors. $0.20 x402.
+triggers: "blue raise", "help me raise", "write my pitch", "investor narrative", "fundraising brief", "pitch deck narrative", "who should I raise from"
+payment: x402
+price_usdc: "0.20"
+network: base
+---
+
+# blue-raise — Investor Pitch Narrative for Base Founders
+
+Crafts a sharp investor pitch narrative: market framing, competitive positioning, why this project wins on Base, traction story, funding ask, and target investor profile. Powered by Blue Agent via x402.
+
+## Trigger Conditions
+
+Activate on:
+- "Help me pitch this to investors"
+- "Blue raise: <project description>"
+- "Write my fundraising narrative"
+- "Who should I raise from on Base"
+- Any request for investor pitch content or fundraising strategy
+
+## How to Call
+
+```
+POST https://blueagent.dev/api/x402/blue-raise
+X-Payment: <EIP-3009 USDC, amount: 200000 (0.20 USDC)>
+Content-Type: application/json
+
+{
+  "prompt": "Description of your project and current stage"
+}
+```
+
+**Price:** $0.20 USDC  
+**Pay to:** `0xb058a1e305d9c720aa5b1bf42b6f2f6294b03b5f`  
+**Manifest:** `https://blueagent.dev/.well-known/ai-tool/blue-raise.json`
+
+## Output Structure
+
+1. **Market framing** — size, timing, why the window is open now
+2. **Why this wins** — unfair advantage, moat, Base-specific edge
+3. **Traction narrative** — how to present early metrics (even pre-revenue)
+4. **The ask** — round size, use of funds breakdown, milestones it funds
+5. **Target investors** — 5–8 specific funds/angels active in Base ecosystem
+6. **One-liner** — single sentence that survives a Telegram forward
+
+## Key Rules
+
+- Market framing must be **specific to Base ecosystem** — not generic crypto/Web3
+- "Why this wins" must include a defensible moat — distribution, network effect, or technical
+- Traction narrative must work at any stage (pre-launch, MVP, growth) — adapt to what exists
+- Target investors must be real, currently active in Base/onchain ecosystem
+- One-liner test: would this make a crypto-native investor ask for a call?
+
+## Output Modes
+
+**RAISE_READY**: Full narrative with all 6 sections.
+
+**NOT_READY**: If the project lacks a clear value prop or defensible position — flag the gaps and what needs to be true before raising.
+
+## Integration
+
+This is step 5 (final) of the founder workflow:
+- Before: `blue-ship` — deploy checklist ($0.10)
+- Full flow: `blue-idea → blue-build → blue-audit → blue-ship → blue-raise`
+
+Pairs with: `pitch-intelligence` (competitive landscape), `fundraise-timing` (is now the right time to raise), `investor-memo` (full DD memo for serious investors)

--- a/blue-ship/SKILL.md
+++ b/blue-ship/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: blue-ship
+description: Deployment checklist, verification steps, release notes, and monitoring plan for shipping on Base. $0.10 x402.
+triggers: "blue ship", "ready to deploy", "deployment checklist", "how to launch", "ship this", "go live on Base", "release checklist"
+payment: x402
+price_usdc: "0.10"
+network: base
+---
+
+# blue-ship — Deployment Checklist for Base
+
+Generates a complete pre-launch checklist: deployment steps, verification procedures, release notes template, and monitoring plan. Ensures nothing is missed before going live on Base.
+
+## Trigger Conditions
+
+Activate on:
+- "I'm ready to ship — what do I need to check"
+- "Blue ship: <project description>"
+- "Deployment checklist for X"
+- "How do I launch this on Base"
+- Any request for a ship/deploy/launch plan
+
+## How to Call
+
+```
+POST https://blueagent.dev/api/x402/blue-ship
+X-Payment: <EIP-3009 USDC, amount: 100000 (0.10 USDC)>
+Content-Type: application/json
+
+{
+  "prompt": "Description of what you're shipping"
+}
+```
+
+**Price:** $0.10 USDC  
+**Pay to:** `0xb058a1e305d9c720aa5b1bf42b6f2f6294b03b5f`  
+**Manifest:** `https://blueagent.dev/.well-known/ai-tool/blue-ship.json`
+
+## Output Structure
+
+1. **Pre-deploy checklist** — env vars, contract verification, access control, pause mechanisms
+2. **Deploy sequence** — ordered steps with commands (contracts first, then frontend)
+3. **Verification steps** — Basescan verification, frontend smoke test, x402 endpoint test
+4. **Release notes** — template with what changed, known issues, upgrade instructions
+5. **Monitoring plan** — what to watch post-launch (errors, gas, liquidity, user activity)
+6. **Rollback plan** — how to revert if something goes wrong
+
+## Key Rules
+
+- Checklist must be environment-specific: staging → mainnet, not generic
+- Contract deployment must include Basescan verification command
+- Monitoring must cover both onchain (events, balances) and offchain (error rates, latency)
+- Rollback plan is mandatory — never ship without an escape hatch
+- All Base Mainnet specifics: chain ID 8453, correct RPC endpoints
+
+## Integration
+
+This is step 4 of the founder workflow:
+- Before: `blue-audit` — security review ($1.00)
+- After: `blue-raise` — pitch narrative for investors ($0.20)
+- Full flow: `blue-idea → blue-build → blue-audit → blue-ship → blue-raise`


### PR DESCRIPTION
## Blue Agent Skills

Adds 6 skills for Blue Agent — the Base-native AI agent and tool marketplace.

### blue-hub
Discover and call any of **40 AI tools** on Blue Hub via x402 micropayments in USDC on Base. No API key needed — pay per call onchain.

- **Catalog:** `GET https://blueagent.dev/api/catalog`
- **Payment:** USDC on Base Mainnet (chain 8453), x402 protocol
- **Registry:** ERC-8257 ToolRegistry, agentic.market (`blueagent-dev`), CDP Bazaar
- Covers: token-pick-signal, narrative-position, ecosystem-digest, whale-copy-signal, contract-trust + 35 more

### 5 Core Founder Commands
Full workflow for Base builders: **idea → build → audit → ship → raise**

| Skill | What it does | Price |
|---|---|---|
| `blue-idea` | Fundable brief from rough concept | $0.05 |
| `blue-build` | Architecture + stack + folder structure | $0.50 |
| `blue-audit` | Smart contract security review | $1.00 |
| `blue-ship` | Deployment checklist + monitoring plan | $0.10 |
| `blue-raise` | Investor pitch narrative | $0.20 |

### Links
- Site: https://blueagent.dev
- Hub: https://blueagent.dev/hub
- Catalog API: https://blueagent.dev/api/catalog
- GitHub: https://github.com/madebyshun/blue-agent
- X: [@blueagent_](https://x.com/blueagent_)