### PR TITLE
docs(bankr): weekly skill update — x402 any-token, expiring LLM credits, Fable 5, club upgrade, bulk transfers

### DIFF
--- a/bankr/SKILL.md
+++ b/bankr/SKILL.md
@@ -331,6 +331,8 @@ Manage Bankr Club subscription from the CLI (status, signup, cancel). Pay with U
 
 Pricing is $20/mo or $198/yr USD-equivalent. Actual on-chain amount depends on the chosen token's price at quote time. The `--token` flag was added in CLI 0.3.4; older versions only support USDC.
 
+**Monthly → yearly upgrade**: active monthly members can upgrade to yearly by asking the agent (e.g. "upgrade me to yearly"). The full yearly price is charged and the new 365-day term stacks on top of any remaining monthly time, so no paid time is lost. Yearly → monthly downgrades and yearly resubscribes are not supported.
+
 ### Auth & Config Commands
 
 | Command | Description |
@@ -499,7 +501,7 @@ The [Bankr LLM Gateway](https://docs.bankr.bot/llm-gateway/overview) is a unifie
 - Check credits: `bankr llm credits` | Top up: `bankr llm credits add <amount>` | Auto top-up: `bankr llm credits auto --enable --amount 25 --tokens USDC`
 - In OpenClaw config, prefix model IDs with `bankr/` (e.g. `bankr/claude-sonnet-4.6`). In direct API calls, use bare IDs (e.g. `claude-sonnet-4.6`)
 - **Per-model discounts** available for Bankr Club members and partners — applied automatically at billing time
-- **BNB Chain promo**: top up $5+ via BNB Chain and receive a $5 bonus credit (one-time per wallet)
+- **Expiring credit grants**: promotional or developer grants may carry an expiry date. Your spendable balance is your permanent (purchased) credits plus any unexpired grants — grants are spent first (soonest-expiring first) and drop off automatically at expiry
 
 ### Quick Commands
 
@@ -575,6 +577,7 @@ For full details — setup paths, model list, provider config, SDK examples, key
 - Send to 0x addresses, ENS-style names (`.eth`, `.base.eth`, `.cb.id`), or social handles
 - CLI direct (`bankr wallet transfer`) accepts 0x addresses + ENS only — social handles go through the AI agent
 - Multi-chain support
+- **Bulk / multi-recipient** sends via the agent — same-chain ERC-20 transfers to many recipients batch into a single on-chain transaction (one set of gas)
 - Flexible amount formats
 - Social handle resolution (Twitter, Farcaster, Telegram) via the agent
 
@@ -635,12 +638,13 @@ For full details — setup paths, model list, provider config, SDK examples, key
 
 ### x402 Paid API Calls
 
-The agent can discover, call, and deploy x402-protected API endpoints, automatically handling USDC payments on Base:
+The agent can discover, call, and deploy x402-protected API endpoints, automatically handling token payments on Base:
 
 - **Discover** endpoints in the Bankr registry or via web search
 - **Inspect** endpoint pricing, methods, and input/output schemas
-- **Call** endpoints with automatic payment signing (max $10/request)
+- **Call** endpoints with automatic payment signing in the endpoint's required token — USDC or any supported ERC-20 (max $10/request)
 - **Deploy** new x402 endpoints directly through the agent (write handler code, set pricing, deploy)
+- **Price** your own endpoints in USDC or any supported ERC-20; revenue settles on-chain and is accounted in USD at settlement time
 - Works with any x402-compatible endpoint (Bankr-hosted or external)
 
 **Reference**: [references/x402-cloud.md](references/x402-cloud.md)
@@ -926,6 +930,7 @@ See [references/safety.md](references/safety.md) for comprehensive safety guidan
 - "Send 0.1 ETH to vitalik.eth"
 - "Transfer $20 USDC to @friend"
 - "Send 50 USDC to 0x123..."
+- "Send 5 USDC to each of these addresses: 0x..., 0x..., 0x..." (bulk — batched into one transaction)
 
 ### NFTs
 

--- a/bankr/references/llm-gateway.md
+++ b/bankr/references/llm-gateway.md
@@ -40,6 +40,7 @@ bankr config get llmKey
 
 | Model | Provider | Best For |
 |-------|----------|----------|
+| `claude-fable-5` | Anthropic | Latest generation, agentic + multimodal (1M context, image input) |
 | `claude-opus-4.8` | Anthropic | Latest, most capable reasoning (1M context) |
 | `claude-opus-4.7` | Anthropic | Advanced reasoning (1M context) |
 | `claude-opus-4.6` | Anthropic | Advanced reasoning (1M context) |
@@ -123,15 +124,16 @@ bankr llm credits auto --disable
 
 When credits are exhausted, gateway requests will fail with HTTP 402.
 
-### BNB Chain Promotion
+### Expiring Credit Grants
 
-Top up LLM credits via BNB Chain ($5+ minimum) and receive a **$5 bonus credit** — one-time per wallet. Check eligibility at [bankr.bot/llm?tab=credits](https://bankr.bot/llm?tab=credits) or via the CLI:
+Beyond purchased credits, your account may receive **time-limited grant credits** (for example promotional or developer grants). Your spendable balance is your permanent pool (purchases and regular top-ups) plus the remaining amount of any unexpired grants:
 
-```bash
-bankr llm credits add 5 --token USDT   # BNB Chain auto-selected if it holds the most USDT
+```
+spendable = permanent pool + Σ (remaining of each grant where expiry > now)
+spend order = expiring grants first (soonest-expiring), then the permanent pool
 ```
 
-Bonus credits appear in your credit history alongside regular top-ups.
+Expired grants drop off automatically — there is no manual cleanup. The Credits page and `/llm/usage` show a breakdown of your permanent pool vs. each grant and its expiry, and your credit history labels grant rows.
 
 ### Agent Credit Top-Up
 

--- a/bankr/references/transfers.md
+++ b/bankr/references/transfers.md
@@ -49,6 +49,15 @@ curl "https://api.bankr.bot/addresses/resolve?value=vitalik.eth&type=ens"
   - ERC20 tokens: USDC, USDT, WETH, etc.
 - **Solana**: SOL and SPL tokens (via AI agent — the CLI's `bankr wallet transfer` is EVM-only)
 
+## Bulk / Multi-Recipient Transfers
+
+Through the AI agent you can send to many recipients in one request (e.g. an airdrop or payroll run). Same-chain ERC-20 transfers to multiple recipients are batched into a **single on-chain transaction** (one set of gas) rather than one transaction per recipient; native-token sends are submitted individually. Each recipient's outcome is reported back so you can see exactly which legs succeeded.
+
+```bash
+bankr agent prompt "Send 5 USDC to 0xAAA..., 0xBBB..., and 0xCCC... on Base"
+bankr agent prompt "Airdrop 10 USDC each to @alice, @bob, and @carol"
+```
+
 ## Recipient Formats
 
 Pass the bare username for social handles (no `.eth` suffix even if the user's display name has one) — the resolver only matches by exact Farcaster/Twitter username.
@@ -90,6 +99,10 @@ Pass the bare username for social handles (no `.eth` suffix even if the user's d
 - "Send $20 of ETH to @friend on Twitter"
 - "Transfer 0.1 ETH to @user on Farcaster"
 - "Send 50 USDC to @buddy on Telegram"
+
+**Bulk / multi-recipient:**
+- "Send 5 USDC to 0xAAA..., 0xBBB..., and 0xCCC..."
+- "Airdrop 10 USDC each to @alice, @bob, and @carol"
 
 **With chain specified:**
 - "Send ETH on Base to vitalik.eth"

--- a/bankr/references/x402-cloud.md
+++ b/bankr/references/x402-cloud.md
@@ -1,6 +1,6 @@
 # x402 Cloud Reference
 
-x402 Cloud lets you deploy paid API endpoints that agents and developers pay for automatically using the x402 payment protocol. Write a handler, set a price, deploy with one command — callers pay in USDC on Base per request.
+x402 Cloud lets you deploy paid API endpoints that agents and developers pay for automatically using the x402 payment protocol. Write a handler, set a price, deploy with one command — callers pay per request in USDC or any supported ERC-20 token on Base.
 
 **Base URL:** `https://x402.bankr.bot`
 
@@ -16,7 +16,7 @@ x402 Cloud lets you deploy paid API endpoints that agents and developers pay for
 | Pro | 5% | Unlimited |
 | Enterprise | 3% | Contact sales |
 
-No credit card required. First 1,000 settled requests each month are free. Payments settle on-chain in USDC on Base — your share goes directly to your wallet.
+No credit card required. First 1,000 settled requests each month are free. Payments settle on-chain on Base — in USDC or the token your endpoint is priced in — and your share goes directly to your wallet. Revenue is accounted in USD at settlement time.
 
 ## Deploying via Agent
 
@@ -160,6 +160,7 @@ Service config lives in `bankr.x402.json` at the project root:
 ```
 
 - **price**: USD per request (e.g. "0.001" = $0.001)
+- **tokenAddress** (optional): price the endpoint in a specific ERC-20 instead of USDC. Symbol and decimals are resolved server-side; revenue is still accounted in USD at settlement.
 - **methods**: HTTP methods accepted (default: all). Use `["POST"]` for body-based endpoints.
 - **schema**: Input/output schema for agent discovery. Agents use this to understand how to call your endpoint.
 - **category/tags**: Improve discoverability for agents searching for services.
@@ -181,7 +182,7 @@ bankr agent prompt "Call the sentiment analysis endpoint on x402 with text 'Bitc
 bankr agent prompt "What does the x402 weather endpoint cost?"
 ```
 
-The agent uses USDC on Base for all x402 payments. Maximum payment per request is $10. The agent will always confirm payment amount before calling.
+The agent pays in the token each endpoint requires (USDC or any supported ERC-20) on Base. Maximum payment per request is $10. The agent will always confirm the payment amount and token before calling.
 
 ### With x402-fetch (for developers)
 
@@ -226,8 +227,8 @@ https://x402.bankr.bot/<walletAddress>/<serviceName>[/path]
 
 ## How Payment Works
 
-1. Client calls your endpoint — gets 402 with payment requirements
-2. Client's wallet signs a USDC payment on Base
+1. Client calls your endpoint — gets 402 with payment requirements (including the accepted token)
+2. Client's wallet signs a payment in the endpoint's token on Base
 3. Client retries with `X-PAYMENT` header containing the signed payment
 4. Payment is verified, your handler runs, payment settles on-chain
 5. Your share goes to your wallet, platform fee (if any) goes to Bankr


### PR DESCRIPTION
## Summary

Weekly refresh of the **bankr** skill to keep its documented capabilities in sync with what the Bankr agent, CLI, and APIs now support. Documentation-only — no behavioral content beyond accurate capability descriptions.

## Changes

**x402 paid API calls (`SKILL.md`, `references/x402-cloud.md`)**
- Payments are no longer USDC-only: callers can pay in USDC **or any supported ERC-20** on Base, and you can **price your own endpoints in any supported ERC-20**.
- Revenue is settled on-chain and accounted in **USD at settlement time**.
- Documented the optional per-endpoint payment-token configuration and updated the "How Payment Works" flow accordingly.

**LLM Gateway (`SKILL.md`, `references/llm-gateway.md`)**
- Added **`claude-fable-5`** to the available models list.
- Documented **time-limited expiring credit grants** — spendable balance = permanent pool + unexpired grants, with grants spent first (soonest-expiring first) and dropping off automatically at expiry.
- Removed the **ended BNB Chain top-up promo** (BNB Chain remains a supported top-up chain; only the bonus offer ended).

**Bankr Club (`SKILL.md`)**
- Documented **monthly → yearly upgrades via the agent**: the yearly term stacks on top of any remaining monthly time, so no paid time is lost.

**Transfers (`SKILL.md`, `references/transfers.md`)**
- Documented **bulk / multi-recipient sends**: same-chain ERC-20 transfers to many recipients batch into a single on-chain transaction, with per-recipient outcomes reported. Added prompt examples.

## Notes
- Public-repo safe: general capability documentation only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01EkN7dWxvxQ1XZMwG1q2Ash)_