### PR TITLE
feat(blueagent): update to v2 — 53 tools, blueagent.dev endpoint

### DIFF
--- a/blueagent/SKILL.md
+++ b/blueagent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: blueagent-x402
 description: >
-  53 pay-per-use AI tools for Base builders, traders, and agents — powered by Blue Agent.
+  64 pay-per-use AI tools for Base builders, traders, and agents — powered by Blue Agent.
   Use when you need to analyze tokens (honeypot, deep DD, security), audit wallets (PnL, AML, airdrop),
   get builder intelligence (market fit, pitch, GTM, investor memo), track narratives and whale flows,
   scan quantum risk, or optimize DeFi yield. All tools run on Base, pay USDC via x402. No API key needed.
@@ -18,7 +18,7 @@ metadata:
 
 # Blue Agent x402 — 53 AI Tools for Base
 
-53 pay-per-use AI services on Base — pay USDC per call via x402. No subscription, no API key.
+64 pay-per-use AI services on Base — pay USDC per call via x402. No subscription, no API key.
 
 **Base URL:** `https://blueagent.dev/api/x402`
 **Token:** `$BLUEAGENT` — `0xf895783b2931c919955e18b5e3343e7c7c456ba3` (Base)

--- a/blueagent/SKILL.md
+++ b/blueagent/SKILL.md
@@ -1,136 +1,309 @@
 ---
 name: blueagent-x402
 description: >
-  Security OS for autonomous agents and builders on Base.
-  31 pay-per-use tools across Quantum Security, Agent Safety, Research, Data, and Earn.
-  Built for AI agents, Zero-Human Companies (ZHC), and Base ecosystem builders.
-  Pay USDC per call via x402 protocol — no subscription, no API key needed.
+  53 pay-per-use AI tools for Base builders, traders, and agents — powered by Blue Agent.
+  Use when you need to analyze tokens (honeypot, deep DD, security), audit wallets (PnL, AML, airdrop),
+  get builder intelligence (market fit, pitch, GTM, investor memo), track narratives and whale flows,
+  scan quantum risk, or optimize DeFi yield. All tools run on Base, pay USDC via x402. No API key needed.
 metadata:
   {
     "clawdbot":
       {
         "emoji": "🟦",
-        "homepage": "https://github.com/madebyshun/blueagent-x402-services",
+        "homepage": "https://github.com/madebyshun/blue-agent",
         "requires": { "bins": ["bankr"] },
       },
   }
 ---
 
-# BlueAgent x402 — Security OS for Autonomous Agents
+# Blue Agent x402 — 53 AI Tools for Base
 
-**31 pay-per-use AI tools on Base** — Quantum Security · Agent Safety · Research · Data · Earn
+53 pay-per-use AI services on Base — pay USDC per call via x402. No subscription, no API key.
 
-**Base URL:** `https://x402.bankr.bot/0xf31f59e7b8b58555f7871f71973a394c8f1bffe5/`
-
----
-
-## QUANTUM SECURITY
-
-| Service | Price | Description |
-|---------|-------|-------------|
-| `quantum-premium` | $1.50 | Wallet quantum vulnerability score — public key exposure, threat timeline, migration steps |
-| `quantum-batch` | up to $2.50 | Scan 1–10 wallets at $0.25 each — pay only for what you scan |
-| `quantum-migrate` | $2.00 | Step-by-step quantum-safe migration plan with tools and timeline |
-| `quantum-timeline` | $0.40 | Evidence-based quantum threat timeline — when CRQC arrives and what it means |
-| `key-exposure` | $0.50 | Check if wallet's public key is exposed on-chain — the #1 quantum risk factor |
+**Base URL:** `https://blueagent.dev/api/x402`
+**Token:** `$BLUEAGENT` — `0xf895783b2931c919955e18b5e3343e7c7c456ba3` (Base)
+**Community:** https://t.me/blueagent_hub
 
 ---
 
-## AGENT SAFETY
+## Tool Catalog
 
-| Service | Price | Description |
-|---------|-------|-------------|
-| `risk-gate` | $0.05 | Pre-transaction safety check — APPROVE / WARN / BLOCK with risk score |
-| `honeypot-check` | $0.05 | Detect honeypot or rug pull contracts before buying |
-| `allowance-audit` | $0.20 | Audit dangerous token approvals — find unlimited allowances to revoke |
-| `phishing-scan` | $0.10 | Scan URL, address, or @handle for phishing and scam indicators |
-| `mev-shield` | $0.30 | MEV sandwich attack risk before large swaps — protection strategies |
-| `contract-trust` | $0.25 | Trust score for any contract — verified, audited, safe for agent interaction? |
-| `aml-screen` | $0.25 | AML compliance screening — transaction patterns, risk flags |
-| `circuit-breaker` | $0.50 | CONTINUE / PAUSE / HALT decision for autonomous agents and ZHC |
+### 🔍 Intelligence (5 tools)
 
