### PR TITLE
chore(bankr): weekly skill update 2026-06-06

### DIFF
--- a/bankr/SKILL.md
+++ b/bankr/SKILL.md
@@ -225,14 +225,15 @@ Omit `threadId` to start a new conversation. CLI equivalent: `bankr agent prompt
 |----------|--------|------|-------------|
 | `/wallet/me` | GET | Read | Wallet info (address, chains) |
 | `/wallet/portfolio` | GET | Read | Portfolio balances, supports `?include=pnl,nfts` for progressive loading |
-| `/wallet/swap-quote` | POST | Write | Quote a same-chain EVM swap (returns price, gas estimate, route) |
-| `/wallet/swap` | POST | Write | Execute a same-chain EVM swap (funds return to caller's wallet) |
+| `/wallet/swap-quote` | POST | Read | Quote a same-chain EVM swap without executing |
+| `/wallet/swap` | POST | Write | Execute a same-chain EVM swap (output returns to your wallet) |
 | `/wallet/transfer` | POST | Write | Transfer tokens (multi-chain, supports `allowedRecipients` enforcement) |
 | `/wallet/sign` | POST | Write | Sign messages, typed data, or transactions |
 | `/wallet/submit` | POST | Write | Submit raw transactions to chain |
 
 - **Read endpoints** (`/wallet/me`, `/wallet/portfolio`) — any valid API key with a wallet
-- **Write endpoints** (`/wallet/swap-quote`, `/wallet/swap`, `/wallet/transfer`, `/wallet/sign`, `/wallet/submit`) — require `walletApiEnabled` and `readOnly` check. `/wallet/transfer` also enforces `allowedRecipients`; `/wallet/swap` does not (output returns to the caller's own wallet)
+- **Swap quote** (`/wallet/swap-quote`) — a quote is a read, so read-only API keys are allowed; API-key callers still need `walletApiEnabled`
+- **Write endpoints** (`/wallet/swap`, `/wallet/transfer`, `/wallet/sign`, `/wallet/submit`) — require `walletApiEnabled` and reject read-only keys. `/wallet/transfer` also enforces `allowedRecipients`; `/wallet/swap` does not (output returns to your own wallet)
 - IP allowlist enforced on all endpoints
 
 #### Recipient & user lookup helpers (public, no auth)
@@ -242,7 +243,7 @@ Omit `threadId` to start a new conversation. CLI equivalent: `bankr agent prompt
 | `/addresses/resolve?value=<recipient>&type=<address\|ens\|twitter\|farcaster>` | GET | Resolve a recipient (0x address, ENS-style name `.eth`/`.base.eth`/`.cb.id`, or social handle) to a 0x address. Used by `bankr wallet transfer --to` to support ENS input. |
 | `/users/search?...` | GET | Search Bankr users by Twitter or Farcaster username. |
 
-The legacy aliases `/public/resolve-recipient` and `/public/search-users` have been removed (sunset 2026-06-03). Use the `/addresses/*` and `/users/*` namespaces instead.
+The legacy aliases `/public/resolve-recipient` and `/public/search-users` still respond but are deprecated (they return `Deprecation`/`Sunset` headers) and slated for removal — migrate callers to the structured `/addresses/*` and `/users/*` namespaces.
 
 #### Agent API (`/agent/*`) — AI-powered endpoints (async)
 
