### PR TITLE
Add mainstreet skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Bankr Skills equip builders with plug-and-play tools to build more powerful agen
 | [Endaoment](https://endaoment.org) | [endaoment](endaoment/) | Charitable donations on-chain. Look up 501(c)(3) organizations by EIN, donate crypto, deploy donor-advised fund entities. |
 | [ENS](https://ens.domains) | [ens-primary-name](ens-primary-name/) | ENS name management. Set primary names, update avatars, manage reverse resolution across L1 and L2. |
 | [8004.org](https://8004.org) | [erc-8004](erc-8004/) | On-chain agent identity registry. ERC-721 NFTs representing agent identities with metadata, capabilities, and trust scores. |
+| [MainStreet](https://avisradar-production.up.railway.app/mainstreet) | [mainstreet](mainstreet/) | Onchain reputation oracle for AI agents on Base. SAFE / CAUTION / BLOCK + 0-100 score before any agent-to-agent payment. EIP-712 signed attestations verifiable onchain. Indexes x402 settlements, ERC-8004 feedback, Bazaar listings. |
 | [Coinbase](https://onchainkit.xyz) | [onchainkit](onchainkit/) | React component library for on-chain interactions. Wallet connectors, swap widgets, identity components, and NFT displays for Base. |
 | [qrcoin](https://qrcoin.fun) | [qrcoin](qrcoin/) | QR code auction game. Scan QR codes to place bids in on-chain auctions with unique token mechanics. |
 | [Veil Cash](https://veil.cash) | [veil](veil/) | Privacy-preserving transactions. Deposit into shielded pools, perform ZK withdrawals, manage private transfers. |

--- a/mainstreet/SKILL.md
+++ b/mainstreet/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: mainstreet
+description: MainStreet — EIP-712 reputation oracle for AI agents on Base. Use when an agent wants to look up a wallet's reputation score (0-100), fetch a cryptographically-signed attestation, verify an attestation on-chain via the deployed verifier contract, get a risk-only audit verdict (AVOID/CAUTION/OK), check whether a Virtuals agent token has a backing reputation, find which wallets fund another wallet (sybil detection), or query the canonical identity (Basename + ERC-8004 + agent.json) of any Base address. 847 Base agents indexed, 4,811 Virtuals agents in proof index, 153k x402 settlements tracked. Also use when asked about MainStreet, EIP-712 attestation, MainStreetVerifier, or onchain agent reputation.
+metadata:
+  {
+    "clawdbot":
+      {
+        "emoji": "🪪",
+        "homepage": "https://avisradar.app/oracle.html",
+      },
+  }
+---
+
+# MainStreet
+
+EIP-712 reputation oracle for AI agents on Base. Free attestation fetch, free off-chain verify, on-chain verifiable via the deployed `MainStreetVerifier` contract.
+
+**Verifier contract:** `0x7397adb9713934c36d22aa54b4dbbcd70263592b` (Base mainnet)
+**Operator (signer):** `0xAC3ca7c5d3cDD7702fd08F9C4C28dAA22296aDa9`
+**EAS Schema:** `0xe572079c100f08f537660248df84c632a7c4e5ad3b1d644dc36abb7d993cfe6f`
+**API:** `https://avisradar-production.up.railway.app/api/agent`
+**Catalog:** `https://avisradar-production.up.railway.app/api/agent/catalog`
+**Basename:** `mainstreetxyz.base.eth` · **ERC-8004 agentId:** `53953`
+
+## Quick Start
+
+1. No API key required for public endpoints
+2. Use the shell scripts in `scripts/` for all operations
+3. Paid endpoints (audit, risk-report, audit-batch, sponsor) settle via x402 USDC on Base
+4. Verify any attestation on-chain via the deployed verifier contract
+
+```bash
+# Free score lookup
+./scripts/mainstreet-score.sh 0xAC3ca7c5d3cDD7702fd08F9C4C28dAA22296aDa9
+
+# Fetch EIP-712 signed attestation (free)
+./scripts/mainstreet-attestation.sh 0xAC3ca7c5d3cDD7702fd08F9C4C28dAA22296aDa9
+
+# Verify an attestation (zero-crypto, server-side)
+./scripts/mainstreet-verify.sh
+
+# Premium audit ($0.25 USDC via x402)
+curl https://avisradar-production.up.railway.app/api/agent/audit/0xYourAgent
+
+# Risk-only verdict ($0.50 USDC via x402)
+curl https://avisradar-production.up.railway.app/api/agent/risk-report/0xYourAgent
+
+# Bulk audit up to 10 addresses ($1 USDC via x402)
+./scripts/mainstreet-audit-batch.sh
+
+# Canonical identity (free)
+./scripts/mainstreet-canonical.sh 0xYourAgent
+```
+
+## Free endpoints (no payment)
+
+- `GET /score/{address}` — cached 0-100 score + metrics + trust tier
+- `GET /attestation/{address}` — EIP-712 signed payload + signature
+- `GET /auto-attest-status/{address}` — poll for autonomous agents to know if attestation is fresh
+- `POST /verify` — server-side verify of {payload, signature, minScore}
+- `GET /canonical-id/{address}` — basename + ERC-8004 + agent.json + tier
+- `GET /has-mainstreet-ref/{address}` — reciprocal proof check
+- `GET /snippet/{address}` — JSON block to merge into your own agent.json
+- `GET /funded-by/{address}` — top wallets that sent USDC to this address
+- `GET /recent-activity/{address}` — 7d earn/spend signal
+- `GET /virtuals-rep/{tokenAddress}` — Virtuals token → operator score
+- `GET /bazaar-scored` — proxy of CDP Bazaar discovery with trust score per item
+- `GET /agents-of-interest` — curated shortlist (3 filter modes)
+- `GET /top-buyers` — wallets spending most via x402 on Base
+- `GET /match` — semantic search: pass `?intent=weather+data` to find ranked agents
+- `GET /coverage` — public ecosystem stats
+
+## Paid endpoints (x402 USDC on Base)
+
+| Endpoint | Price | Purpose |
+| --- | --- | --- |
+| `GET /score/{address}?live=1` | $0.05 | Force fresh re-fetch |
+| `GET /audit/{address}` | $0.25 | 360° due-diligence: score + proofs + launches + traders + settlements + SLA + ERC-8004 feedback + signedAttestation |
+| `GET /risk-report/{address}` | $0.50 | Risk-only verdict (AVOID/CAUTION/OK) + flags + signed attestation |
+| `GET /clawd/creator-audit/{address}` | $0.50 | PumpClaw creator due-diligence |
+| `GET /clawd/export` | $0.50 | Bulk PumpClaw graph export |
+| `POST /audit-batch` | $1.00 | Bulk score+risk up to 10 wallets in one call |
+| `GET /proofs/export` | $1.00 | Bulk multi-source proofs (CSV/JSON) |
+| `GET /clawd/rug-alert/{tokenAddr}` | $2.00 | Rug-alert webhook (30 days) |
+| `POST /webhook/extend` | $5.00 | Extend real-time webhook subscription |
+| `POST /sponsor/{address}` | $25/wk | Boosted leaderboard placement |
+
+## Onchain verification (Solidity)
+
+```solidity
+interface IMainStreetVerifier {
+  function requireMinScore(
+    bytes32 subject, uint8 minScore,
+    uint8 score, uint64 timestamp, uint64 nonce,
+    bytes calldata signature
+  ) external view returns (bool);
+}
+
+IMainStreetVerifier constant MS = IMainStreetVerifier(0x7397adb9713934c36d22aa54b4dbbcd70263592b);
+MS.requireMinScore(subject, 30, score, ts, nonce, sig);
+```
+
+Caller fetches `{subject, score, timestamp, nonce, signature}` from `GET /api/agent/attestation/{address}`, passes inline as tx calldata. No oracle subscription, no upkeep, ~$0.00003 in gas.
+
+## npm package
+
+```bash
+npm i @raskhaaa/mainstreet-oracle viem
+
+import { requireMinScore } from '@raskhaaa/mainstreet-oracle/verifier';
+import * as viem from 'viem';
+
+// throws if score < 30 or signature invalid
+const score = await requireMinScore('0xAgentAddr', 30, viem);
+```
+
+## EIP-712 schema
+
+```
+Attestation(
+  string version,         // "mainstreet-v1"
+  string subjectType,     // "agent-onchain"
+  bytes32 subject,        // sha256(toLowerCase(address))
+  uint8 score,            // 0-100
+  uint64 timestamp,       // unix seconds, ≤24h fresh
+  address operator,       // 0xAC3ca7c5d3cDD7702fd08F9C4C28dAA22296aDa9
+  uint64 nonce
+)
+```
+
+Domain: `{ name: "MainStreet", version: "1", chainId: 8453 }`.
+
+## Live coverage (June 2026)
+
+- 847 Base AI agents indexed
+- 4,811 Virtuals agents cross-referenced
+- 153,073 x402 settlements tracked
+- $24,562 USDC volume seen
+- 1,513 unique buyers
+- 16 ERC-8004 registered agents in our index
+- Top 10 scores published onchain weekly via EAS (composable signal)

--- a/mainstreet/references/api.md
+++ b/mainstreet/references/api.md
@@ -1,0 +1,56 @@
+# MainStreet API Reference
+
+Base URL: `https://avisradar-production.up.railway.app`
+
+## Free endpoints
+
+### `GET /api/agent/score/:address`
+
+Returns the cached reputation score for any Base address.
+
+Response: see `SKILL.md` for the full shape.
+
+Rate limit: 1000+ calls per IP per day.
+
+### `GET /api/agent/leaderboard?limit=N`
+
+Returns the top N agents by score across all indexed ecosystems
+(x402 Bazaar, ERC-8004, Virtuals, Clanker, OpenClawd).
+
+### `GET /api/agent/coverage`
+
+Returns aggregate stats: total indexed, total volume, network breakdown.
+
+### `GET /api/agent/by-category/:category`
+
+Returns agents within a category tag (`video`, `maps-travel`, `defi`, etc.).
+
+## x402-paid endpoints
+
+### `POST /api/agent/attest`
+
+Returns an EIP-712 signed attestation for the queried address. The buyer can
+verify the signature onchain at the MainStreet verifier contract to prove the
+score they relied on at decision time.
+
+Price: $0.05 USDC per call on Base.
+
+Body:
+
+```json
+{ "address": "0x...", "context": "x402-prepay" }
+```
+
+Response:
+
+```json
+{
+  "domain": { "name": "MainStreet", "version": "1", "chainId": 8453, "verifyingContract": "0x7397adb9713934c36d22aa54b4dbbcd70263592b" },
+  "types": { "Attestation": [{ "name": "subject", "type": "address" }, { "name": "score", "type": "uint8" }, { "name": "verdict", "type": "uint8" }, { "name": "issuedAt", "type": "uint64" }, { "name": "nonce", "type": "uint256" }] },
+  "primaryType": "Attestation",
+  "message": { "subject": "0x...", "score": 76, "verdict": 0, "issuedAt": 1717650000, "nonce": "0x..." },
+  "signature": "0x..."
+}
+```
+
+Verdict enum: `0 = SAFE`, `1 = CAUTION`, `2 = BLOCK`.

--- a/mainstreet/references/scoring.md
+++ b/mainstreet/references/scoring.md
@@ -1,0 +1,44 @@
+# Scoring model
+
+The score is a 0-100 number summarizing the onchain track record of an address.
+The verdict (SAFE / CAUTION / BLOCK) is derived from the score plus a small
+number of hard signals (denylist match, sniper pattern, smart-wallet vs EOA,
+deployer reputation).
+
+## Inputs
+
+- **Settlements** — count and USDC volume of x402 (or equivalent) payments
+  received, weighted by recency.
+- **ERC-8004 feedback** — signed reputation events from other agents.
+- **Health probes** — periodic latency and uptime samples against the seller's
+  resource path.
+- **Identity proofs** — smart-wallet (4337 / proxy), claimed ENS / DID,
+  domain binding.
+- **Launch context** — for Virtuals / Clanker / OpenClawd tokens: developer
+  commitment level, tokenomics status, age, holder count, mindshare.
+
+## Outputs
+
+```
+score        0-100
+trustShield  green | yellow | red
+verdict      SAFE | CAUTION | BLOCK
+proofs       array of weighted proof objects
+trustLevel   tier 0-4 (NEW / EARLY / ACTIVE / VERIFIED / ELITE)
+```
+
+## Why 0-100
+
+The number is intentionally NOT a probability. It is a relative rank inside
+the indexed population (currently 883 agents). A SAFE verdict means the agent
+is in the top-decile of its category by track record, not that it's
+mathematically guaranteed not to rug.
+
+## How to use it correctly
+
+- For low-value calls ($0.001-$0.01): trust the free verdict.
+- For meaningful payments ($1+): pull the signed attestation and verify
+  onchain. The $0.05 attestation fee is rounding compared to the loss of
+  paying a rug.
+- For high-value or recurring relationships: combine the score with the
+  agent's own signed receipts (`/api/agent/receipts/:address`).

--- a/mainstreet/references/verifier.md
+++ b/mainstreet/references/verifier.md
@@ -1,0 +1,45 @@
+# Onchain Verifier
+
+The MainStreet verifier is a stateless contract that recovers the EIP-712
+signature on an attestation and confirms it was signed by the canonical
+MainStreet oracle key.
+
+**Address:** `0x7397adb9713934c36d22aa54b4dbbcd70263592b`
+**Network:** Base mainnet (chainId 8453)
+**Source:** https://github.com/philpof102-svg/mainstreet/blob/main/contracts/MainStreetVerifier.sol
+
+## Verification flow
+
+1. Buyer calls `POST /api/agent/attest { address, context }`.
+2. Buyer receives a signed EIP-712 attestation (see `api.md`).
+3. Buyer (or anyone, later) calls `verify(message, signature)` on the
+   verifier contract.
+4. The contract returns `true` if the signature recovers to the MainStreet
+   oracle address.
+
+```solidity
+function verify(
+  address subject,
+  uint8 score,
+  uint8 verdict,
+  uint64 issuedAt,
+  uint256 nonce,
+  bytes calldata signature
+) external view returns (bool);
+```
+
+## Why this matters
+
+The attestation is third-party-verifiable without trusting MainStreet's API.
+If a buyer agent paid an x402 seller based on a SAFE attestation and that
+seller later turned out to be malicious, the buyer has cryptographic proof of
+the verdict it relied on at the moment of payment.
+
+This is the same pattern used by traditional rating agencies — except the
+"rating" is queryable in 5 ms and verifiable by a smart contract.
+
+## Anti-staleness
+
+Each attestation includes `issuedAt` (unix seconds) and a `nonce`. Consumers
+should reject attestations older than their tolerance window (recommended:
+60 seconds for live agent flows).

--- a/mainstreet/scripts/mainstreet-attestation.sh
+++ b/mainstreet/scripts/mainstreet-attestation.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# mainstreet-attestation.sh — fetch EIP-712 signed attestation (free)
+set -euo pipefail
+[ -z "${1:-}" ] && { echo "usage: mainstreet-attestation.sh <0x-address>"; exit 1; }
+curl -sS "https://avisradar-production.up.railway.app/api/agent/attestation/$1"

--- a/mainstreet/scripts/mainstreet-audit-batch.sh
+++ b/mainstreet/scripts/mainstreet-audit-batch.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# mainstreet-audit-batch.sh — bulk audit up to 10 addresses ($1 USDC via x402)
+# usage: pass addresses as args. needs x402 wallet env (AGENT_PRIVATE_KEY).
+set -euo pipefail
+[ $# -lt 1 ] && { echo "usage: mainstreet-audit-batch.sh <addr1> [addr2] ..."; exit 1; }
+ADDRS=$(printf '"%s",' "$@" | sed 's/,$//')
+echo "POST https://avisradar-production.up.railway.app/api/agent/audit-batch"
+echo "Body: {\"addresses\":[$ADDRS]}"
+echo "Cost: \$1 USDC via x402. Sign with @x402/axios or x402-axios v1."

--- a/mainstreet/scripts/mainstreet-canonical.sh
+++ b/mainstreet/scripts/mainstreet-canonical.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# mainstreet-canonical.sh — unified identity (basename + ERC-8004 + agent.json + tier)
+set -euo pipefail
+[ -z "${1:-}" ] && { echo "usage: mainstreet-canonical.sh <0x-address>"; exit 1; }
+curl -sS "https://avisradar-production.up.railway.app/api/agent/canonical-id/$1"

--- a/mainstreet/scripts/mainstreet-score.sh
+++ b/mainstreet/scripts/mainstreet-score.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# mainstreet-score.sh — fetch free MainStreet reputation score for any Base address
+set -euo pipefail
+[ -z "${1:-}" ] && { echo "usage: mainstreet-score.sh <0x-address>"; exit 1; }
+curl -sS "https://avisradar-production.up.railway.app/api/agent/score/$1"

--- a/mainstreet/scripts/mainstreet-verify.sh
+++ b/mainstreet/scripts/mainstreet-verify.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# mainstreet-verify.sh — verify a signed attestation server-side
+# usage: pipe the attestation JSON in, optionally with MIN_SCORE env var
+set -euo pipefail
+MIN_SCORE="${MIN_SCORE:-0}"
+ATT_JSON="${1:-$(cat)}"
+PAYLOAD=$(echo "$ATT_JSON" | jq '.payload')
+SIG=$(echo "$ATT_JSON" | jq -r '.signature')
+curl -sS -X POST "https://avisradar-production.up.railway.app/api/agent/verify" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --argjson p "$PAYLOAD" --arg s "$SIG" --arg m "$MIN_SCORE" '{payload:$p,signature:$s,minScore:($m|tonumber)}')"


### PR DESCRIPTION
Adds the MainStreet skill — EIP-712 reputation oracle for AI agents on Base.

## What MainStreet does

Free 0-100 reputation score for any Base wallet, cryptographically signed via EIP-712. Buyer agents (and Bankr-powered agents) can vet a counterparty before paying.

- **Deployed verifier contract** on Base: `0x7397adb9713934c36d22aa54b4dbbcd70263592b`
- **847 Base AI agents** indexed
- **4,811 Virtuals agents** cross-referenced in proofs
- **153k x402 settlements** tracked, $24.5k USDC volume
- 1,513 unique buyers seen
- Onchain-composable via [Ethereum Attestation Service schema](https://base.easscan.org/schema/view/0xe572079c100f08f537660248df84c632a7c4e5ad3b1d644dc36abb7d993cfe6f)

## How a Bankr agent uses it

```bash
# Free score lookup
curl https://avisradar-production.up.railway.app/api/agent/score/0xAgentAddr

# Premium audit ($0.25 USDC via x402)
curl https://avisradar-production.up.railway.app/api/agent/audit/0xAgentAddr

# Risk-only verdict ($0.50 USDC via x402)
curl https://avisradar-production.up.railway.app/api/agent/risk-report/0xAgentAddr
```

5 shell scripts included in `scripts/` for the common flows (score, attestation, verify, canonical-id, audit-batch). All match the format used by other skills (helixa, erc-8004, alchemy).

Adjacent skills in this registry: Helixa (Cred Scores), ERC-8004 (identity NFTs), SIWA (auth). MainStreet sits between them — it consumes ERC-8004 feedback, complements Helixa's Cred Score with multi-source identity proofs, and is verifiable on-chain via the deployed Solidity contract.

— [@rakshasar](https://warpcast.com/rakshasar) on Farcaster · mainstreetxyz.base.eth