----
+| Tool | Price | Description |
+|------|-------|-------------|
+| `token-pick-signal` | $0.20 | Highest-conviction asymmetric token setup on Base right now |
+| `narrative-position` | $0.15 | Which CT narratives are building vs peaking — where to position |
+| `ecosystem-digest` | $0.20 | Weekly Base ecosystem intelligence: builders, protocols, narratives |
+| `market-fit` | $0.25 | Score your product's market fit with 3-agent swarm intelligence |
+| `token-launch-readiness` | $0.30 | Go/no-go signal on whether your project is ready to launch a token |
 
-## RESEARCH
+### 🛠️ Builder (20 tools)
 
-| Service | Price | Description |
-|---------|-------|-------------|
-| `deep-analysis` | $0.35 | Deep due diligence for any Base token or project — risk score, rug probability |
-| `tokenomics-score` | $0.50 | Supply, inflation, unlock cliff analysis — sustainability score, sell pressure |
-| `whitepaper-tldr` | $0.20 | Summarize any whitepaper into 5 key bullets — thesis, moat, risks |
-| `narrative-pulse` | $0.40 | Trending crypto narratives — momentum scores, Base ecosystem themes |
-| `vc-tracker` | $1.00 | VC investment activity — hot sectors, thesis, signals for builders and traders |
-| `launch-advisor` | $3.00 | Full token launch playbook — tokenomics, 8-week timeline, marketing, KPIs |
-| `grant-evaluator` | $5.00 | Base ecosystem grant scoring — innovation, feasibility, impact, team quality |
-| `x402-readiness` | $1.00 | Audit any API for x402 payment protocol readiness — gaps, steps, pricing |
-| `base-deploy-check` | $0.50 | Pre-deployment security check — vulnerabilities, centralization risks, go/no-go |
+| Tool | Price | Description |
+|------|-------|-------------|
+| `blue-idea` | $0.05 | Turn a rough concept into a fundable brief |
+| `blue-build` | $0.50 | Architecture, stack, folder structure, integrations, test plan |
+| `blue-audit` | $1.00 | Security + product risk review. Go/no-go verdict |
+| `blue-ship` | $0.10 | Deployment checklist, verification, release notes |
+| `blue-raise` | $0.20 | Fundraising narrative and investor deck outline |
+| `roadmap-validator` | $0.25 | Validate roadmap against market timing and narrative fit |
+| `competitor-scan` | $0.20 | Identify competitors and surface your defensible edge |
+| `pitch-intelligence` | $0.30 | Investor-grade pitch intelligence with narrative scoring |
+| `fundraise-timing` | $0.20 | Is now the right time to raise? Market + stage readiness signal |
+| `gtm-brief` | $0.25 | Go-to-market playbook: channels, timing, messaging |
+| `stack-recommender` | $0.20 | Optimal tech stack for Base builders |
+| `investor-memo` | $0.35 | Full investor memo: thesis, market, moat, risks, ask |
+| `token-distribution-plan` | $0.30 | Token allocation: team, community, investors, treasury, liquidity |
+| `agent-performance` | $0.25 | Benchmark your AI agent's revenue and engagement metrics |
+| `agent-collab-match` | $0.20 | Find agents that complement your tool |
+| `repo-health` | $0.20 | Audit GitHub repo: code quality, docs, CI, contributor signals |
+| `community-sentiment` | $0.20 | Sentiment analysis across your community channels |
+| `defi-opportunity` | $0.25 | Scan Base DeFi for emerging yield and protocol opportunities |
+| `builder-deep-dd` | $0.35 | Full due diligence on any Base builder |
+| `launch-simulator` | $0.50 | Token launch simulation: Blue + Aeon + MiroShark 3-agent consensus |
+| `launch-simulator-2` | $0.35 | Launch Simulator Tier 2 — with live DexScreener market data |
+| `launch-simulator-3` | $0.50 | Launch Simulator Tier 3 — full simulation with risk matrix |
+| `launch-advisor` | $3.00 | Full token launch playbook: tokenomics, 8-week timeline, KPIs |
+| `grant-evaluator` | $5.00 | Grant application scoring using Base/Coinbase criteria |
+| `builder-score` | $0.35 | Builder reputation score (0-100) for any X/Twitter handle |
+| `agent-score` | $0.35 | Performance score for AI agents on Base |
 