@@ -700,7 +701,7 @@ Per-key settings configured at [bankr.bot/api-keys](https://bankr.bot/api-keys):
 
 **API Key Types**: Bankr uses a single key format (`bk_...`) with capability flags (`walletApiEnabled`, `agentApiEnabled`, `tokenLaunchApiEnabled`, `llmGatewayEnabled`). You can optionally configure a separate LLM Gateway key via `bankr config set llmKey` or `BANKR_LLM_KEY` — useful when you want independent revocation or different permissions for agent vs LLM access.
 
-**Read-Only API Keys**: New keys default to `readOnly: true`. This filters all write tools (swaps, transfers, staking, token launches, etc.) from agent sessions. The `/wallet/sign`, `/wallet/submit`, and `/wallet/transfer` write endpoints return 403. Use `--read-write` during login or toggle in the web settings to disable. Ideal for monitoring bots and research agents.
+**Read-Only API Keys**: New keys default to `readOnly: true`. This filters all write tools (swaps, transfers, staking, token launches, etc.) from agent sessions. The `/wallet/swap`, `/wallet/sign`, `/wallet/submit`, and `/wallet/transfer` write endpoints return 403 (the `/wallet/swap-quote` read endpoint still works). Use `--read-write` during login or toggle in the web settings to disable. Ideal for monitoring bots and research agents.
 
 **IP Whitelisting**: Set `allowedIps` on your API key to restrict usage to specific IPs or CIDR ranges (e.g., `10.0.0.0/24`). Requests from non-whitelisted IPs are rejected with 403 at the auth layer.
 

--- a/bankr/SKILL.md
+++ b/bankr/SKILL.md
@@ -225,12 +225,14 @@ Omit `threadId` to start a new conversation. CLI equivalent: `bankr agent prompt
 |----------|--------|------|-------------|
 | `/wallet/me` | GET | Read | Wallet info (address, chains) |
 | `/wallet/portfolio` | GET | Read | Portfolio balances, supports `?include=pnl,nfts` for progressive loading |
+| `/wallet/swap-quote` | POST | Write | Quote a same-chain EVM swap (returns price, gas estimate, route) |
+| `/wallet/swap` | POST | Write | Execute a same-chain EVM swap (funds return to caller's wallet) |
 | `/wallet/transfer` | POST | Write | Transfer tokens (multi-chain, supports `allowedRecipients` enforcement) |
 | `/wallet/sign` | POST | Write | Sign messages, typed data, or transactions |
 | `/wallet/submit` | POST | Write | Submit raw transactions to chain |
 
 - **Read endpoints** (`/wallet/me`, `/wallet/portfolio`) — any valid API key with a wallet
-- **Write endpoints** (`/wallet/transfer`, `/wallet/sign`, `/wallet/submit`) — require `walletApiEnabled`, `readOnly` check, and `allowedRecipients` enforcement
+- **Write endpoints** (`/wallet/swap-quote`, `/wallet/swap`, `/wallet/transfer`, `/wallet/sign`, `/wallet/submit`) — require `walletApiEnabled` and `readOnly` check. `/wallet/transfer` also enforces `allowedRecipients`; `/wallet/swap` does not (output returns to the caller's own wallet)
 - IP allowlist enforced on all endpoints
 
 #### Recipient & user lookup helpers (public, no auth)
@@ -240,7 +242,7 @@ Omit `threadId` to start a new conversation. CLI equivalent: `bankr agent prompt
 | `/addresses/resolve?value=<recipient>&type=<address\|ens\|twitter\|farcaster>` | GET | Resolve a recipient (0x address, ENS-style name `.eth`/`.base.eth`/`.cb.id`, or social handle) to a 0x address. Used by `bankr wallet transfer --to` to support ENS input. |
 | `/users/search?...` | GET | Search Bankr users by Twitter or Farcaster username. |
 
-The legacy aliases `/public/resolve-recipient` and `/public/search-users` still work but are marked deprecated (Sunset: 2026-06-03) — migrate callers to the structured `/addresses/*` and `/users/*` namespaces.
+The legacy aliases `/public/resolve-recipient` and `/public/search-users` have been removed (sunset 2026-06-03). Use the `/addresses/*` and `/users/*` namespaces instead.
 
 #### Agent API (`/agent/*`) — AI-powered endpoints (async)
 

--- a/bankr/references/llm-gateway.md
+++ b/bankr/references/llm-gateway.md
@@ -73,6 +73,7 @@ bankr config get llmKey
 | `qwen3-coder` | Alibaba | Code generation, debugging (262K) |
 | `kimi-k2.6` | Moonshot AI | Latest, long-context (262K) |
 | `kimi-k2.5` | Moonshot AI | Long-context reasoning (262K) |
+| `minimax-m3` | MiniMax | Flagship multimodal reasoning (512K context) |
 | `minimax-m2.7` | MiniMax | Balanced performance (204.8K) |
 | `minimax-m2.7-highspeed` | MiniMax | Faster variant, double throughput (204.8K) |
 | `minimax-m2.5` | MiniMax | Cost-effective (204.8K) |

--- a/bankr/references/safety.md
+++ b/bankr/references/safety.md
@@ -58,7 +58,7 @@ Each API key has independent toggles managed at [bankr.bot/api-keys](https://ban
 
 | Flag | Controls Access To | Default |
 |------|-------------------|---------|
-| `walletApiEnabled` | `/wallet/*` write endpoints (swap, swap-quote, transfer, sign, submit) | true |
+| `walletApiEnabled` | `/wallet/*` endpoints: swap, swap-quote, transfer, sign, submit | true |
 | `agentApiEnabled` | `/agent/*` AI endpoints (prompt, job status, profile) | false |
 | `tokenLaunchApiEnabled` | Token deployment (`/token-launches/deploy`) and agent deploy tool | true |
 | `llmGatewayEnabled` | LLM Gateway at `llm.bankr.bot` (chat completions, model access) | false |

--- a/bankr/references/safety.md
+++ b/bankr/references/safety.md
@@ -58,7 +58,7 @@ Each API key has independent toggles managed at [bankr.bot/api-keys](https://ban
 
 | Flag | Controls Access To | Default |
 |------|-------------------|---------|
-| `walletApiEnabled` | `/wallet/*` write endpoints (transfer, sign, submit) | true |
+| `walletApiEnabled` | `/wallet/*` write endpoints (swap, swap-quote, transfer, sign, submit) | true |
 | `agentApiEnabled` | `/agent/*` AI endpoints (prompt, job status, profile) | false |
 | `tokenLaunchApiEnabled` | Token deployment (`/token-launches/deploy`) and agent deploy tool | true |
 | `llmGatewayEnabled` | LLM Gateway at `llm.bankr.bot` (chat completions, model access) | false |


### PR DESCRIPTION
## Summary

Weekly update to the Bankr skill documentation reflecting recent platform changes.

### Changes

- **Wallet API**: Add the `/wallet/swap` (write) and `/wallet/swap-quote` (read) endpoints for same-chain EVM swaps. A quote is a read, so read-only API keys are allowed; the execute endpoint rejects read-only keys and does not enforce `allowedRecipients` (swap output returns to the caller's own wallet).
- **LLM Gateway**: Add the MiniMax M3 model (flagship multimodal reasoning, 512K context) to the model table.
- **Legacy aliases**: Refresh the note for `/public/resolve-recipient` and `/public/search-users` — they still respond but emit `Deprecation`/`Sunset` headers and are slated for removal; migrate callers to the structured `/addresses/*` and `/users/*` namespaces.
- **Safety reference**: Update the `walletApiEnabled` capability flag to list the swap and swap-quote endpoints.

### Files changed

- `bankr/SKILL.md` — Wallet API endpoint table, auth notes, read-only endpoint list, legacy-alias note
- `bankr/references/llm-gateway.md` — MiniMax M3 in model table
- `bankr/references/safety.md` — `walletApiEnabled` capability flag description

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpLPUpVmuPz5s8bQCP5JCf)_