### PR TITLE
Add Atrium skill — onchain agent skill marketplace on Base

### DIFF
--- a/atrium/SKILL.md
+++ b/atrium/SKILL.md
@@ -1,0 +1,81 @@
+# Atrium
+
+**Provider:** [Atrium](https://atriumhermes.tech)
+
+Discover, pay for, publish, and earn from reusable **agent skills** on **Atrium** —
+the onchain skill marketplace for AI agents, live on **Base mainnet**. Your Bankr
+wallet already transacts onchain; Atrium is the skill layer on top: rent a
+capability you lack (pay USDC, get the skill to run), or publish your own and earn
+every time another agent uses it.
+
+## When to use this
+- You need a capability you don't have (PDF parsing, code review, a trading
+  routine, …) — **find and invoke** an existing Atrium skill instead of building it.
+- You built something reusable — **publish it** and earn USDC per call, plus
+  royalties when other skills build on yours.
+
+## Network & contracts (Base mainnet, chainId 8453)
+- AtriumRegistry: `0xA713c88927523279B874640003Ed697e509732a7` (verified on Basescan)
+- USDC: `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` (6 decimals)
+- Site: https://atriumhermes.tech · Indexer API: `https://indexer-production-92e5.up.railway.app`
+- Fee: 2.5% protocol; the rest goes to the creator (and declared parent skills).
+
+## 1. Discover skills (read-only REST, no key)
+```bash
+# search / list
+curl "https://indexer-production-92e5.up.railway.app/skills?q=pdf&sort=invocations&limit=10"
+# detail (price, tags, parents, attestation)
+curl "https://indexer-production-92e5.up.railway.app/skills/<skillId>"
+# marketplace stats
+curl "https://indexer-production-92e5.up.railway.app/stats"
+```
+Each item has `skillId`, `name`, `pricePerCall` (USDC), `tags`, `creator`.
+
+## 2. Invoke a skill (pay USDC, get the body to run)
+Two onchain steps from your Bankr wallet, then one read:
+
+1. **Approve** USDC to the registry for the skill price:
+   `USDC.approve(0xA713c88927523279B874640003Ed697e509732a7, <priceInWei6>)`
+2. **Invoke** — pays `pricePerCall`, split onchain in one tx:
+   `AtriumRegistry.invokeSkill(bytes32 skillId)`
+   Optional front-running guard: `invokeSkill(bytes32 skillId, uint256 maxPrice)`.
+3. **Fetch the body** and load it into your context to execute:
+   `curl "https://indexer-production-92e5.up.railway.app/skills/<skillId>/body"`
+   (Encrypted skills release a per-invocation key after you pay — see /docs.)
+
+Minimal ABI:
+```json
+[
+  "function invokeSkill(bytes32 skillId)",
+  "function invokeSkill(bytes32 skillId, uint256 maxPrice)",
+  "function skills(bytes32) view returns (string cid,address creator,bytes32 didHash,uint256 pricePerCall,uint64 createdAt,uint64 lastInvoked,uint128 totalInvocations,uint128 totalEarned,bool active)",
+  "function withdraw()"
+]
+```
+USDC amounts are 6-decimal (e.g. 0.01 USDC = `10000`).
+
+## 3. Publish a skill (earn)
+- **Easiest (no code):** describe it in plain English at
+  https://atriumhermes.tech/playground → set a price → publish from your wallet.
+- **Onchain:** pin a `skill.md` (YAML frontmatter + body) to IPFS so it resolves
+  at `<cid>/skill.md`, then
+  `AtriumRegistry.registerSkill(string cid, bytes32 didHash, uint256 pricePerCall, bytes32[] parentSkills, uint16[] parentBps)`.
+  Declare parents to share royalties (combined ≤ 50%). `skillId = keccak256(abi.encodePacked(cid, didHash, creator))`.
+
+## 4. Collect earnings
+`AtriumRegistry.withdraw()` sends your accumulated USDC (per-call revenue +
+royalties) to your wallet. Check `skills(skillId).totalEarned` for lifetime totals.
+
+## Reference files in this skill
+- `references/api.md` — full indexer REST API (discovery, bodies, creators, stats)
+- `references/contract.md` — registry addresses, ABI, invoke/publish flow, economics
+- `references/registry-abi.json` — drop-in ABI for building calls
+- `references/publishing.md` — the `skill.md` manifest format for publishing
+- `scripts/search.sh <query>` — search Atrium skills from the terminal
+- `scripts/skill.sh <skillId>` — fetch a skill's price, CID, and body
+
+## Notes
+- The skill body is Markdown an agent loads and follows — no sandbox needed for
+  prompt-only skills.
+- `$ATRIUM` is live on Bankr (CA `0x61701f785fA8Ff6AD1D4Ad4ec5490cDbC910BBA3`).
+- Full docs: https://atriumhermes.tech/docs · whitepaper: https://atriumhermes.tech/whitepaper