----
+### 📈 Trading & Alpha (3 tools)
 
-## DATA & ALERTS
+| Tool | Price | Description |
+|------|-------|-------------|
+| `whale-copy-signal` | $0.25 | Track and copy high-alpha whale wallets on Base |
+| `token-momentum-scanner` | $0.20 | Real-time momentum scan — breakouts, volume spikes |
+| `portfolio-rebalancer` | $0.25 | AI-driven portfolio rebalancing for Base market conditions |
 
-| Service | Price | Description |
-|---------|-------|-------------|
-| `wallet-pnl` | $1.00 | Wallet PnL report — win rate, trading style, smart money score |
-| `whale-tracker` | $0.10 | Smart money flow analysis — accumulation vs distribution signal |
-| `dex-flow` | $0.15 | DEX buy/sell pressure and volume flow — live DexScreener data |
-| `airdrop-check` | $0.10 | Base airdrop eligibility — which protocols, activity score, estimated value |
+### 📣 Content (3 tools)
+
+| Tool | Price | Description |
+|------|-------|-------------|
+| `thread-intelligence` | $0.20 | Turn alpha or updates into high-engagement X threads |
+| `builder-brand-score` | $0.25 | Score your personal brand as a Base builder |
+| `community-growth-playbook` | $0.25 | Proven growth tactics for Base builder communities |
+
+### 🤖 Agent Economy (3 tools)
+
+| Tool | Price | Description |
+|------|-------|-------------|
+| `agent-revenue-optimizer` | $0.30 | Maximize your agent's x402 revenue and pricing strategy |
+| `agent-token-strategy` | $0.30 | Design your agent token: utility, distribution, launch sequence |
+| `multi-agent-workflow` | $0.25 | Design automated multi-agent workflows with x402 payment routing |
+
+### 🌐 Base Ecosystem (3 tools)
+
+| Tool | Price | Description |
+|------|-------|-------------|
+| `base-grant-finder` | $0.20 | Match your project to Base ecosystem grants |
+| `base-protocol-comparison` | $0.25 | Side-by-side comparison of Base protocols |
+| `base-builder-network-match` | $0.20 | Connect with Base builders who complement your skills |
+
+### ⛓️ On-chain (7 tools)
+
+| Tool | Price | Description |
+|------|-------|-------------|
+| `wallet-strategy-analyzer` | $0.30 | Decode any wallet's on-chain strategy and alpha signals |
+| `protocol-risk-monitor` | $0.35 | Real-time risk assessment for your DeFi positions |
+| `wallet-pnl` | $1.00 | Deep PnL report for any Base wallet |
+| `aml-screen` | $0.25 | AML compliance screening — clean/suspicious verdict |
+| `airdrop-check` | $0.10 | Base airdrop eligibility check with activity score |
+| `whale-tracker` | $0.10 | Smart money and whale flow analysis for any token |
+| `dex-flow` | $0.15 | Live DEX buy/sell pressure and liquidity flow |
+
+### 🔒 Security (11 tools)
+
+| Tool | Price | Description |
+|------|-------|-------------|
+| `honeypot-check` | $0.10 | Detect honeypot tokens before buying — SAFE/SUSPICIOUS/HONEYPOT |
+| `risk-gate` | $0.05 | Pre-transaction safety check — APPROVE/WARN/BLOCK |
+| `deep-analysis` | $0.50 | Full due diligence on any Base token |
+| `contract-trust` | $0.15 | Trust score for any contract — safe for agent interaction? |
+| `quantum-premium` | $1.50 | Quantum vulnerability score for any wallet |
+| `quantum-batch` | $2.50 | Batch quantum scan — 1-10 wallets at $0.25 each |
+| `quantum-migrate` | $2.00 | Step-by-step quantum-safe wallet migration plan |
+| `quantum-timeline` | $0.40 | Quantum threat timeline — when CRQC arrives, what it means |
+| `key-exposure` | $0.50 | Check if wallet's public key is exposed on-chain |
+
+### 💰 Earn (3 tools)
+
+| Tool | Price | Description |
+|------|-------|-------------|
+| `yield-optimizer` | $0.15 | Best APY opportunities on Base DeFi — live DeFiLlama data |
+| `lp-analyzer` | $0.25 | LP position analysis: impermanent loss, fee income, rebalance |
+| `tax-report` | $2.00 | On-chain tax summary: realized gains, taxable events, P&L |
+
+### 🔔 Alerts (2 tools)
+
+| Tool | Price | Description |
+|------|-------|-------------|
+| `alert-subscribe` | $0.50 | Subscribe to real-time alerts via webhook |
 | `alert-check` | $0.10 | Check active alert triggers for any address |
