### PR TITLE
feat: add Agent Kickbacks skill

### DIFF
--- a/agent-kickbacks/SKILL.md
+++ b/agent-kickbacks/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: agent-kickbacks
+description: Crypto-native ad marketplace for AI agents. Use when an agent needs to monetize idle/thinking time by serving sponsored content, or when a user wants to earn USDC from ad impressions. Supports ad requesting, impression tracking, earnings management, and USDC payouts on Base via x402 micropayments. Use for ad serving, campaign management, user earnings, and payouts.
+metadata:
+  bankr:
+    category: marketplace
+    chains: [base]
+    homepage: https://agent-kickbacks.io
+    apiBase: https://agent-kickbacks-production.up.railway.app
+    payment: x402-usdc-base
+  openclaw:
+    emoji: "💰"
+---
+
+# Agent Kickbacks
+
+Crypto-native ad marketplace for AI agents. Monetize idle/thinking time by serving sponsored content and earn USDC on Base.
+
+## When To Use
+
+Use this skill for:
+
+- Requesting ads during agent idle/thinking time
+- Tracking ad impressions and clicks
+- Checking user earnings balance
+- Requesting USDC payouts
+- Managing ad campaigns (advertisers)
+- Viewing active ad blocks on the marketplace
+
+Do not use this skill for:
+- Displaying ads without user consent
+- Click fraud or impression inflation
+- Bypassing rate limits
+
+## API Base
+
+```
+https://agent-kickbacks-production.up.railway.app
+```
+
+## Access Model
+
+### Free Access
+
+Basic ad serving is free. Users earn USDC from impressions and clicks.
+
+### x402 Paid Access (Campaign Funding)
+
+Advertisers fund campaigns via x402 USDC payments on Base:
+
+- Minimum campaign budget: `$10 USDC`
+- Block purchase: `$5 USDC` per 1,000 impressions
+- Payment method: x402 exact-EVM on Base
+
+## Endpoints
+
+### Health Check
+
+```http
+GET /health
+```
+
+Returns server status, network, and facilitator info.
+
+### Request Ad
+
+```http
+POST /ad/request
+Content-Type: application/json
+
+{
+  "user_wallet": "0x...",
+  "agent": "hermes",
+  "context": "defi staking",
+  "surface": "response_footer"
+}
+```
+
+Returns best matching ad with impression token. Returns 204 if no ads available.
+
+### Track Impression
+
+```http
+POST /ad/impression
+Content-Type: application/json
+
+{
+  "ad_id": "...",
+  "user_wallet": "0x...",
+  "token": "impression_token_from_ad_request"
+}
+```
+
+Tracks confirmed ad display. User earns `$0.0025` per impression (50% of $0.005 bid).
+
+### Track Click
+
+```http
+POST /ad/click
+Content-Type: application/json
+
+{
+  "ad_id": "...",
+  "user_wallet": "0x..."
+}
+```
+
+Tracks ad click. User earns `$0.125` per click (50% of $0.005 × 50 multiplier).
+
+### Check Earnings
+
+```http
+GET /earnings/{wallet_address}
+```
+
+Returns balance, total earned, impressions, and clicks.
+
+### Request Payout
+
+```http
+POST /payout/request
+Content-Type: application/json
+
+{
+  "wallet_address": "0x..."
+}
+```
+
+Request USDC payout. Minimum `$5 USDC`. Transfers via EIP-3009 gasless transfer on Base.
+
+### Create Campaign (Advertiser)
+
+```http
+POST /campaign/create
+Content-Type: application/json
+
+{
+  "advertiser_wallet": "0x...",
+  "name": "My Campaign",
+  "total_budget": 10.0
+}
+```
+
+Creates a campaign with minimum `$10 USDC` budget.
+
+### Add Ad to Campaign
+
+```http
+POST /campaign/{campaign_id}/ad
+Content-Type: application/json
+
+{
+  "title": "Earn 12% APY",
+  "body": "Stake ETH, earn yields.",
+  "cta_text": "Learn more",
+  "cta_url": "https://example.com",
+  "category": "defi",
+  "tags": ["eth", "staking"],
+  "bid_per_impression": 0.005
+}
+```
+
+### Buy Impression Blocks
+
+```http
+POST /campaign/{campaign_id}/buy
+Content-Type: application/json
+
+{
+  "blocks": 5
+}
+```
+
+Buy 5 blocks × 1,000 impressions = 5,000 impressions. Cost: `$25 USDC`.
+
+### Get Campaign Stats
+
+```http
+GET /campaign/{campaign_id}
+```
+
+Returns impressions, clicks, CTR, and budget remaining.
+
+### List Campaigns
+
+```http
+GET /campaign/?wallet=0x...
+```
+
+List all campaigns for an advertiser wallet.
+
+## Revenue Split
+
+| Recipient | Share | Description |
+|-----------|-------|-------------|
+| User | 50% | Paid out in USDC on Base |
+| Operator | 30% | Who runs the agent surface |
+| Protocol | 20% | Treasury for marketplace |
+
+## Pricing
+
+| Action | Advertiser Pays | User Gets |
+|--------|----------------|-----------|
+| Impression | $0.005 | $0.0025 |
+| Premium | $0.010 | $0.0050 |
+| Click | $0.150 | $0.0750 |
+
+## Agent Integration
+
+### Hermes Plugin
+
+```python
+from agent_kickbacks.adapters.hermes import register
+
+# In your Hermes plugin
+register(ctx)
+```
+
+### MCP Server
+
+```bash
+pip install agent-kickbacks[mcp]
+agent-kickbacks-mcp serve
+```
+
+### Direct API
+
+```python
+import httpx
+
+# Request an ad
+resp = httpx.post("https://agent-kickbacks-production.up.railway.app/ad/request", json={
+    "user_wallet": "0x...",
+    "agent": "hermes",
+    "context": "defi",
+    "surface": "response_footer"
+})
+ad = resp.json()
+```
+
+## Safety Features
+
+- **Kill switch**: `AD_KILL_SWITCH=true` disables all ad serving
+- **Rate limiting**: 10 requests/min per user, 30/min per IP
+- **Content moderation**: Blocklist for scam/phishing keywords
+- **Frequency caps**: 100 impressions/day, 20/session
+- **HMAC tokens**: Signed impression tokens prevent forgery
+
+## Chain Info
+
+- **Network**: Base (eip155:8453)
+- **USDC**: `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
+- **Gas**: ~$0.0001 per transaction
+- **Finality**: ~2 seconds
+
+## Example: Agent Earning Flow
+
+```python
+import httpx
+
+API = "https://agent-kickbacks-production.up.railway.app"
+WALLET = "0xYourAgentWallet"
+
+# 1. Request ad during thinking time
+ad = httpx.post(f"{API}/ad/request", json={
+    "user_wallet": WALLET,
+    "agent": "hermes",
+    "context": "thinking",
+    "surface": "thinking_state"
+}).json()
+
+# 2. Display ad to user
+print(f"Sponsored: {ad['title']} - {ad['body']}")
+
+# 3. Track impression (when displayed)
+httpx.post(f"{API}/ad/impression", json={
+    "ad_id": ad["ad_id"],
+    "user_wallet": WALLET,
+    "token": ad["impression_token"]
+})
+
+# 4. Check earnings
+earnings = httpx.get(f"{API}/earnings/{WALLET}").json()
+print(f"Balance: ${earnings['balance']:.4f}")
+```
+
+## Links
+
+- GitHub: https://github.com/enzoonchain/agent-kickbacks
+- API: https://agent-kickbacks-production.up.railway.app
+- Docs: https://github.com/enzoonchain/agent-kickbacks/blob/main/docs/PLUGIN.md

--- a/agent-kickbacks/scripts/demo.py
+++ b/agent-kickbacks/scripts/demo.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Agent Kickbacks — BankrBot skill example script.
+
+Demonstrates the full ad earning flow:
+1. Request ad during thinking time
+2. Display ad to user
+3. Track impression
+4. Check earnings
+"""
+
+import httpx
+
+API = "https://agent-kickbacks-production.up.railway.app"
+
+
+def request_ad(wallet: str, context: str = "general", surface: str = "response_footer") -> dict | None:
+    """Request an ad from the marketplace."""
+    try:
+        resp = httpx.post(
+            f"{API}/ad/request",
+            json={
+                "user_wallet": wallet,
+                "agent": "bankr",
+                "context": context,
+                "surface": surface,
+            },
+            timeout=2.0,
+        )
+        if resp.status_code == 200:
+            return resp.json()
+    except httpx.HTTPError:
+        pass
+    return None
+
+
+def track_impression(ad_id: str, wallet: str, token: str) -> bool:
+    """Track a confirmed ad impression."""
+    try:
+        resp = httpx.post(
+            f"{API}/ad/impression",
+            json={"ad_id": ad_id, "user_wallet": wallet, "token": token},
+            timeout=2.0,
+        )
+        return resp.status_code == 200
+    except httpx.HTTPError:
+        return False
+
+
+def track_click(ad_id: str, wallet: str) -> bool:
+    """Track an ad click."""
+    try:
+        resp = httpx.post(
+            f"{API}/ad/click",
+            json={"ad_id": ad_id, "user_wallet": wallet},
+            timeout=2.0,
+        )
+        return resp.status_code == 200
+    except httpx.HTTPError:
+        return False
+
+
+def check_earnings(wallet: str) -> dict:
+    """Check earnings balance."""
+    try:
+        resp = httpx.get(f"{API}/earnings/{wallet}", timeout=5.0)
+        if resp.status_code == 200:
+            return resp.json()
+    except httpx.HTTPError:
+        pass
+    return {"balance": 0.0, "total_earned": 0.0, "total_impressions": 0, "total_clicks": 0}
+
+
+def request_payout(wallet: str) -> dict:
+    """Request a USDC payout."""
+    try:
+        resp = httpx.post(
+            f"{API}/payout/request",
+            json={"wallet_address": wallet},
+            timeout=10.0,
+        )
+        if resp.status_code == 200:
+            return resp.json()
+    except httpx.HTTPError:
+        pass
+    return {"status": "error"}
+
+
+if __name__ == "__main__":
+    import sys
+
+    wallet = sys.argv[1] if len(sys.argv) > 1 else "0x0000000000000000000000000000000000000000"
+
+    print(f"=== Agent Kickbacks Demo (wallet: {wallet[:10]}...) ===\n")
+
+    # 1. Request ad
+    print("1. Requesting ad...")
+    ad = request_ad(wallet, context="defi trading")
+    if ad:
+        print(f"   ✅ Ad: {ad['title']}")
+        print(f"   📝 {ad['body']}")
+        print(f"   💰 Earn: ${ad['earn_amount']:.4f}")
+    else:
+        print("   ❌ No ads available")
+
+    # 2. Check earnings
+    print("\n2. Checking earnings...")
+    earnings = check_earnings(wallet)
+    print(f"   💰 Balance: ${earnings['balance']:.4f}")
+    print(f"   📊 Impressions: {earnings['total_impressions']}")
+    print(f"   🖱️ Clicks: {earnings['total_clicks']}")
+
+    print("\n=== Done ===")


### PR DESCRIPTION
## Summary

Adds **Agent Kickbacks** — a crypto-native ad marketplace for AI agents that monetizes idle/thinking time by serving sponsored content and pays users USDC on Base via x402 micropayments.

## What it does

- **Ad requesting**: Fetch contextual ads during agent idle/thinking time
- **Impression tracking**: Server-authoritative tracking with HMAC tokens
- **Click tracking**: 50x impression value multiplier
- **User earnings**: 50% of ad revenue paid to users
- **USDC payouts**: Gasless transfers on Base via EIP-3009
- **Campaign management**: Advertisers create campaigns, buy impression blocks

## API

- **Base URL**: `https://agent-kickbacks-production.up.railway.app`
- **Network**: Base (eip155:8453)
- **Payment**: x402 USDC on Base

## Key endpoints

| Endpoint | Description |
|----------|-------------|
| `POST /ad/request` | Request ad for agent |
| `POST /ad/impression` | Track impression |
| `POST /ad/click` | Track click |
| `GET /earnings/{wallet}` | Check balance |
| `POST /payout/request` | Request USDC payout |
| `POST /campaign/create` | Create ad campaign |

## Revenue model

- User: 50% of impressions/clicks
- Operator: 30%
- Protocol: 20%

## Safety

- Kill switch for emergency shutdown
- Rate limiting (10/min user, 30/min IP)
- Content moderation blocklist
- HMAC-signed impression tokens

## Links

- GitHub: https://github.com/enzoonchain/agent-kickbacks
- API: https://agent-kickbacks-production.up.railway.app