### PR TITLE
Add definitive-flash skill: stop-loss and take-profit orders via Definitive Flash API

### DIFF
--- a/definitive-flash/SKILL.md
+++ b/definitive-flash/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: definitive-flash
+description: Place, list, and cancel limit, stop-loss, and take-profit orders on Base via the Definitive Flash API. Designed for EIP-7702 smart wallets with ZeroDev Kernel v3.3 delegation — handles the Kernel signature wrapping that isValidSignature requires.
+tags: ["defi", "trading", "base", "orders", "stop-loss", "limit", "definitive"]
+version: 1
+visibility: public
+metadata:
+  {
+    "clawdbot":
+      {
+        "emoji": "📈",
+        "homepage": "https://definitive.fi",
+        "requires": { "bins": ["bankr", "python3"] },
+      },
+  }
+---
+
+# Definitive Flash
+
+Place programmatic limit, stop-loss, and take-profit orders on Base via the [Definitive Flash API](https://definitive.fi). Orders execute when the on-chain price hits the trigger — no keeper required on your end.
+
+## Credentials
+
+Two keys are required:
+
+| Key | Purpose | How to get |
+|-----|---------|------------|
+| `DEFINITIVE_API_KEY` | Authenticate API requests (`dpka_*` prefix) | https://app.definitive.fi → Settings → API Keys |
+| `BANKR_API_KEY` | Sign order typed data via `bankr wallet sign` | Your Bankr API key (unrestricted scope) |
+
+Set both as environment variables before running scripts:
+```bash
+export DEFINITIVE_API_KEY="dpka_..."
+export BANKR_API_KEY="bk_usr_..."
+```
+
+## Wallet Requirement
+
+Your Bankr wallet must be the `funderAddress` that holds the tokens to sell. For **EIP-7702 wallets with ZeroDev Kernel v3.3 delegation** (the standard Bankr smart wallet on Base), all signatures must be Kernel-wrapped — see `references/kernel-signing.md` for why, and how the scripts handle it automatically.
+
+## Place a Stop-Loss or Take-Profit
+
+```bash
+python3 scripts/place_order.py \
+  --wallet   0xYOUR_WALLET \
+  --token    0xTOKEN_ADDRESS \
+  --qty      1000000 \
+  --type     stop-loss \
+  --price    0.00025 \
+  --symbol   TOKEN
+```
+
+| Flag | Description |
+|------|-------------|
+| `--wallet` | Your Bankr wallet address (funderAddress) |
+| `--token` | Token contract address on Base |
+| `--qty` | Token quantity to sell (decimal units, e.g. `1000000` for 1M tokens) |
+| `--type` | `stop-loss` (sell when price drops to trigger) or `take-profit` (sell when price rises to trigger) |
+| `--price` | Trigger price in USD per token |
+| `--symbol` | Human-readable ticker (for logging only) |
+
+**Token precision note:** Pass the token amount with at most 6 decimal places (e.g. `1234567.891234`). Definitive's float→wei conversion can exceed your on-chain balance if you use more precision than what's held.
+
+On success the script prints the `orderId` and exits 0.
+
+## List Active Orders
+
+```bash
+python3 scripts/list_orders.py --wallet 0xYOUR_WALLET
+```
+
+Prints all `PENDING`, `ACCEPTED`, and `PARTIALLY_FILLED` orders grouped by token.
+
+## Cancel an Order
+
+```bash
+python3 scripts/cancel_order.py \
+  --wallet  0xYOUR_WALLET \
+  --orderid 12345678-abcd-...
+```
+
+Cancel uses the same Kernel-wrapped signing as placement. Without the wrapper the cancel endpoint returns `404 NOT_FOUND` (Definitive hides the order when auth fails).
+
+## Order Types
+
+| `--type` | Trigger | Use case |
+|----------|---------|----------|
+| `stop-loss` | Price drops **to or below** `--price` | Protect against downside |
+| `take-profit` | Price rises **to or above** `--price` | Lock in upside at a target |
+
+For a full position exit strategy: place one `stop-loss` for the full quantity, and multiple `take-profit` orders for portions of the position (40% at 1.2x, 35% at 1.5x, 25% at 2x, etc.).
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| HTTP 403 signature verification failed | Wrong signature format for Kernel wallet | Ensure you're using the Kernel-wrapped typed data path (scripts handle this automatically) |
+| HTTP 422 insufficient source asset balance | Token qty exceeds on-chain balance due to float precision | Floor qty to 6 decimal places before passing |
+| HTTP 422 flash order cap exceeded (100/100) | Too many open orders + quote attempts | Cancel unused orders; wait for the rolling quota to decay before retrying |
+| HTTP 404 on cancel | Kernel-wrapped signature not used for cancel | Use `cancel_order.py` which wraps the personal_sign hash correctly |
+
+## References
+
+- `references/kernel-signing.md` — Deep-dive on why Kernel v3.3 requires wrapped signatures and how the wrapping works
+- `references/api.md` — Raw Definitive Flash API endpoint reference

--- a/definitive-flash/references/api.md
+++ b/definitive-flash/references/api.md
@@ -1,0 +1,174 @@
+# Definitive Flash API Reference
+
+**Base URL:** `https://ddp.definitive.fi/v2/flash`
+
+**Auth header:** `x-definitive-api-key: <DEFINITIVE_API_KEY>`
+
+All requests and responses are JSON. All token quantities are decimal strings (not wei).
+
+---
+
+## Place an Order
+
+Three sequential calls: quote → (optional approval) → submit.
+
+### 1. POST /quote
+
+Get a quote and receive the typed data to sign.
+
+**Request body:**
+```json
+{
+  "targetChain":    "base",
+  "contraChain":    "base",
+  "targetAsset":    "0xTOKEN_ADDRESS",
+  "contraAsset":    "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+  "side":           "sell",
+  "qty":            "1000000.000000",
+  "orderType":      "stop-loss",
+  "triggers": [
+    {
+      "notionalPrice": "0.000250000000000000",
+      "triggerType":   "lower"
+    }
+  ],
+  "funderAddress":  "0xYOUR_WALLET",
+  "recipient":      "0xYOUR_WALLET"
+}
+```
+
+`triggerType`: `"lower"` for stop-loss (fires when price falls to trigger), `"upper"` for take-profit (fires when price rises to trigger).
+
+**Price format:** Plain decimal string with up to 18 decimal places. Scientific notation (e.g. `"1.8e-06"`) is rejected — use `f"{price:.18f}".rstrip("0").rstrip(".")`.
+
+**Response fields:**
+```json
+{
+  "quoteId": "uuid",
+  "evm": {
+    "orderTypedData":  "<JSON string>",
+    "permitTypedData": "<JSON string or null>",
+    "approveTx":       { "to": "0x...", "data": "0x..." }
+  }
+}
+```
+
+- `orderTypedData`: always present — sign this with the Kernel wrapper
+- `permitTypedData`: present when a permit2 signature is needed (sign with same Kernel wrapper)
+- `approveTx`: present when an on-chain ERC-20 approval is needed before submitting
+
+### 2. (If approveTx) Submit the approval transaction
+
+If `approveTx` is present, submit it via bankr before calling `/order`:
+```bash
+bankr wallet submit tx --to <approveTx.to> --chain-id 8453 --data <approveTx.data> \
+  -d "Approve Definitive for <SYMBOL>"
+```
+Wait ~5 seconds for the approval to confirm on-chain before submitting the order.
+
+### 3. POST /order
+
+Submit the signed order.
+
+**Request body:**
+```json
+{
+  "targetChain":       "base",
+  "contraChain":       "base",
+  "targetAsset":       "0xTOKEN_ADDRESS",
+  "contraAsset":       "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
+  "side":              "sell",
+  "qty":               "1000000.000000",
+  "orderType":         "stop-loss",
+  "triggers": [
+    {
+      "notionalPrice": "0.000250000000000000",
+      "triggerType":   "lower"
+    }
+  ],
+  "funderAddress":     "0xYOUR_WALLET",
+  "recipient":         "0xYOUR_WALLET",
+  "quoteId":           "<quoteId from step 1>",
+  "userSignature":     "0x00<130-char-sig>",
+  "evmOrderTypedData": "<same JSON string from quote response>",
+
+  "evmPermitTypedData": "<same JSON string from quote, if present>",
+  "evmPermitSignature": "0x00<130-char-sig>"
+}
+```
+
+**Response:**
+```json
+{ "orderId": "uuid" }
+```
+
+---
+
+## List Orders
+
+### GET /orders
+
+```
+GET /orders?funderAddress=0xYOUR_WALLET&pageSize=50
+```
+
+**Response:**
+```json
+{
+  "orders": [
+    {
+      "orderId":    "uuid",
+      "orderType":  "stop-loss",
+      "status":     "ORDER_STATUS_ACCEPTED",
+      "targetAsset": { "address": "0x...", "ticker": "TOKEN" },
+      "qty":        "1000000.000000",
+      "trigger":    { "notionalPrice": "0.000250000000000000", "triggerType": "lower" },
+      "placedAt":   "2026-06-06T12:00:00Z"
+    }
+  ],
+  "nextPageToken": "..."
+}
+```
+
+Active statuses: `ORDER_STATUS_PENDING`, `ORDER_STATUS_ACCEPTED`, `ORDER_STATUS_PARTIALLY_FILLED`
+
+Paginate by passing `pageToken=<nextPageToken>` until `nextPageToken` is absent.
+
+---
+
+## Cancel an Order
+
+### POST /orders/{orderId}/cancel
+
+```json
+{
+  "cancelMessage": "Definitive Flash v1 — Cancel Order\nOrder: {orderId}",
+  "userSignature": "0x00<130-char-sig>"
+}
+```
+
+The cancel message is a fixed string — compute `personal_sign` hash of that exact string, wrap in Kernel typed data, sign with bankr, prepend `0x00`. See `references/kernel-signing.md`.
+
+**Returns:** 200 on success. `404 NOT_FOUND` if the order doesn't exist **or** if signature verification fails (Definitive returns 404 for auth failures as a security measure).
+
+---
+
+## Error Codes
+
+| HTTP | code | Meaning |
+|------|------|---------|
+| 403 | – | Signature verification failed (wrong format for smart wallet) |
+| 422 | `FAILED_PRECONDITION` | Insufficient token balance — reduce qty slightly (floor to 6 dp) |
+| 422 | `RESOURCE_EXHAUSTED` | 100-order cap hit. Cancels active orders to free slots, then retry. |
+| 422 | Other | Order rejected — inspect `error.message` |
+| 404 | `NOT_FOUND` | Order not found or auth failed (cancel endpoint) |
+
+---
+
+## Useful Constants (Base)
+
+| Item | Value |
+|------|-------|
+| USDC (contraAsset) | `0x833589fcd6edb6e08f4c7c32d4f71b54bda02913` |
+| Chain ID | `8453` |
+| Chain name | `"base"` |

--- a/definitive-flash/references/kernel-signing.md
+++ b/definitive-flash/references/kernel-signing.md
@@ -1,0 +1,111 @@
+# Kernel v3.3 Signature Wrapping
+
+## Why Normal Signatures Fail
+
+Definitive Flash verifies every order and cancel signature by calling `isValidSignature(bytes32 hash, bytes sig)` on the funder's wallet address (EIP-1271). For a standard EOA this is a simple `ecrecover` check. For a **ZeroDev Kernel v3.3** smart wallet (EIP-7702 delegated), the check goes through Kernel's own validation logic.
+
+Kernel v3.3 decodes the signature type from the first byte:
+
+| First byte | Mode | Validator used |
+|------------|------|----------------|
+| `0x00` | **SUDO / root** | `rootValidator` (ECDSAValidator) |
+| `0x01` | Named validator | Extracted from next 20 bytes of sig |
+| `0x02` | Permission | Permission-based |
+
+The critical constraint with `0x01`: the ValidationId it extracts includes bytes from the ECDSA signature itself, so it never matches the canonical stored validator ID → `InvalidValidator()` revert. **Always use `0x00` (SUDO mode).**
+
+Even in SUDO mode, Kernel does not pass the original hash to ECDSAValidator directly. It wraps it:
+
+```
+wrapped_hash = keccak256(
+  "\x19\x01"
+  || kernel_domain_separator
+  || keccak256(KERNEL_WRAPPER_TYPE_HASH || original_hash)
+)
+```
+
+Where:
+- `KERNEL_WRAPPER_TYPE_HASH = keccak256("Kernel(bytes32 hash)") = 0x1547321c374afde8a591d972a084b071c594c275e36724931ff96c25f2999c83`
+- `kernel_domain_separator` uses: `name="Kernel"`, **`version="0.3.3"`** (NOT "0.3.0-beta" from GitHub main), `chainId=8453`, `verifyingContract=<wallet_address>`
+
+ECDSAValidator then checks `ecrecover(wrapped_hash, sig[1:]) == owner`.
+
+## The Signing Approach
+
+Instead of signing the raw hash and prepending `0x00`, construct a **`Kernel(bytes32 hash)` typed data struct** and have bankr sign it via `eth_signTypedData_v4`. Bankr's `_hashTypedData` produces the identical `wrapped_hash` that ECDSAValidator checks, so the resulting signature verifies correctly.
+
+### Step 1 — Compute the original EIP-712 hash
+
+Use `eth_account` with a dummy key to hash Definitive's typed data without actually signing it:
+
+```python
+from eth_account import Account
+
+dummy = Account.from_key(b'\x01' * 32)
+signed = dummy.sign_typed_data(full_message=definitive_typed_data)
+original_hash = signed.message_hash  # bytes
+```
+
+### Step 2 — Build the Kernel wrapper typed data
+
+```python
+kernel_td = {
+    "types": {
+        "EIP712Domain": [
+            {"name": "name",             "type": "string"},
+            {"name": "version",          "type": "string"},
+            {"name": "chainId",          "type": "uint256"},
+            {"name": "verifyingContract","type": "address"},
+        ],
+        "Kernel": [{"name": "hash", "type": "bytes32"}],
+    },
+    "domain": {
+        "name":              "Kernel",
+        "version":           "0.3.3",   # deployed version — NOT "0.3.0-beta"
+        "chainId":           8453,
+        "verifyingContract": WALLET_ADDRESS,
+    },
+    "primaryType": "Kernel",
+    "message": {"hash": "0x" + original_hash.hex()},
+}
+```
+
+### Step 3 — Sign with bankr and prepend type byte
+
+```bash
+bankr wallet sign --type eth_signTypedData_v4 --typed-data '<kernel_td_json>'
+# returns: 0x<130 hex chars>
+```
+
+Return value to Definitive: `"0x00" + raw_sig[2:]` (66 bytes total).
+
+## Cancel Signatures
+
+The cancel endpoint uses the same `isValidSignature` check but with a **personal_sign** message rather than typed data. Apply the same wrapper:
+
+1. Compute `personal_hash = keccak256("\x19Ethereum Signed Message:\n{len}{msg}")` — use `eth_account.messages.encode_defunct` + a dummy sign to get the hash.
+2. Build the same `Kernel(bytes32 hash)` typed data substituting `personal_hash`.
+3. Sign with bankr and return `"0x00" + sig[2:]`.
+
+Without this, the cancel endpoint returns `404 NOT_FOUND` (Definitive hides the order when auth fails rather than returning 401/403).
+
+## Verifying On-Chain
+
+You can confirm a signature is valid before submitting:
+
+```bash
+# isValidSignature(bytes32,bytes) selector = 0x1626ba7e
+cast call <WALLET> "isValidSignature(bytes32,bytes)(bytes4)" <HASH> <SIG> --rpc-url https://mainnet.base.org
+# Expected: 0x1626ba7e
+```
+
+## Version Discovery
+
+The deployed Kernel version can differ from the GitHub `main` branch. Always confirm with:
+
+```bash
+cast call <WALLET> "accountId()(string)" --rpc-url https://mainnet.base.org
+# e.g. "kernel.advanced.v0.3.3"
+```
+
+Use the version string after `v` (e.g. `0.3.3`) in the domain.

--- a/definitive-flash/scripts/cancel_order.py
+++ b/definitive-flash/scripts/cancel_order.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""
+Cancel a Definitive Flash order.
+
+Usage:
+  python3 cancel_order.py --wallet 0xYOUR_WALLET --orderid <uuid>
+
+The cancel endpoint validates the signature via isValidSignature on the Kernel
+wallet. This script wraps the personal_sign hash in a Kernel(bytes32 hash)
+typed data struct (type-0x00 SUDO) — without this, Definitive returns 404.
+
+Environment:
+  DEFINITIVE_API_KEY   dpka_* key from app.definitive.fi
+  BANKR_API_KEY        Bankr API key with signing permissions
+"""
+
+import argparse, json, os, re, subprocess, sys, urllib.request as _req, urllib.error as _err
+
+DEFINITIVE_BASE = "https://ddp.definitive.fi/v2/flash"
+CHAIN_ID = 8453
+
+
+def _api_key() -> str:
+    k = os.environ.get("DEFINITIVE_API_KEY", "")
+    if not k:
+        sys.exit("DEFINITIVE_API_KEY not set")
+    return k
+
+
+def _sign_cancel(order_id: str, wallet: str) -> str:
+    """
+    Sign the Definitive cancel message for a Kernel v3.3 smart wallet.
+
+    Process:
+      1. Compute personal_sign hash of the fixed cancel message string.
+      2. Wrap that hash in Kernel(bytes32 hash) typed data.
+      3. Sign with bankr eth_signTypedData_v4.
+      4. Return "0x00" + sig (type-0x00 SUDO mode).
+    """
+    from eth_account import Account as _Acct
+    from eth_account.messages import encode_defunct as _defunct
+
+    cancel_msg = f"Definitive Flash v1 — Cancel Order\nOrder: {order_id}"
+
+    dummy = _Acct.from_key(b"\x01" * 32)
+    _signed = dummy.sign_message(_defunct(text=cancel_msg))
+    personal_hash: bytes = getattr(_signed, "message_hash", None) or getattr(_signed, "messageHash")
+
+    kernel_td = {
+        "types": {
+            "EIP712Domain": [
+                {"name": "name",              "type": "string"},
+                {"name": "version",           "type": "string"},
+                {"name": "chainId",           "type": "uint256"},
+                {"name": "verifyingContract", "type": "address"},
+            ],
+            "Kernel": [{"name": "hash", "type": "bytes32"}],
+        },
+        "domain": {
+            "name":              "Kernel",
+            "version":           "0.3.3",
+            "chainId":           CHAIN_ID,
+            "verifyingContract": wallet,
+        },
+        "primaryType": "Kernel",
+        "message": {"hash": "0x" + personal_hash.hex()},
+    }
+
+    env = {**os.environ}
+    result = subprocess.run(
+        ["bankr", "wallet", "sign", "--type", "eth_signTypedData_v4",
+         "--typed-data", json.dumps(kernel_td)],
+        capture_output=True, text=True, timeout=30, env=env,
+    )
+    output = result.stdout + result.stderr
+    m = re.search(r"0x[0-9a-fA-F]{130}", output)
+    if not m:
+        raise RuntimeError(f"bankr sign returned no signature: {output[:400]}")
+    return "0x00" + m[0][2:]
+
+
+def cancel_order(wallet: str, order_id: str) -> bool:
+    """Cancel a Definitive Flash order. Returns True on success."""
+    cancel_msg = f"Definitive Flash v1 — Cancel Order\nOrder: {order_id}"
+
+    print(f"[sign] Signing cancel for {order_id[:8]}…", flush=True)
+    sig = _sign_cancel(order_id, wallet)
+
+    body = json.dumps({"cancelMessage": cancel_msg, "userSignature": sig}).encode()
+    req = _req.Request(
+        f"{DEFINITIVE_BASE}/orders/{order_id}/cancel",
+        data=body,
+        headers={
+            "Content-Type":         "application/json",
+            "Accept":               "application/json",
+            "x-definitive-api-key": _api_key(),
+            "User-Agent":           "Mozilla/5.0",
+        },
+        method="POST",
+    )
+    try:
+        _req.urlopen(req, timeout=20)
+        print(f"[ok] Order {order_id} cancelled")
+        return True
+    except _err.HTTPError as e:
+        body_str = e.read().decode()
+        print(f"[error] HTTP {e.code}: {body_str}", file=sys.stderr)
+        return False
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--wallet",  required=True, help="Funder wallet address")
+    p.add_argument("--orderid", required=True, help="Order UUID to cancel")
+    args = p.parse_args()
+
+    try:
+        ok = cancel_order(wallet=args.wallet, order_id=args.orderid)
+        sys.exit(0 if ok else 1)
+    except Exception as e:
+        print(f"[error] {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/definitive-flash/scripts/list_orders.py
+++ b/definitive-flash/scripts/list_orders.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+List active Definitive Flash orders for a wallet.
+
+Usage:
+  python3 list_orders.py --wallet 0xYOUR_WALLET [--all]
+
+  --all    Include cancelled and filled orders (default: active only)
+
+Environment:
+  DEFINITIVE_API_KEY   dpka_* key from app.definitive.fi
+"""
+
+import argparse, json, os, sys, urllib.request as _req, urllib.error as _err
+
+DEFINITIVE_BASE = "https://ddp.definitive.fi/v2/flash"
+ACTIVE = {"ORDER_STATUS_PENDING", "ORDER_STATUS_ACCEPTED", "ORDER_STATUS_PARTIALLY_FILLED"}
+
+
+def _api_key() -> str:
+    k = os.environ.get("DEFINITIVE_API_KEY", "")
+    if not k:
+        sys.exit("DEFINITIVE_API_KEY not set")
+    return k
+
+
+def fetch_orders(wallet: str, active_only: bool = True) -> list[dict]:
+    headers = {
+        "x-definitive-api-key": _api_key(),
+        "Accept":               "application/json",
+        "User-Agent":           "Mozilla/5.0",
+    }
+    orders = []
+    page_token = None
+    while True:
+        qs = f"funderAddress={wallet}"
+        if page_token:
+            qs += f"&pageToken={page_token}"
+        req = _req.Request(f"{DEFINITIVE_BASE}/orders?{qs}", headers=headers)
+        try:
+            data = json.loads(_req.urlopen(req, timeout=20).read())
+        except _err.HTTPError as e:
+            sys.exit(f"API error {e.code}: {e.read().decode()}")
+        for o in data.get("orders", []):
+            if active_only and o.get("status") not in ACTIVE:
+                continue
+            orders.append(o)
+        page_token = data.get("nextPageToken")
+        if not page_token:
+            break
+    return orders
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--wallet", required=True, help="Funder wallet address")
+    p.add_argument("--all",    action="store_true", help="Include closed orders")
+    p.add_argument("--json",   action="store_true", dest="json_out",
+                   help="Output raw JSON")
+    args = p.parse_args()
+
+    orders = fetch_orders(args.wallet, active_only=not args.all)
+
+    if args.json_out:
+        print(json.dumps(orders, indent=2))
+        return
+
+    if not orders:
+        print("No orders found.")
+        return
+
+    from collections import defaultdict
+    by_token: dict[str, list] = defaultdict(list)
+    for o in orders:
+        ta = o.get("targetAsset") or {}
+        key = f"{ta.get('ticker','?')} ({ta.get('address','')[:10]})"
+        by_token[key].append(o)
+
+    total = len(orders)
+    active_count = sum(1 for o in orders if o.get("status") in ACTIVE)
+    print(f"Orders: {active_count} active / {total} total\n")
+
+    for token, ords in sorted(by_token.items()):
+        print(f"  {token}")
+        for o in ords:
+            trigger = o.get("trigger") or {}
+            price   = trigger.get("notionalPrice", "—")
+            status  = o.get("status", "").replace("ORDER_STATUS_", "")
+            oid     = o.get("orderId", "")[:8]
+            placed  = o.get("placedAt", "")[:10]
+            print(f"    {o['orderType']:14s}  @ {price:30s}  [{status}]  {oid}  {placed}")
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/definitive-flash/scripts/place_order.py
+++ b/definitive-flash/scripts/place_order.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""
+Place a stop-loss or take-profit order via Definitive Flash.
+
+Usage:
+  python3 place_order.py \
+    --wallet  0xYOUR_WALLET \
+    --token   0xTOKEN_ADDRESS \
+    --qty     1000000.000000 \
+    --type    stop-loss \
+    --price   0.00025 \
+    --symbol  TOKEN
+
+  Qty: decimal token units, floored to 6 dp (avoids insufficient-balance 422).
+  Price: USD per token, plain decimal — scientific notation is rejected by Definitive.
+
+Environment:
+  DEFINITIVE_API_KEY   dpka_* key from app.definitive.fi
+  BANKR_API_KEY        Bankr API key with signing permissions
+"""
+
+import argparse, json, math, os, re, subprocess, sys, time, urllib.request as _req, urllib.error as _err
+
+DEFINITIVE_BASE = "https://ddp.definitive.fi/v2/flash"
+USDC = "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+CHAIN_ID = 8453
+
+
+# ── Signing ───────────────────────────────────────────────────────────────────
+
+def _keccak(data: bytes) -> bytes:
+    from Crypto.Hash import keccak as _k
+    h = _k.new(digest_bits=256)
+    h.update(data)
+    return h.digest()
+
+
+def _sign_definitive_typed_data(typed_data_str: str, wallet: str) -> str:
+    """
+    Sign Definitive typed data for a ZeroDev Kernel v3.3 (EIP-7702) wallet.
+
+    Kernel wraps the original hash before passing to ECDSAValidator:
+        wrapped = keccak256(\\x19\\x01 || kernel_domain_sep
+                            || keccak256(KWTH || original_hash))
+    where kernel_domain: name="Kernel", version="0.3.3", chainId=8453,
+          verifyingContract=wallet_address.
+
+    We sign via a Kernel(bytes32 hash) typed data struct (type-0x00 SUDO path)
+    so that bankr's eth_signTypedData_v4 produces the identical wrapped hash.
+    """
+    from eth_account import Account as _Acct
+
+    td = json.loads(typed_data_str)
+    if isinstance(td.get("domain", {}).get("chainId"), str):
+        td["domain"]["chainId"] = int(td["domain"]["chainId"])
+
+    dummy = _Acct.from_key(b"\x01" * 32)
+    signed = dummy.sign_typed_data(full_message=td)
+    original_hash: bytes = getattr(signed, "message_hash", None) or getattr(signed, "messageHash")
+
+    kernel_td = {
+        "types": {
+            "EIP712Domain": [
+                {"name": "name",              "type": "string"},
+                {"name": "version",           "type": "string"},
+                {"name": "chainId",           "type": "uint256"},
+                {"name": "verifyingContract", "type": "address"},
+            ],
+            "Kernel": [{"name": "hash", "type": "bytes32"}],
+        },
+        "domain": {
+            "name":              "Kernel",
+            "version":           "0.3.3",
+            "chainId":           CHAIN_ID,
+            "verifyingContract": wallet,
+        },
+        "primaryType": "Kernel",
+        "message": {"hash": "0x" + original_hash.hex()},
+    }
+
+    env = {**os.environ}
+    result = subprocess.run(
+        ["bankr", "wallet", "sign", "--type", "eth_signTypedData_v4",
+         "--typed-data", json.dumps(kernel_td)],
+        capture_output=True, text=True, timeout=30, env=env,
+    )
+    output = result.stdout + result.stderr
+    m = re.search(r"0x[0-9a-fA-F]{130}", output)
+    if not m:
+        raise RuntimeError(f"bankr sign returned no signature: {output[:400]}")
+    return "0x00" + m[0][2:]  # type-0x00 SUDO prefix
+
+
+# ── Definitive API ────────────────────────────────────────────────────────────
+
+def _api_key() -> str:
+    k = os.environ.get("DEFINITIVE_API_KEY", "")
+    if not k:
+        sys.exit("DEFINITIVE_API_KEY not set")
+    return k
+
+
+def _post(path: str, body: dict, timeout: int = 30) -> dict:
+    data = json.dumps(body).encode()
+    req = _req.Request(
+        DEFINITIVE_BASE + path, data=data,
+        headers={
+            "Content-Type":          "application/json",
+            "Accept":                "application/json",
+            "x-definitive-api-key":  _api_key(),
+            "User-Agent":            "Mozilla/5.0",
+        },
+    )
+    try:
+        return json.loads(_req.urlopen(req, timeout=timeout).read())
+    except _err.HTTPError as e:
+        body_str = e.read().decode()
+        raise RuntimeError(f"HTTP {e.code}: {body_str}") from e
+
+
+def _fmt(v: float) -> str:
+    """Format float as plain decimal string — Definitive rejects scientific notation."""
+    return f"{v:.18f}".rstrip("0").rstrip(".")
+
+
+def _floor6(qty: float) -> float:
+    """Floor to 6 decimal places to avoid float→wei precision exceeding balance."""
+    return math.floor(qty * 1_000_000) / 1_000_000
+
+
+# ── Order placement ───────────────────────────────────────────────────────────
+
+def place_order(wallet: str, token: str, qty: float, order_type: str,
+                price: float, symbol: str) -> str:
+    """
+    Place a stop-loss or take-profit order. Returns orderId.
+    order_type: "stop-loss" or "take-profit"
+    """
+    safe_qty = _floor6(qty)
+    trigger_type = "lower" if order_type == "stop-loss" else "upper"
+
+    body_base = {
+        "targetChain":  "base",
+        "contraChain":  "base",
+        "targetAsset":  token,
+        "contraAsset":  USDC,
+        "side":         "sell",
+        "qty":          _fmt(safe_qty),
+        "orderType":    order_type,
+        "triggers": [{"notionalPrice": _fmt(price), "triggerType": trigger_type}],
+        "funderAddress": wallet,
+        "recipient":     wallet,
+    }
+
+    # Step 1: Quote
+    print(f"[quote] {symbol} {order_type} @ ${price:.10g} ({safe_qty} tokens)…", flush=True)
+    quote = _post("/quote", body_base)
+    if "error" in quote:
+        raise RuntimeError(f"Quote rejected: {quote['error']}")
+
+    quote_id = quote["quoteId"]
+    evm = quote.get("evm") or {}
+    otd_str  = evm.get("orderTypedData")  or quote.get("orderTypedData")
+    ptd_str  = evm.get("permitTypedData") or quote.get("permitTypedData")
+    approve  = evm.get("approveTx")       or quote.get("approveTx")
+
+    if not otd_str:
+        raise RuntimeError("No orderTypedData in quote response")
+
+    # Step 2: On-chain approval if needed
+    if approve:
+        print(f"[approve] Submitting ERC-20 approval…", flush=True)
+        result = subprocess.run(
+            ["bankr", "wallet", "submit", "tx",
+             "--to", approve["to"], "--chain-id", str(CHAIN_ID),
+             "--data", approve["data"], "-d", f"Approve Definitive for {symbol}"],
+            capture_output=True, text=True, timeout=60, env={**os.environ},
+        )
+        combined = (result.stdout + result.stderr).lower()
+        if "success" not in combined and "0x" not in combined:
+            raise RuntimeError(f"Approval failed: {result.stdout + result.stderr}")
+        print("[approve] Waiting 5s for on-chain confirmation…", flush=True)
+        time.sleep(5)
+
+    # Step 3: Sign orderTypedData
+    print("[sign] Signing order typed data (Kernel v3.3 wrapper)…", flush=True)
+    user_sig = _sign_definitive_typed_data(otd_str, wallet)
+
+    # Step 3b: Sign permitTypedData if present
+    permit_sig = None
+    if ptd_str:
+        print("[sign] Signing permit typed data…", flush=True)
+        permit_sig = _sign_definitive_typed_data(ptd_str, wallet)
+
+    # Step 4: Submit
+    order_body = {**body_base, "quoteId": quote_id,
+                  "userSignature": user_sig, "evmOrderTypedData": otd_str}
+    if permit_sig and ptd_str:
+        order_body["evmPermitTypedData"] = ptd_str
+        order_body["evmPermitSignature"] = permit_sig
+
+    print("[submit] Submitting order…", flush=True)
+    resp = _post("/order", order_body, timeout=45)
+    if "error" in resp:
+        raise RuntimeError(f"Order rejected: {resp['error']}")
+
+    order_id = resp.get("orderId", "")
+    print(f"[ok] {symbol} {order_type} placed: {order_id}")
+    return order_id
+
+
+# ── CLI ───────────────────────────────────────────────────────────────────────
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__,
+                                formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--wallet",  required=True, help="Funder wallet address")
+    p.add_argument("--token",   required=True, help="Token contract address on Base")
+    p.add_argument("--qty",     required=True, type=float, help="Token quantity (decimal)")
+    p.add_argument("--type",    required=True, dest="order_type",
+                   choices=["stop-loss", "take-profit"],
+                   help="Order type")
+    p.add_argument("--price",   required=True, type=float, help="Trigger price in USD per token")
+    p.add_argument("--symbol",  default="TOKEN", help="Token ticker (for logging)")
+    args = p.parse_args()
+
+    try:
+        order_id = place_order(
+            wallet=args.wallet,
+            token=args.token,
+            qty=args.qty,
+            order_type=args.order_type,
+            price=args.price,
+            symbol=args.symbol,
+        )
+        print(order_id)
+    except Exception as e:
+        print(f"[error] {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds a skill for placing, listing, and cancelling stop-loss and take-profit orders on Base via the [Definitive Flash API](https://definitive.fi)
- Designed for EIP-7702 wallets with ZeroDev Kernel v3.3 delegation (the standard Bankr smart wallet on Base)
- Handles the Kernel v3.3 signature wrapping that Definitive's `isValidSignature` check requires — the non-obvious part that isn't documented anywhere

## The Key Technical Problem This Solves

Definitive Flash verifies every order and cancel signature by calling `isValidSignature(bytes32, bytes)` (EIP-1271) on the funder's wallet. For Bankr smart wallets (EIP-7702, ZeroDev Kernel v3.3), Kernel wraps the original hash before passing it to ECDSAValidator:

```
wrapped = keccak256("\x19\x01" || kernel_domain_sep || keccak256(KWTH || original_hash))
```

where `KWTH = keccak256("Kernel(bytes32 hash)")` and the domain uses `version="0.3.3"` and `verifyingContract=<wallet>`.

Signing the raw hash (what a naive implementation does) fails with HTTP 403. The skill signs a `Kernel(bytes32 hash)` typed data struct instead, using `bankr wallet sign --type eth_signTypedData_v4`, which produces the identical wrapped hash. The same wrapping applies to cancel signatures (personal_sign path) — without it, Definitive returns 404 instead of 401/403.

## Files

| File | Purpose |
|------|---------|
| `SKILL.md` | Usage, credentials, error table, quick-start |
| `references/kernel-signing.md` | How Kernel v3.3 wrapping works and why it's required |
| `references/api.md` | Definitive Flash endpoint reference (quote→approve→submit, cancel, list) |
| `scripts/place_order.py` | Place stop-loss or take-profit with full signing pipeline |
| `scripts/cancel_order.py` | Cancel with Kernel-wrapped personal_sign |
| `scripts/list_orders.py` | Paginated active order listing |

## Test plan

- [ ] `list_orders.py` — verified against live Definitive API, returns active orders grouped by token
- [ ] `place_order.py` — signing pipeline verified end-to-end: quote succeeds, Kernel-wrapped typed data signs correctly, `isValidSignature` on-chain returns `0x1626ba7e` ✓
- [ ] `cancel_order.py` — Kernel-wrapped personal_sign verified: `isValidSignature` returns `0x1626ba7e` ✓; used to cancel live orders successfully this session
- [ ] Order cap (100/100) error documented with fix (cancel unused orders to free slots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)