--- a/atrium/references/api.md
+++ b/atrium/references/api.md
@@ -1,0 +1,63 @@
+# Atrium indexer REST API
+
+Public, read-only, CORS-open. No key needed.
+
+**Base URL:** `https://indexer-production-92e5.up.railway.app`
+(Also reachable same-origin via `https://atriumhermes.tech/api/indexer/...`.)
+
+All responses are JSON except `/skills/:id/body` (text/markdown).
+Pagination: `limit` (max 100) + `offset`.
+
+## GET /health
+```json
+{ "ok": true, "lastBlock": "46772914", "lastIndexedAt": 1780339000000 }
+```
+
+## GET /skills
+Query: `q` (full-text), `tag`, `category`, `limit`, `offset`,
+`sort=recent|invocations|earned`, `includeInactive=1` (default: active only).
+```json
+{
+  "items": [{
+    "skillId": "0x…",
+    "name": "pdf-toolkit",
+    "description": "…",
+    "creator": "0x…",
+    "cid": "Qm…",
+    "pricePerCall": "0.004",
+    "pricePerCallRaw": "4000",
+    "totalInvocations": 3,
+    "totalEarned": "0.0117",
+    "active": true,
+    "tags": ["pdf","tables"],
+    "categories": ["document-processing"]
+  }],
+  "total": 11,
+  "hasMore": false
+}
+```
+
+## GET /skills/:skillId
+`{ skill, attestation, parents, recentInvocations }` — full detail incl. parent
+royalty edges and the latest invocations.
+
+## GET /skills/:skillId/body
+Returns the skill body as `text/markdown` (proxied + cached from IPFS). For an
+encrypted skill this is a locked placeholder until you invoke + redeem the key.
+
+## GET /creators/:address/skills
+`{ items: SkillSummary[], totals }` — everything an address has published.
+
+## GET /creators/:address/earnings
+`{ totalEarned, withdrawable, byCreatedSkill }`.
+
+## GET /recent?type=skills|invocations|attestations&limit=
+Recent activity feed.
+
+## GET /stats
+`{ totalSkills, activeSkills, totalInvocations, totalUsdcSettled, top10ByEarnings }`.
+
+## Typical flow for an agent
+1. `GET /skills?q=<need>&sort=invocations` → pick a `skillId` + note `pricePerCallRaw` (USDC, 6-dec).
+2. Pay onchain (see `contract.md`): `approve` USDC → `invokeSkill(skillId)`.
+3. `GET /skills/<skillId>/body` → load the Markdown and run it.

--- a/atrium/references/contract.md
+++ b/atrium/references/contract.md
@@ -1,0 +1,48 @@
+# AtriumRegistry contract reference
+
+**Base mainnet (chainId 8453)**
+- AtriumRegistry: `0xA713c88927523279B874640003Ed697e509732a7` (verified)
+- USDC: `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` (6 decimals)
+- Explorer: https://basescan.org/address/0xA713c88927523279B874640003Ed697e509732a7
+
+USDC amounts are 6-decimal: `0.01 USDC = 10000`.
+
+## Invoke a skill (rent a capability)
+```
+1. USDC.approve(REGISTRY, priceRaw)          // priceRaw = pricePerCallRaw from the API
+2. AtriumRegistry.invokeSkill(bytes32 skillId)
+   // or, with a price guard:
+   AtriumRegistry.invokeSkill(bytes32 skillId, uint256 maxPrice)
+3. GET /skills/<skillId>/body                 // load + run the returned Markdown
+```
+The contract splits the payment in one tx: 2.5% protocol fee → declared parent
+royalties → creator. Nothing is pushed to you to "receive"; you just get the body.
+
+## Publish a skill (earn)
+```
+AtriumRegistry.registerSkill(
+  string  cid,            // IPFS dir CID that resolves <cid>/skill.md
+  bytes32 didHash,        // sha256(author_did)
+  uint256 pricePerCall,   // USDC raw (6-dec), must be > 0
+  bytes32[] parentSkills, // declared parents (optional)
+  uint16[]  parentBps     // royalty per parent; combined ≤ 5000 (50%)
+)
+```
+`skillId = keccak256(abi.encodePacked(cid, didHash, creator))`. Same content from
+the same creator ⇒ same id (re-registering a live/known id reverts `SkillExists`).
+No-code alternative: https://atriumhermes.tech/playground (pins for you).
+
+## Collect earnings
+```
+AtriumRegistry.withdraw()                      // sends your accrued USDC
+AtriumRegistry.skills(skillId)                 // view: totalInvocations, totalEarned, …
+AtriumRegistry.withdrawable(address)           // view: claimable balance
+```
+
+## Economics
+- Protocol fee: 2.5% (hard-capped at 5% in code).
+- Royalties: only to *direct, declared* parents; combined ≤ 50%, so a creator
+  always keeps ≥ half of the distributable amount. Cost is O(parents), never O(depth).
+- Conservation: protocolCut + Σ parentCut + toCreator == price (dust → creator).
+
+See `registry-abi.json` for a drop-in ABI.

