### PR TITLE
Add Lintmus skill — token due diligence for EVM and Solana

### DIFF
--- a/lintmus/SKILL.md
+++ b/lintmus/SKILL.md
@@ -53,7 +53,7 @@ Reports are cached for 60 minutes. If the same token is analyzed twice within an
 ## Endpoint
 
 ```
-POST https://x402.bankr.bot/0xD3aDb4D4B787eE631A1B2618464e21B229873075/analyze
+POST https://x402.bankr.bot/0x8901c544cfb3f1e87ae80e66154b04aee5f0448f/Lintmus
 Content-Type: application/json
 
 {

--- a/lintmus/SKILL.md
+++ b/lintmus/SKILL.md
@@ -13,13 +13,16 @@ install the lintmus skill from https://github.com/lintmus/lintmus
 Lintmus analyzes a token contract and returns:
 
 - **Safety score** (0–100) — aggregated from all data sources
-- **Honeypot detection** — via GoPlus Security API
+- **Honeypot detection** — via GoPlus Security and honeypot.is
 - **Tax analysis** — buy/sell tax percentages
 - **Ownership flags** — mintable, hidden owner, pausable, blacklist
 - **Liquidity** — USD liquidity, 24h volume, LP lock status
 - **Age** — how long the token has been trading
+- **Social signals** — website and social links presence
+- **Liquidity seeding detection** — new tokens with suspiciously high liquidity
+- **Malicious holder detection** — top holders flagged by GoPlus
 - **Contract verification** — is source code public?
-- **Deployer history** — has this wallet rugged before?
+- **Deployer history** — cross-chain rug history via Alchemy (Base, ETH, Polygon)
 
 ## Usage
 

--- a/lintmus/SKILL.md
+++ b/lintmus/SKILL.md
@@ -1,0 +1,76 @@
+# Lintmus
+
+Token due diligence for the bankr.bot ecosystem. Get a safety score, honeypot detection, liquidity health, and deployer history for any EVM or Solana token — before you trade.
+
+## Install
+
+```
+install the lintmus skill from https://github.com/lintmus/lintmus
+```
+
+## Core Capabilities
+
+Lintmus analyzes a token contract and returns:
+
+- **Safety score** (0–100) — aggregated from all data sources
+- **Honeypot detection** — via GoPlus Security API
+- **Tax analysis** — buy/sell tax percentages
+- **Ownership flags** — mintable, hidden owner, pausable, blacklist
+- **Liquidity** — USD liquidity, 24h volume, LP lock status
+- **Age** — how long the token has been trading
+- **Contract verification** — is source code public?
+- **Deployer history** — has this wallet rugged before?
+
+## Usage
+
+Once installed, ask your agent:
+
+```
+analyze token 0x532f27101965dd16442e59d40670faf5ebb142e4 on base
+```
+
+```
+is this token safe? 0xADDRESS on ethereum
+```
+
+```
+run lintmus on 0xADDRESS before I buy
+```
+
+## Supported chains
+
+- `base` — Base mainnet
+- `eth` — Ethereum mainnet
+- `polygon` — Polygon
+- `solana` — Solana
+
+## Pricing
+
+**0.03 USDC per report** — paid via x402 on Base.
+
+Reports are cached for 60 minutes. If the same token is analyzed twice within an hour, the second request is free.
+
+## Endpoint
+
+```
+POST https://x402.bankr.bot/0xD3aDb4D4B787eE631A1B2618464e21B229873075/analyze
+Content-Type: application/json
+
+{
+  "address": "0x532f27101965dd16442e59d40670faf5ebb142e4",
+  "chain": "base"
+}
+```
+
+## Data sources
+
+- [GoPlus Security](https://gopluslabs.io) — honeypot, tax, ownership flags
+- [DexScreener](https://dexscreener.com) — liquidity, volume, price
+- [Etherscan API V2](https://etherscan.io) — contract verification
+- [Alchemy](https://alchemy.com) — deployer address lookup
+
+## About
+
+Built on the bankr.bot infrastructure layer. The Lintmus rug database grows with every analysis — historical accuracy data is published openly so anyone can verify the scoring methodology.
+
+Token: $LINTMUS on Base


### PR DESCRIPTION
Adds the Lintmus skill — multi-source token due diligence for EVM and Solana. Returns a 0–100 safety score covering honeypot detection, tax analysis, ownership flags, liquidity health, contract verification, and deployer history. Priced at 0.03 USDC via x402. 

Repo: https://github.com/Lintmus/Lintmus

Web: https://www.lintmus.com