-
----
-
-## EARN
-
-| Service | Price | Description |
-|---------|-------|-------------|
-| `yield-optimizer` | $0.15 | Best APY on Base DeFi — live DeFiLlama data, risk-adjusted recommendations |
-| `lp-analyzer` | $0.25 | LP position analysis — impermanent loss, fee income, rebalance recommendation |
-| `tax-report` | $2.00 | On-chain tax summary — realized gains, taxable events, P&L |
-| `alert-subscribe` | $0.50 | Subscribe to real-time alerts via webhook — whale, circuit breaker, quantum |
 
 ---
 
 ## Quick Start
 
-### CLI
+### Using Bankr CLI
+
 ```bash
-npm install -g @blueagent/cli
-blueagent setup
-blueagent honeypot-check 0xTOKEN
-blueagent risk-gate "approve USDC to Uniswap"
-blueagent analyze "$BRETT"
+# Security scan a token
+bankr x402 call blueagent.dev/api/x402/honeypot-check \
+  -X POST -d '{"token":"0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"}' -y
+
+# Pre-tx risk check
+bankr x402 call blueagent.dev/api/x402/risk-gate \
+  -X POST -d '{"action":"buy token","contractAddress":"0x...","amount":"$50"}' -y
+
+# Wallet PnL
+bankr x402 call blueagent.dev/api/x402/wallet-pnl \
+  -X POST -d '{"address":"0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045"}' -y
+
+# Token launch readiness
+bankr x402 call blueagent.dev/api/x402/token-launch-readiness \
+  -X POST -d '{"name":"MyToken","description":"A DeFi protocol on Base"}' -y
+
+# Market fit validator
+bankr x402 call blueagent.dev/api/x402/market-fit \
+  -X POST -d '{"description":"A USDC streaming payroll app for DAOs on Base"}' -y
 ```
 
-### SDK
-```typescript
-import { BlueAgent } from '@blueagent/sdk'
+### Using x402-fetch (JS/TS)
 
-const ba = new BlueAgent({ privateKey: process.env.WALLET_PRIVATE_KEY })
-await ba.security.riskcheck({ action: 'swap 100 USDC' })
-await ba.research.analyze({ projectName: '$BRETT' })
-await ba.earn.yieldOptimizer({ token: 'USDC' })
-```
-
-### MCP (Claude Code / AgentKit)
 ```bash
-npx @blueagent/skill install --claude
+npm install x402-fetch viem
 ```
 
-### ZHC Circuit Breaker
 ```typescript
-const status = await ba.security.circuitBreaker({
-  agentId: 'my-zhc',
-  context: 'consecutive losses detected',
-  recentLosses: '$340'
-})
-// { decision: "PAUSE", cooldownPeriod: "30 minutes", requiresHumanReview: false }
+import { wrapFetchWithPayment } from 'x402-fetch';
+import { createWalletClient, http } from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { base } from 'viem/chains';
+
+const account = privateKeyToAccount('0xYOUR_PRIVATE_KEY');
+const wallet = createWalletClient({ account, chain: base, transport: http() });
+const paidFetch = wrapFetchWithPayment(fetch, wallet);
+
+// Security scan
+const res = await paidFetch('https://blueagent.dev/api/x402/honeypot-check', {
+  method: 'POST',
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify({ token: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' })
+});
+const data = await res.json();
 ```