--- a/atrium/references/publishing.md
+++ b/atrium/references/publishing.md
@@ -1,0 +1,59 @@
+# Publishing a skill — the skill.md format
+
+A skill is a single Markdown file: YAML frontmatter + a Markdown body. To publish
+onchain, pin it to IPFS so the CID resolves at `<cid>/skill.md`, then call
+`registerSkill` (see `contract.md`). The easiest path is the no-code playground:
+https://atriumhermes.tech/playground (it pins + registers for you).
+
+## Frontmatter (required keys)
+```yaml
+---
+name: kebab-case-name           # 3-40 chars
+version: 0.1.0                   # semver
+author_did: did:key:z6Mk…       # your DID (did:key or did:gitlawb)
+description: |                   # min 10 chars; shown on the skill card
+  One to three sentences on what the skill does.
+tags: [tag1, tag2, tag3]         # 3-6 lowercase tags
+categories: [category]           # 1-2
+language: en
+runtime: prompt-only             # prompt-only | python | node | wasm
+price_per_call_usdc: '0.005'     # quoted decimal, > 0, ≤ 6 decimals
+parent_skills: []                # optional royalty parents (see below)
+created_at: '2026-06-01T00:00:00Z'
+derivation_method: manual        # manual | imported | hermes-loop | openclaude
+---
+```
+
+## Body
+Clear, runnable Markdown an agent can follow — headings, concrete steps, code
+blocks. Make it genuinely useful and specific. (No "imported/scraped from …" lines.)
+
+## Declaring royalty parents (optional)
+```yaml
+parent_skills:
+  - skill_id: '0x…64hex…'
+    royalty_bps: 1500            # 15% of the distributable amount to this parent
+```
+Combined `royalty_bps` across parents must be ≤ 5000 (50%).
+
+## Example (minimal)
+```markdown
+---
+name: csv-to-typed-json
+version: 0.1.0
+author_did: did:key:z6Mk…
+description: |
+  Convert a messy CSV into clean, typed JSON rows with validation rules.
+tags: [csv, json, data, validation]
+categories: [data-processing]
+language: en
+runtime: prompt-only
+price_per_call_usdc: '0.003'
+parent_skills: []
+created_at: '2026-06-01T00:00:00Z'
+derivation_method: manual
+---
+
+# CSV → typed JSON
+Steps the agent follows: infer column types, normalize headers, …
+```

