### PR TITLE
Fix dashboard links: bankr.bot/api → bankr.bot/api-keys

### DIFF
--- a/BOTCOIN/skill.md
+++ b/BOTCOIN/skill.md
@@ -13,10 +13,10 @@ Mine BOTCOIN by solving hybrid natural language challenges. Your LLM reads a pro
 ## Prerequisites
 
 1. **Bankr API key** with write access enabled. Set as `BANKR_API_KEY` env var.
-   - Sign up at [bankr.bot/api](https://bankr.bot/api) (email or X/Twitter login)
+   - Sign up at [bankr.bot/api-keys](https://bankr.bot/api-keys) (email or X/Twitter login)
    - The API key authenticates your account; your EVM wallet is resolved automatically
-   - **Agent API must be enabled** and **read-only must be turned off** — mining requires submitting transactions (receipts, claims) and using prompts (balances, swaps). Enable these at bankr.bot/api.
-   - **Recommended:** Configure your API key's `allowedIps` at [bankr.bot/api](https://bankr.bot/api) to restrict signing to your server's IP address only. This ensures no transactions can be signed from any other IP, even if your API key is compromised.
+   - **Agent API must be enabled** and **read-only must be turned off** — mining requires submitting transactions (receipts, claims) and using prompts (balances, swaps). Enable these at bankr.bot/api-keys.
+   - **Recommended:** Configure your API key's `allowedIps` at [bankr.bot/api-keys](https://bankr.bot/api-keys) to restrict signing to your server's IP address only. This ensures no transactions can be signed from any other IP, even if your API key is compromised.
 
 2. **Bankr skill installed.** If you don't already have the Bankr OpenClaw skill, install it now:
    ```
@@ -684,6 +684,6 @@ Use one retry helper for all coordinator calls.
 
 ### Bankr errors
 - **401 from Bankr**: Invalid API key. Stop and tell user to check `BANKR_API_KEY`.
-- **403 from Bankr**: Key lacks write/agent access. Stop and tell user to enable it at bankr.bot/api.
+- **403 from Bankr**: Key lacks write/agent access. Stop and tell user to enable it at bankr.bot/api-keys.
 - **429 from Bankr**: Rate limited. Wait 60 seconds and retry.
 - **Transaction failed**: Log the error and retry once. If it fails again, stop and report to user.

--- a/agenticbets/SKILL.md
+++ b/agenticbets/SKILL.md
@@ -52,7 +52,7 @@ bankr login email user@example.com --code 123456 --accept-terms --key-name "Agen
 
 **Option B: Web login**
 
-1. Visit [bankr.bot/api](https://bankr.bot/api)
+1. Visit [bankr.bot/api-keys](https://bankr.bot/api-keys)
 2. Sign in with email + OTP
 3. Generate an API key with **Wallet API** write access enabled
 

--- a/agenticbets/references/agent-usage.md
+++ b/agenticbets/references/agent-usage.md
@@ -84,7 +84,7 @@ Before placing a bet, an agent should:
    test -f ~/.bankr/config.json && echo "OK" || echo "Run: bankr login email <email>"
    ```
 
-2. **Verify write access** — the script will return 403 if key is read-only. On 403, instruct user to regenerate key with `--read-write` or toggle off "Read-only" at bankr.bot/api.
+2. **Verify write access** — the script will return 403 if key is read-only. On 403, instruct user to regenerate key with `--read-write` or toggle off "Read-only" at bankr.bot/api-keys.
 
 3. **Verify ETH balance for gas** — `/wallet/submit` broadcasts raw txs, so the Bankr wallet needs native ETH on Base. If the tx fails with "insufficient funds for gas," surface this clearly.
 

--- a/bankr-shopify/SKILL.md
+++ b/bankr-shopify/SKILL.md
@@ -32,7 +32,7 @@ The REST Admin API is legacy since 2024-04 and only receives security fixes. **U
    - `SHOPIFY_ACCESS_TOKEN` — admin token (starts with `shpat_`)
    - `SHOPIFY_STORE_DOMAIN` — `my-store.myshopify.com` (the permanent myshopify domain, not your custom one)
    - `SHOPIFY_API_VERSION` — default `2026-01`
-   - `BANKR_API_KEY` — for the Bankr bridge sections; generate at https://bankr.bot/api
+   - `BANKR_API_KEY` — for the Bankr bridge sections; generate at https://bankr.bot/api-keys
 
 > **Heads up:** As of January 1, 2026, new "legacy custom apps" created in the Shopify admin are gone. New setups should use the **Dev Dashboard** (`shopify.dev/docs/apps/build/dev-dashboard`). Existing admin-created apps keep working. If the user's shop has no existing custom app and it's after 2026-01-01, direct them to Dev Dashboard instead of the admin flow.
 

--- a/bankr/SKILL.md
+++ b/bankr/SKILL.md
@@ -43,7 +43,7 @@ This creates a wallet, accepts terms, and generates an API key — no browser ne
 
 **Option B: Bankr Terminal**
 
-1. Visit [bankr.bot/api](https://bankr.bot/api)
+1. Visit [bankr.bot/api-keys](https://bankr.bot/api-keys)
 2. **Sign up / Sign in** — Enter your email and the one-time passcode (OTP) sent to it
 3. **Generate an API key** — Create a key with **Wallet & Agent API** access enabled (the key starts with `bk_...`)
 
@@ -484,7 +484,7 @@ bankr agent cancel job_abc123
 
 The [Bankr LLM Gateway](https://docs.bankr.bot/llm-gateway/overview) is a unified API for Claude, Gemini, GPT, Grok, DeepSeek, Qwen, Kimi, MiniMax, GLM, and other models — multi-provider access, cost tracking, automatic failover, and SDK compatibility through a single endpoint.
 
-**Base URL:** `https://llm.bankr.bot` | **Dashboard:** [bankr.bot/llm](https://bankr.bot/llm) | **API Keys:** [bankr.bot/api](https://bankr.bot/api)
+**Base URL:** `https://llm.bankr.bot` | **Dashboard:** [bankr.bot/llm](https://bankr.bot/llm) | **API Keys:** [bankr.bot/api-keys](https://bankr.bot/api-keys)
 
 ### Key Concepts
 
@@ -692,9 +692,9 @@ User-controlled settings that apply to every surface — chat, agent, API, CLI. 
 
 If USD pricing is unavailable and a limit is enabled, the transaction is **rejected** (fail-closed) rather than waved through. Your own wallet addresses are always implicitly allowed as recipients.
 
-### API-Key Level Controls (bankr.bot/api)
+### API-Key Level Controls (bankr.bot/api-keys)
 
-Per-key settings configured at [bankr.bot/api](https://bankr.bot/api):
+Per-key settings configured at [bankr.bot/api-keys](https://bankr.bot/api-keys):
 
 **API Key Types**: Bankr uses a single key format (`bk_...`) with capability flags (`walletApiEnabled`, `agentApiEnabled`, `tokenLaunchApiEnabled`, `llmGatewayEnabled`). You can optionally configure a separate LLM Gateway key via `bankr config set llmKey` or `BANKR_LLM_KEY` — useful when you want independent revocation or different permissions for agent vs LLM access.
 
@@ -709,7 +709,7 @@ Per-key settings configured at [bankr.bot/api](https://bankr.bot/api):
 If you suspect a key is compromised:
 
 1. **Pause** the wallet at [bankr.bot](https://bankr.bot) → Security — halts every outbound transaction immediately
-2. **Revoke** the key at [bankr.bot/api](https://bankr.bot/api)
+2. **Revoke** the key at [bankr.bot/api-keys](https://bankr.bot/api-keys)
 3. **Rotate** — generate a new key and update deployments
 4. **Audit** — review recent transactions and agent job history before unpausing
 
@@ -724,7 +724,7 @@ If you suspect a key is compromised:
 - Add `~/.bankr/` and `.env` to `.gitignore` — the CLI stores credentials in `~/.bankr/config.json`
 - Test with small amounts on low-cost chains (Base, Polygon) before production use
 - Use `waitForConfirmation: true` with `/wallet/submit` — transactions execute immediately with no confirmation prompt
-- Rotate keys periodically via the dashboard or API key rotation endpoint, and revoke immediately if compromised at [bankr.bot/api](https://bankr.bot/api)
+- Rotate keys periodically via the dashboard or API key rotation endpoint, and revoke immediately if compromised at [bankr.bot/api-keys](https://bankr.bot/api-keys)
 
 **Reference**: [references/safety.md](references/safety.md)
 
@@ -1058,7 +1058,7 @@ curl -X POST "https://api.bankr.bot/wallet/submit" \
 
 - **Documentation**: https://docs.bankr.bot
 - **LLM Gateway Docs**: https://docs.bankr.bot/llm-gateway/overview
-- **API Key Management**: https://bankr.bot/api
+- **API Key Management**: https://bankr.bot/api-keys
 - **Terminal**: https://bankr.bot/terminal
 - **CLI Package**: https://www.npmjs.com/package/@bankr/cli
 - **Twitter**: @bankr_bot

--- a/bankr/references/api-workflow.md
+++ b/bankr/references/api-workflow.md
@@ -289,7 +289,7 @@ done
 }
 ```
 
-**Resolution**: Check API key, ensure "Wallet & Agent API" access is enabled at https://bankr.bot/api
+**Resolution**: Check API key, ensure "Wallet & Agent API" access is enabled at https://bankr.bot/api-keys
 
 ### Forbidden (403)
 ```json
@@ -299,7 +299,7 @@ done
 }
 ```
 
-**Resolution**: Visit https://bankr.bot/api and enable Wallet & Agent API access on your key
+**Resolution**: Visit https://bankr.bot/api-keys and enable Wallet & Agent API access on your key
 
 ### Rate Limiting (429)
 ```json
@@ -387,7 +387,7 @@ done
 - Use environment variables or config.json
 - Rotate periodically
 - Monitor usage
-- Revoke immediately if leaked at https://bankr.bot/api
+- Revoke immediately if leaked at https://bankr.bot/api-keys
 
 ### Validation
 - Validate user input

--- a/bankr/references/error-handling.md
+++ b/bankr/references/error-handling.md
@@ -21,7 +21,7 @@ bun install -g @bankr/cli
 bankr login
 ```
 
-Or if you already have an API key from https://bankr.bot/api:
+Or if you already have an API key from https://bankr.bot/api-keys:
 ```bash
 bankr config set apiKey bk_your_actual_key_here
 ```
@@ -99,7 +99,7 @@ bankr agent "What is my balance?"
 | **400** | Bad request | Check prompt format, validate parameters |
 | **401** | Unauthorized | Fix API key (see Authentication section) |
 | **402** | Payment required | For LLM Gateway: top up via `bankr llm credits add 25` or at [bankr.bot/llm?tab=credits](https://bankr.bot/llm?tab=credits) (`bankr llm credits` to check). For Agent API: ensure wallet has funds for fees |
-| **403** | Forbidden | Agent API access not enabled — enable at https://bankr.bot/api |
+| **403** | Forbidden | Agent API access not enabled — enable at https://bankr.bot/api-keys |
 | **429** | Rate limited | Wait and retry with exponential backoff |
 | **500** | Server error | Retry after delay |
 | **502** | Bad gateway | Temporary issue, retry after delay |
@@ -212,7 +212,7 @@ To fix this:
 2. [Step 2]
 3. [Step 3]
 
-Need help? Visit https://bankr.bot/api
+Need help? Visit https://bankr.bot/api-keys
 ```
 
 ### Examples
@@ -281,7 +281,7 @@ When reporting issues, include:
 
 ### Resources
 - **Agent API Reference**: https://www.notion.so/Agent-API-2e18e0f9661f80cb83ccfc046f8872e3
-- **API Key Management**: https://bankr.bot/api
+- **API Key Management**: https://bankr.bot/api-keys
 - **Twitter**: @bankr_bot
 - **Telegram**: @bankr_ai_bot
 

--- a/bankr/references/llm-gateway.md
+++ b/bankr/references/llm-gateway.md
@@ -16,7 +16,7 @@ The gateway uses your **LLM key** for authentication. The key resolution order:
 
 Most users only need a single key for both the agent API and the LLM gateway. Set a separate LLM key only if your keys have different permissions or rate limits.
 
-**Dashboard:** Manage usage, credits, and auto top-up at [bankr.bot/llm](https://bankr.bot/llm). Top up credits at [bankr.bot/llm?tab=credits](https://bankr.bot/llm?tab=credits). Generate and configure API keys at [bankr.bot/api](https://bankr.bot/api).
+**Dashboard:** Manage usage, credits, and auto top-up at [bankr.bot/llm](https://bankr.bot/llm). Top up credits at [bankr.bot/llm?tab=credits](https://bankr.bot/llm?tab=credits). Generate and configure API keys at [bankr.bot/api-keys](https://bankr.bot/api-keys).
 
 ### Setting the LLM Key
 
@@ -152,7 +152,7 @@ If the user already has a Bankr account, they just need to configure the gateway
 ### Have Bankr Account
 
 1. Get an API key with **LLM Gateway** enabled:
-   - **Have a key?** Enable LLM Gateway at [bankr.bot/api](https://bankr.bot/api)
+   - **Have a key?** Enable LLM Gateway at [bankr.bot/api-keys](https://bankr.bot/api-keys)
    - **Need a key?** Generate via CLI: `bankr login email user@example.com` → `bankr login email user@example.com --code OTP --accept-terms --key-name "My Agent" --llm`
 2. Run: `bankr llm setup openclaw --install`
 3. Set default model in `~/.openclaw/openclaw.json`:
@@ -166,7 +166,7 @@ If the user already has a Bankr account, they just need to configure the gateway
 
 1. Send OTP: `bankr login email user@example.com`
 2. Complete setup: `bankr login email user@example.com --code OTP --accept-terms --key-name "My Agent" --llm`
-   - Can also create/configure keys at [bankr.bot/api](https://bankr.bot/api)
+   - Can also create/configure keys at [bankr.bot/api-keys](https://bankr.bot/api-keys)
 3. **Top up credits:** `bankr llm credits add 25` or at [bankr.bot/llm?tab=credits](https://bankr.bot/llm?tab=credits) — new wallets start with $0
 4. Verify: `bankr llm credits` (must show > $0)
 5. Run: `bankr llm setup openclaw --install`
@@ -190,7 +190,7 @@ Key resolution: `BANKR_LLM_KEY` env var → `llmKey` in config → falls back to
 
 ### Key Permissions
 
-Manage at [bankr.bot/api](https://bankr.bot/api):
+Manage at [bankr.bot/api-keys](https://bankr.bot/api-keys):
 
 | Toggle | Controls |
 |--------|----------|

--- a/bankr/references/safety.md
+++ b/bankr/references/safety.md
@@ -2,7 +2,7 @@
 
 Comprehensive safety guidance for building agents and integrations with the Bankr API and CLI. Covers wallet-level security settings, API key access controls, wallet separation, rate limits, and operational best practices.
 
-Bankr has two independent layers of safety controls: **wallet-level** (configured at [bankr.bot](https://bankr.bot) → Security; applies to every surface) and **per-API-key** (configured at [bankr.bot/api](https://bankr.bot/api); applies to one key). Both run independently — a transaction must satisfy both to broadcast.
+Bankr has two independent layers of safety controls: **wallet-level** (configured at [bankr.bot](https://bankr.bot) → Security; applies to every surface) and **per-API-key** (configured at [bankr.bot/api-keys](https://bankr.bot/api-keys); applies to one key). Both run independently — a transaction must satisfy both to broadcast.
 
 ## Wallet-Level Security Settings
 
@@ -44,7 +44,7 @@ The wallet-level permitted-recipients list is independent from the API-key `allo
 If you suspect a key is compromised:
 
 1. **Pause** the wallet at [bankr.bot](https://bankr.bot) → Security. Halts every outbound transaction immediately, including in-flight broadcasts. Revoking the key alone does not stop transactions already past auth.
-2. **Revoke** the key at [bankr.bot/api](https://bankr.bot/api).
+2. **Revoke** the key at [bankr.bot/api-keys](https://bankr.bot/api-keys).
 3. **Rotate** — generate a new key with the same access profile and update deployments.
 4. **Audit** — review recent transactions and agent job history before unpausing.
 
@@ -54,7 +54,7 @@ Bankr uses a single key format (`bk_...`) with **capability flags** that control
 
 ### Capability Flags
 
-Each API key has independent toggles managed at [bankr.bot/api](https://bankr.bot/api):
+Each API key has independent toggles managed at [bankr.bot/api-keys](https://bankr.bot/api-keys):
 
 | Flag | Controls Access To | Default |
 |------|-------------------|---------|
@@ -91,7 +91,7 @@ For full LLM Gateway setup details, see [llm-gateway.md](llm-gateway.md).
 
 ## API Key Access Control
 
-Bankr API keys support granular access control configured at [bankr.bot/api](https://bankr.bot/api). Two key security features: **read-only mode** and **IP whitelisting**.
+Bankr API keys support granular access control configured at [bankr.bot/api-keys](https://bankr.bot/api-keys). Two key security features: **read-only mode** and **IP whitelisting**.
 
 ### Read-Only API Keys
 
@@ -113,7 +113,7 @@ For `/agent/sign`:
 ```json
 {
   "error": "Read-only API key",
-  "message": "This API key has read-only access and cannot sign messages or transactions. Update your API key permissions at https://bankr.bot/api"
+  "message": "This API key has read-only access and cannot sign messages or transactions. Update your API key permissions at https://bankr.bot/api-keys"
 }
 ```
 
@@ -121,7 +121,7 @@ For `/agent/submit`:
 ```json
 {
   "error": "Read-only API key",
-  "message": "This API key has read-only access and cannot submit transactions. Update your API key permissions at https://bankr.bot/api"
+  "message": "This API key has read-only access and cannot submit transactions. Update your API key permissions at https://bankr.bot/api-keys"
 }
 ```
 
@@ -161,7 +161,7 @@ API keys support an `allowedIps` whitelist with both individual IPs and CIDR ran
 
 ### Configuring Access Control
 
-Manage API key settings at [bankr.bot/api](https://bankr.bot/api):
+Manage API key settings at [bankr.bot/api-keys](https://bankr.bot/api-keys):
 
 | Field | Type | Description |
 |-------|------|-------------|
@@ -235,7 +235,7 @@ When building autonomous agents that execute transactions, use a **separate Bank
 
 ### Setup Steps
 
-1. **Create a new Bankr account** — Sign up at [bankr.bot/api](https://bankr.bot/api) with a different email. This provisions fresh EVM and Solana wallets automatically.
+1. **Create a new Bankr account** — Sign up at [bankr.bot/api-keys](https://bankr.bot/api-keys) with a different email. This provisions fresh EVM and Solana wallets automatically.
 2. **Generate an API key** — Enable **Agent API** access for the key
 3. **Configure access controls** — Set `readOnly`, `allowedIps`, or both as appropriate for your use case
 4. **Fund with limited amounts** — Transfer only what the agent needs for its operations
@@ -321,7 +321,7 @@ Blockchain transactions are **irreversible** once confirmed. Key safety rules:
 
 ### Rotation & Revocation
 
-- **Rotate periodically** — Rotate keys via the dashboard at [bankr.bot/api](https://bankr.bot/api) or programmatically via the API key rotation endpoint. Rotation atomically generates a new key and deactivates the old one. After rotating, update both env vars and CLI config (`bankr login --api-key NEW_KEY`)
+- **Rotate periodically** — Rotate keys via the dashboard at [bankr.bot/api-keys](https://bankr.bot/api-keys) or programmatically via the API key rotation endpoint. Rotation atomically generates a new key and deactivates the old one. After rotating, update both env vars and CLI config (`bankr login --api-key NEW_KEY`)
 - **Revoke immediately** — If any key (API or LLM) is leaked, deactivate it immediately at the dashboard
 - **One key per purpose** — Use separate keys for different agents, environments, and services (Agent API vs LLM Gateway) so you can revoke individually without disrupting unrelated systems
 

--- a/litcoin/README.md
+++ b/litcoin/README.md
@@ -64,7 +64,7 @@ Gives your agent the ability to:
 
 ## Requirements
 
-- Bankr API key with agent write access (get at [bankr.bot/api](https://bankr.bot/api))
+- Bankr API key with agent write access (get at [bankr.bot/api-keys](https://bankr.bot/api-keys))
 - Optional: AI provider key for research mining (OpenRouter, Bankr LLM, Groq, etc.)
 - Python 3.9+ (installed automatically by most agents)
 

--- a/litcoin/SKILL.md
+++ b/litcoin/SKILL.md
@@ -13,7 +13,7 @@ metadata:
     tags: [crypto, mining, defi, ai-agent, base, research, staking]
     required_environment_variables:
       - name: BANKR_API_KEY
-        prompt: "Paste your Bankr API key (starts with 'bk_'). Get one at https://bankr.bot/api with agent write access enabled."
+        prompt: "Paste your Bankr API key (starts with 'bk_'). Get one at https://bankr.bot/api-keys with agent write access enabled."
         help: "Controls the on-chain wallet used for mining, claims, staking, and vault operations."
         required_for: [mining, claims, staking, vaults, compute]
   openclaw:
@@ -30,7 +30,7 @@ metadata:
 
 Mine $LITCOIN on Base (chain 8453) using the Python SDK. Two mining paths: comprehension mining (no LLM needed) and research mining (LLM generates optimized code, tested in sandbox, verified on-chain).
 
-**Requirements:** Python 3.9+, a Bankr API key from [bankr.bot/api](https://bankr.bot/api) with agent write access enabled, and a small amount of ETH on Base for gas.
+**Requirements:** Python 3.9+, a Bankr API key from [bankr.bot/api-keys](https://bankr.bot/api-keys) with agent write access enabled, and a small amount of ETH on Base for gas.
 
 ## Install
 

--- a/litcoin/docs.md
+++ b/litcoin/docs.md
@@ -25,7 +25,7 @@ pip install litcoin
 from litcoin import Agent
 
 agent = Agent(
-    bankr_key="bk_YOUR_KEY",        # Bankr API key (get one at bankr.bot/api)
+    bankr_key="bk_YOUR_KEY",        # Bankr API key (get one at bankr.bot/api-keys)
     ai_key="sk-YOUR_KEY",           # AI provider key (enables relay mining)
     ai_url="https://api.openai.com/v1",  # Any OpenAI-compatible provider
     model="gpt-4o-mini",
@@ -70,7 +70,7 @@ Requirements: Python 3.9+, `requests` library. The miner auto-installs `websocke
 
 You need two things to mine:
 
-1. A Bankr wallet — create at https://bankr.bot, get an API key at https://bankr.bot/api, fund with some ETH on Base for gas.
+1. A Bankr wallet — create at https://bankr.bot, get an API key at https://bankr.bot/api-keys, fund with some ETH on Base for gas.
 2. An AI provider API key (optional but recommended for relay mining). Any OpenAI-compatible provider works: Bankr LLM Gateway (80% off for BNKR stakers), OpenAI, Groq (free tier), Together AI, Venice (venice.ai), or local Ollama.
 
 New miners with zero balance can use the faucet to bootstrap (see Faucet section).

--- a/litcoin/references/protocol.md
+++ b/litcoin/references/protocol.md
@@ -24,7 +24,7 @@ pip install litcoin
 from litcoin import Agent
 
 agent = Agent(
-    bankr_key="bk_YOUR_KEY",        # Bankr API key (get one at bankr.bot/api)
+    bankr_key="bk_YOUR_KEY",        # Bankr API key (get one at bankr.bot/api-keys)
     ai_key="sk-YOUR_KEY",           # AI provider key (enables relay + research mining)
     ai_url="https://openrouter.ai/api/v1",
     model="google/gemini-2.5-flash",
@@ -62,7 +62,7 @@ Requirements: Python 3.9+, `requests` library. The miner auto-installs `websocke
 
 You need two things to mine:
 
-1. A Bankr wallet — create at https://bankr.bot, get an API key at https://bankr.bot/api, fund with some ETH on Base for gas.
+1. A Bankr wallet — create at https://bankr.bot, get an API key at https://bankr.bot/api-keys, fund with some ETH on Base for gas.
 2. An AI provider: local Ollama (zero API cost, self-hosted), Bankr LLM (low-cost credits), Groq (free tier), OpenRouter, or any OpenAI-compatible provider. Local models recommended for relay mining.
 
 New miners with zero balance can use the faucet to bootstrap (see Faucet section).

--- a/nexus-trading-labs/references/deposit-withdraw.md
+++ b/nexus-trading-labs/references/deposit-withdraw.md
@@ -21,9 +21,9 @@ Returns `{ ok: true, amount, accountId, approveTxHash, depositTxHash }`. Funds l
 
 **Requirements:** Wallet & Agent API enabled on bankrApiKey, wallet has USDC on Arbitrum, wallet has ~0.00001 ETH for LayerZero fee.
 
-**allowedRecipients blocker:** If the key has `allowedRecipients` set, server returns 403. Fix: go to bankr.bot/api, clear the allowedRecipients list, retry.
+**allowedRecipients blocker:** If the key has `allowedRecipients` set, server returns 403. Fix: go to bankr.bot/api-keys, clear the allowedRecipients list, retry.
 
-**When to ask for Bankr API key:** "I need your Bankr API key to submit the deposit. Find it at bankr.bot/api — same key used for trading."
+**When to ask for Bankr API key:** "I need your Bankr API key to submit the deposit. Find it at bankr.bot/api-keys — same key used for trading."
 
 ### Prepare-only path (returns calldata for manual signing)
 
@@ -79,7 +79,7 @@ POST https://og.nexustradinglabs.com/proxy/bankr-withdraw
 }
 ```
 
-**`bankrApiKey` is MANDATORY.** Omitting it returns 401. Always ask the user for it before withdrawal: "I need your Bankr API key to sign the withdrawal. Find it at bankr.bot/api — Wallet & Agent API must be enabled."
+**`bankrApiKey` is MANDATORY.** Omitting it returns 401. Always ask the user for it before withdrawal: "I need your Bankr API key to sign the withdrawal. Find it at bankr.bot/api-keys — Wallet & Agent API must be enabled."
 
 Server: derives ed25519 key → fetches withdrawal nonce → builds EIP-712 Withdraw message → signs via Bankr eth_signTypedData_v4 → submits to Orderly /v1/withdraw_request. Funds arrive on Arbitrum, no user signature required.
 

--- a/nexus-trading-labs/references/market-data.md
+++ b/nexus-trading-labs/references/market-data.md
@@ -54,7 +54,7 @@ All price + market data for a symbol in one call.
 | `insufficient_margin` | Not enough free collateral | Reduce size, add leverage, or deposit |
 | `below_min_notional` | Order below Orderly minimum (~$10) | Increase notional |
 | `no_open_position` | https://og.nexustradinglabs.com/set-sl-tp with no position | Open position first |
-| `deposit_requires_wallet_execution` | allowedRecipients blocking tx | Clear at bankr.bot/api |
+| `deposit_requires_wallet_execution` | allowedRecipients blocking tx | Clear at bankr.bot/api-keys |
 | Orderly code 78 | Unsettled negative PnL blocking withdrawal | Server auto-handles; manual: settle-pnl then re-check free_collateral |
 | Orderly code 29 | EIP-712 signature invalid | Internal error — contact Nexus |
 

--- a/nexus-trading-labs/references/trading.md
+++ b/nexus-trading-labs/references/trading.md
@@ -7,7 +7,7 @@ Trigger when `/trade` returns `{ error: "wallet_not_registered" }`.
 (Full URL: `POST https://og.nexustradinglabs.com/trade`) `{ error: "wallet_not_registered" }`.
 
 **Step R1 — Ask for Bankr API key**
-> "Your wallet `<walletAddress>` isn't linked to a Nexus account yet. I need your Bankr API key for one-time setup — find it at bankr.bot/api (enable 'Wallet & Agent API'). It's used only for registration and never stored."
+> "Your wallet `<walletAddress>` isn't linked to a Nexus account yet. I need your Bankr API key for one-time setup — find it at bankr.bot/api-keys (enable 'Wallet & Agent API'). It's used only for registration and never stored."
 
 **Step R2 — Register**
 ```
@@ -21,7 +21,7 @@ POST https://og.nexustradinglabs.com/proxy/bankr-register
 Server: checks Orderly account → EIP-712 registers if needed → derives ed25519 key → stores in KV.
 
 If R2 returns EIP-712 blocked error:
-> "Your Bankr API key has 'allowed recipients' restrictions blocking EIP-712 signing. Generate a new key at bankr.bot/api without that restriction."
+> "Your Bankr API key has 'allowed recipients' restrictions blocking EIP-712 signing. Generate a new key at bankr.bot/api-keys without that restriction."
 
 **Step R3 — Retry the original trade immediately.** No user action needed.
 

--- a/opensea/docs/policy-administration.md
+++ b/opensea/docs/policy-administration.md
@@ -95,9 +95,9 @@ Reference: [Fireblocks TAP overview](https://developers.fireblocks.com/docs/set-
 
 ## Bankr
 
-Bankr key scope flags (`readOnly`, `walletApiEnabled`, `agentApiEnabled`, `allowedRecipients`, `allowedIps`, daily limits) are configured at [bankr.bot/api](https://bankr.bot/api) — there is no API to modify them programmatically, by design. To re-scope a key:
+Bankr key scope flags (`readOnly`, `walletApiEnabled`, `agentApiEnabled`, `allowedRecipients`, `allowedIps`, daily limits) are configured at [bankr.bot/api-keys](https://bankr.bot/api-keys) — there is no API to modify them programmatically, by design. To re-scope a key:
 
-1. Log in to bankr.bot/api on your operator machine.
+1. Log in to bankr.bot/api-keys on your operator machine.
 2. Edit the relevant key's flags. For an agent-signing key, set `allowedRecipients` to the EVM/Solana address allowlist the agent should be permitted to send to, set `allowedIps` to your deploy CIDR, set a daily message limit.
 3. If the agent is currently running, it will continue to use cached credentials until the next restart; rotate the key if you need an immediate cut-over.
 

--- a/opensea/opensea-wallet/SKILL.md
+++ b/opensea/opensea-wallet/SKILL.md
@@ -155,7 +155,7 @@ Each provider has a different out-of-band credential that gates mutation:
 | Privy | `owner_id` key quorum on the wallet — owner key held off-machine |
 | Turnkey | Root user quorum — non-root API user used for signing |
 | Fireblocks | Admin quorum for TAP changes; API user role set to `Signer` only |
-| Bankr | Dashboard re-scoping at bankr.bot/api — no API to mutate scope |
+| Bankr | Dashboard re-scoping at bankr.bot/api-keys — no API to mutate scope |
 
 Setting these up is part of the happy path in `references/wallet-setup.md`, not optional hardening. `opensea wallet info` reports whether the structural gate is in place where it can be detected via API; for Fireblocks and Bankr, where it cannot, the command prints a static reminder to verify at the console.
 

--- a/opensea/opensea-wallet/references/wallet-setup.md
+++ b/opensea/opensea-wallet/references/wallet-setup.md
@@ -235,7 +235,7 @@ Bankr is an HTTP signing service for agent wallets. The adapter calls Bankr's AP
 
 ### 1. Provision an API Key with appropriate scope flags
 
-Sign up at [bankr.bot](https://bankr.bot) and create a key at [bankr.bot/api](https://bankr.bot/api). Configure the key's scope flags as part of the happy path, not optional hardening:
+Sign up at [bankr.bot](https://bankr.bot) and create a key at [bankr.bot/api-keys](https://bankr.bot/api-keys). Configure the key's scope flags as part of the happy path, not optional hardening:
 
 - **For monitoring-only agents:** enable `readOnly`. The agent can call read endpoints (prices, balances, analytics) but `/wallet/sign` and `/wallet/submit` will return 403.
 - **For signing agents:** set the following on the key —
@@ -259,7 +259,7 @@ export BANKR_API_KEY="your-bankr-api-key"
 opensea wallet info
 ```
 
-Confirms the key reaches Bankr and prints the wallet address. The output will include the static reminder to re-verify scope flags at bankr.bot/api — this is by design, not a bug.
+Confirms the key reaches Bankr and prints the wallet address. The output will include the static reminder to re-verify scope flags at bankr.bot/api-keys — this is by design, not a bug.
 
 ### 4. Execute a Swap
 

--- a/signals/SKILL.md
+++ b/signals/SKILL.md
@@ -36,7 +36,7 @@ metrics and copy top performers. No self-reported results.
 1. **Create account** at [bankr.bot](https://bankr.bot) - provide email, get OTP, done.
    Creating an account automatically provisions EVM wallets (Base, Ethereum, Polygon, Unichain) and a Solana wallet.
 
-2. **Get API key** at [bankr.bot/api](https://bankr.bot/api) - create a key with **Agent API** access enabled. Key starts with `bk_`.
+2. **Get API key** at [bankr.bot/api-keys](https://bankr.bot/api-keys) - create a key with **Agent API** access enabled. Key starts with `bk_`.
 
 3. **Save config:**
 ```bash

--- a/trails/SKILL.md
+++ b/trails/SKILL.md
@@ -16,7 +16,7 @@ Cross-chain swap, bridge, and DeFi orchestration powered by Sequence. Agents spe
 
 ```bash
 export TRAILS_API=<your-sequence-project-access-key>   # from https://sequence.build
-export BANKR_API_KEY=<your-bankr-key>                  # from bankr.bot/api
+export BANKR_API_KEY=<your-bankr-key>                  # from bankr.bot/api-keys
 ```
 
 ## Quick Start

--- a/trails/references/trails.md
+++ b/trails/references/trails.md
@@ -285,7 +285,7 @@ Auth header: `X-Access-Key: $TRAILS_API`
 
 ```bash
 export TRAILS_API=<your-sequence-project-access-key>   # from https://sequence.build
-export BANKR_API_KEY=<your-bankr-key>                  # from bankr.bot/api (Agent API access required)
+export BANKR_API_KEY=<your-bankr-key>                  # from bankr.bot/api-keys (Agent API access required)
 ```
 
 ## References


### PR DESCRIPTION
## Summary

Every API-key dashboard reference across the skills pointed to the bare `bankr.bot/api` path instead of the correct `bankr.bot/api-keys`. This PR fixes all of them.

- **55 references** updated across **22 files**
- Covers markdown links (both display text and URL), plain URLs, and example error-message strings shown to users
- Left untouched: the LLM API host (`llm.bankr.bot`), the `bankr.bot/llm` dashboard links, and the `api-workflow.md` filename — none of those needed changing
- Verified no remaining bare `bankr.bot/api` references and no actual endpoint paths (`bankr.bot/api/...` or query strings) were affected

## Files changed

`bankr/SKILL.md`, `bankr/references/{safety,error-handling,llm-gateway,api-workflow}.md`, `BOTCOIN/skill.md`, `litcoin/{README,SKILL,docs,references/protocol}.md`, `nexus-trading-labs/references/{deposit-withdraw,trading,market-data}.md`, `opensea/{docs/policy-administration,opensea-wallet/SKILL,opensea-wallet/references/wallet-setup}.md`, `agenticbets/{SKILL,references/agent-usage}.md`, `signals/SKILL.md`, `trails/{SKILL,references/trails}.md`, `bankr-shopify/SKILL.md`

https://claude.ai/code/session_017kRohgCQmBEY8dr27GvKGv

---
_Generated by [Claude Code](https://claude.ai/code/session_017kRohgCQmBEY8dr27GvKGv)_