+
+---
+
+## Key Service Details
+
+### `risk-gate` — $0.05/req
+Pre-transaction safety check for AI agents.
+
+**Input:**
+```json
+{
+  "action": "buy token on Uniswap",
+  "contractAddress": "0x...",
+  "amount": "$50",
+  "agentId": "my-agent"
+}
+```
+
+**Output:**
+```json
+{
+  "decision": "APPROVE",
+  "riskScore": 18,
+  "riskLevel": "Low",
+  "reasons": ["Verified contract", "Reasonable amount"],
+  "recommendation": "Safe to proceed"
+}
+```
+**Decision values:** `APPROVE` | `WARN` | `BLOCK`
+
+---
+
+### `honeypot-check` — $0.10/req
+Detect honeypot tokens before buying.
+
+**Input:** `{ "token": "0x..." }`
+
+**Output:**
+```json
+{
+  "verdict": "SAFE",
+  "isHoneypot": false,
+  "riskScore": 12,
+  "indicators": [],
+  "safeToTrade": true
+}
+```
+**Verdict values:** `SAFE` | `SUSPICIOUS` | `HONEYPOT`
+
+---
+
+### `deep-analysis` — $0.50/req
+Full due diligence on any Base token.
+
+**Input:** `{ "token": "0x..." }` or `{ "projectName": "Uniswap" }`
+
+**Output:**
+```json
+{
+  "overallScore": 88,
+  "riskScore": 12,
+  "rugProbability": 2,
+  "recommendation": "Strong Buy",
+  "summary": "..."
+}
+```
+
+---
+
+### `wallet-pnl` — $1.00/req
+Deep PnL analysis for any Base wallet.
+
+**Input:** `{ "address": "0x..." }`
+
+**Output:**
+```json
+{
+  "estimatedPnL": "+$3,240",
+  "winRate": "68%",
+  "tradingStyle": "Memecoin Aper",
+  "smartMoneyScore": 72,
+  "summary": "..."
+}
+```
+
+---
+
+### `market-fit` — $0.25/req
+Score your product's market fit.
+
+**Input:** `{ "description": "A USDC streaming payroll app for DAOs on Base" }`
+
+**Output:**
+```json
+{
+  "verdict": "GO",
+  "score": 78,
+  "brief": { "problem": "...", "market": "...", "differentiation": "..." },
+  "risks": ["..."],
+  "suggested_change": "..."
+}
+```
+**Verdict values:** `GO` | `WAIT` | `PIVOT`
 
 ---
 
 ## Resources
 
-- **GitHub:** https://github.com/madebyshun/blueagent-x402-services
-- **Token:** $BLUEAGENT on Base
+- **GitHub:** https://github.com/madebyshun/blue-agent
+- **Console:** https://blueagent.dev
+- **Token:** $BLUEAGENT on Base — `0xf895783b2931c919955e18b5e3343e7c7c456ba3`
 - **Community:** https://t.me/blueagent_hub
-- **Skills:** https://skills.bankr.bot
+- **X:** https://x.com/blueagent_


### PR DESCRIPTION
## Blue Agent x402 — v2 Update

Updating the `blueagent` skill from the original 31-tool submission to the current v2 state.

### What changed

| | Before | After |
|---|---|---|
| Tools | 31 | **53** |
| Base URL | `x402.bankr.bot/0xf31f...` | `https://blueagent.dev/api/x402` |
| Repo | `blueagent-x402-services` | `blue-agent` |
| Hosting | Bankr x402 infra | Self-hosted on Vercel (blueagent.dev) |
| Categories | 5 | **10** |

### 10 categories, 53 tools

- 🔍 **Intelligence** (5) — token picks, narratives, ecosystem digest, market fit, launch readiness
- 🛠️ **Builder** (20) — blue-idea/build/audit/ship/raise, roadmap, pitch, GTM, investor memo, launch simulator
- 📈 **Trading** (3) — whale copy signal, momentum scanner, portfolio rebalancer
- 📣 **Content** (3) — thread intelligence, builder brand score, community growth
- 🤖 **Agent Economy** (3) — revenue optimizer, token strategy, multi-agent workflow
- 🌐 **Base Ecosystem** (3) — grant finder, protocol comparison, builder network match
- ⛓️ **On-chain** (7) — wallet PnL, AML screen, airdrop check, whale tracker, DEX flow
- 🔒 **Security** (9) — honeypot check, risk gate, deep analysis, quantum security suite
- 💰 **Earn** (3) — yield optimizer, LP analyzer, tax report
- 🔔 **Alerts** (2) — webhook subscribe, trigger check

### Live

All 53 tools are live at `https://blueagent.dev/api/x402/{tool-id}` — pay USDC per call on Base via x402.

**Token:** `$BLUEAGENT` — `0xf895783b2931c919955e18b5e3343e7c7c456ba3` (Base)
**X:** [@blueagent_](https://x.com/blueagent_)
**Community:** [t.me/blueagent_hub](https://t.me/blueagent_hub)