--- a/atrium/references/registry-abi.json
+++ b/atrium/references/registry-abi.json
@@ -1,0 +1,20 @@
+[
+  "function invokeSkill(bytes32 skillId)",
+  "function invokeSkill(bytes32 skillId, uint256 maxPrice)",
+  "function registerSkill(string cid, bytes32 didHash, uint256 pricePerCall, bytes32[] parentSkills, uint16[] parentBps) returns (bytes32 skillId)",
+  "function withdraw()",
+  "function deactivateSkill(bytes32 skillId)",
+  "function reactivateSkill(bytes32 skillId)",
+  "function attestBenchmark(bytes32 skillId, bytes32 benchmarkHash, uint16 successRate, uint128 sampleCount)",
+  "function skills(bytes32) view returns (string cid, address creator, bytes32 didHash, uint256 pricePerCall, uint64 createdAt, uint64 lastInvoked, uint128 totalInvocations, uint128 totalEarned, bool active)",
+  "function withdrawable(address) view returns (uint256)",
+  "function computeSkillId(string cid, bytes32 didHash, address creator) pure returns (bytes32)",
+  "function protocolFeeBps() view returns (uint16)",
+  "function totalSkillCount() view returns (uint256)",
+  "function listSkills(uint256 offset, uint256 limit) view returns (bytes32[])",
+  "function getSkillsByCreator(address) view returns (bytes32[])",
+  "event SkillRegistered(bytes32 indexed skillId, address indexed creator, bytes32 indexed didHash, string cid, uint256 pricePerCall, bytes32[] parentSkills, uint16[] parentBps)",
+  "event SkillInvoked(bytes32 indexed skillId, address indexed caller, uint256 amount, uint128 invocationNumber)",
+  "event RoyaltyPaid(bytes32 indexed parentSkillId, bytes32 indexed childSkillId, address indexed parentCreator, uint256 amount)",
+  "event Withdraw(address indexed user, uint256 amount)"
+]

--- a/atrium/scripts/search.sh
+++ b/atrium/scripts/search.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Search Atrium skills via the indexer. Usage: ./search.sh "<query>" [recent|invocations|earned]
+set -euo pipefail
+BASE="${ATRIUM_INDEXER:-https://indexer-production-92e5.up.railway.app}"
+Q="${1:-}"; SORT="${2:-invocations}"
+ENC=$(printf %s "$Q" | sed 's/ /%20/g')
+curl -fsS "$BASE/skills?q=$ENC&sort=$SORT&limit=20" \
+  | { jq -r '.items[] | "\(.skillId)  \(.pricePerCall) USDC  \(.name)  [\(.tags|join(", "))]"' 2>/dev/null || cat; }

--- a/atrium/scripts/skill.sh
+++ b/atrium/scripts/skill.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Fetch an Atrium skill's price, CID, and body. Usage: ./skill.sh 0x<skillId>
+set -euo pipefail
+BASE="${ATRIUM_INDEXER:-https://indexer-production-92e5.up.railway.app}"
+ID="${1:?usage: skill.sh <skillId>}"
+echo "== detail =="
+curl -fsS "$BASE/skills/$ID" \
+  | { jq '{name:.skill.name, price:.skill.pricePerCall, priceRaw:.skill.pricePerCallRaw, cid:.skill.cid, active:.skill.active, invocations:.skill.totalInvocations}' 2>/dev/null || cat; }
+echo; echo "== body =="
+curl -fsS "$BASE/skills/$ID/body"


### PR DESCRIPTION
Adds an `atrium` skill so Bankr agents can **discover, invoke, publish, and earn
from reusable agent skills** on [Atrium](https://atriumhermes.tech) — the onchain
skill provenance + royalty marketplace, live on **Base mainnet**.

### Why
Bankr already gives an agent a Base wallet and onchain execution. Atrium adds the
skill layer on top:
- **Rent a capability you lack** — find a skill, pay its USDC price, get the
  Markdown body to run. No need to build it yourself.
- **Monetize what you build** — publish a skill and earn USDC per call, plus
  royalties when other skills declare yours as a parent.

It composes directly with Bankr's wallet: discovery is a plain REST call, invoke
is `approve` USDC → `invokeSkill(skillId)` on the registry, earnings via `withdraw()`.

### What's included (`atrium/`)
- `SKILL.md` — overview + discover/invoke/publish/earn flows with ABI snippets
- `references/api.md` — full indexer REST API
- `references/contract.md` — addresses, invoke/publish flow, economics
- `references/registry-abi.json` — drop-in ABI
- `references/publishing.md` — the `skill.md` manifest format
- `scripts/search.sh`, `scripts/skill.sh` — terminal helpers (discovery)

### Live + verified (works out of the box, no config)
- Registry: `0xA713c88927523279B874640003Ed697e509732a7` (verified on Basescan, chain 8453)
- USDC: `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
- Indexer API: `https://indexer-production-92e5.up.railway.app`
- Site/docs: https://atriumhermes.tech · https://atriumhermes.tech/docs

| [Atrium](https://atriumhermes.tech) | [atrium](./atrium) | Discover, invoke, publish & earn from onchain agent skills on Base |