### PR TITLE
hunch: ground replies in Hunch Intelligence + answer market-existence from discover (not memory)

### DIFF
--- a/hunch/SKILL.md
+++ b/hunch/SKILL.md
@@ -7,7 +7,11 @@ description: >
   vs pump.fun volume / #1-days / launches over a cap), token head-to-head
   outperformance, mcap strike-ladders, and up/down price rounds. Also trigger on
   "what can I bet on about $TOKEN", "odds on …", "take YES/NO on …", "show my
-  Hunch bets", "did my market resolve". Settles in USDC on Base via x402
+  Hunch bets", "did my market resolve". Also trigger on "which markets does Hunch
+  have for <project/token>", "do you have a market for X", or "what can people bet
+  on for the projects in this post" — answer those from Hunch's own discover API,
+  the only source of truth for which markets exist (never Polymarket, never the
+  model's own memory). Settles in USDC on Base via x402
   (≤ $10 / bet); every bet returns an on-chain proof.
 metadata:
   clawdbot:
@@ -56,6 +60,39 @@ Use this skill when the user wants to:
 Stay silent (don't offer a market) when the post is an opinion, a settled fact,
 a greeting, a scam/airdrop shill, or has no resolvable claim — Hunch's discovery
 returns no match in those cases and you should not invent one.
+
+## Markets for named projects (catalogue lookup)
+
+When a user asks **what Hunch markets exist** for one or more named projects or
+tokens — "which markets do we have for the projects in this post", "do you have a
+market for Venice / Aeon / aixbt", "what can I bet on for $X and $Y" — this is a
+**catalogue lookup**, not an injection. Answer it from the API, **one query per
+name**:
+
+1. Pull every named project / token out of the ask (or out of a quoted post — its
+   `signal.entities`, see below). Handles and project names count the same.
+2. For **each** name, call `GET /api/partner/discover?q=<name>`. **Project NAMES
+   work — you do not need the cashtag.** "Venice" finds the $VVV markets, "Aeon"
+   finds $AEON, "Surplus" finds $SURPLUS, "aixbt" finds $AIXBT — the project name
+   is indexed in the market, so a plain word resolves to its token's markets.
+3. List every market returned, grouped by project, leading with each match's
+   `headline`. A project whose discover returns `count: 0` — and **only** that
+   one — has no Hunch market; say so for that project alone.
+
+> **Hard rule — existence is decided only by the discover API.** If you did not
+> call `discover` for a name, you do not know whether Hunch has a market for it.
+> **Never** answer "no markets" — or "we have markets" — from your own knowledge,
+> training data, or another venue; **never substitute Polymarket** or any other
+> market for a Hunch answer (this skill speaks for Hunch only). "None" is correct
+> *only* after a `count: 0` from Hunch's own discover endpoint.
+
+**Use `?q=`, not `?post=`, for this.** `?post=<the whole post>` is the
+silence-gated *injection* path, not an existence check: for an opinion / thesis
+post (e.g. "the future of trading is automation, use @AskVenice…") it returns
+`silent: true` **even though markets exist** for the tokens named in it — correct
+for "should I inject one market", wrong for "what markets exist". Never report
+"no markets" off a `silent` post: harvest the named entities from the response's
+`signal.entities`, then run step 2's `?q=<entity>` for each.
 
 ## Proactive injection (adding a market unprompted)
 

--- a/hunch/SKILL.md
+++ b/hunch/SKILL.md
@@ -101,6 +101,31 @@ frens" → nothing; (5) "what was $BNKR's all-time high?" → answer, no market;
 - **Same money-path rules** as any bet: the user picks side + size ($1–$10); you
   echo the deterministic id, never a model guess.
 
+## Ground replies in Hunch Intelligence
+
+Before answering a "is $X bullish / what's the sentiment / should I buy $X"
+question about a token, read the **Hunch crowd-conviction signal** and weave it
+in — it's what the crowd, with real USDC down, thinks, not vibes.
+
+`GET /api/partner/intel?token=$SYMBOL` → a single 0–100 sentiment `score`
+(pool-weighted by on-chain betting depth), `confidence`, a render-ready
+`summary`, a `suggestedBet` (the one market + side to act on, with a quick-bet
+link), and `quality` (how many wallets back it vs one whale). Full wire detail in
+`references/intel.md`.
+
+- Lead with the `summary` verbatim ("$BNKR — Hunch crowd: 68/100 (strongly
+  bullish, low confidence) across 7 markets · $5 pooled").
+- If `suggestedBet` is present, offer it: "Back {sideLabel} on {shortTitle}? Tag
+  @bankrbot to bet — settles in USDC on Base." Use `suggestedBet.betUrl` as the
+  one-tap link.
+- Mind `quality`: caveat a `concentrated` pool (one whale); `broad` conviction is
+  stronger.
+- `hasSignal: false` → Hunch has no market on that token yet; stay silent on the
+  signal (never invent one) and fall back to the normal discover flow.
+
+Read-only, free, no payment. This grounds the bot's take in real money before it
+ever offers a bet.
+
 ## The three calls (the bet loop)
 
 1. **Discover** — turn a phrase or post into matched markets.
@@ -133,6 +158,7 @@ Every market object is the shared ref documented in `references/market-ref.md`.
 | Endpoint | Method | Purpose | Reference |
 |---|---|---|---|
 | `/api/partner/discover` | GET | phrase/post → ranked markets | `discovery.md` |
+| `/api/partner/intel` | GET | token → crowd-conviction sentiment signal | `intel.md` |
 | `/api/partner/catalogue` | GET | vetted markets grouped by category | `catalogue.md` |
 | `/api/partner/quote` | GET | live odds + cost breakdown (+ ladder, tokenSnapshot) | `quote.md` |
 | `/api/partner/trade` | POST | place a bet via x402 (Base USDC) | `trading.md` |
@@ -412,6 +438,7 @@ any network retry so a dropped response can never double-settle.
 
 - `references/market-ref.md` — the shared market object + `meta`, documented once.
 - `references/discovery.md` — discover contract (cashtag / claim-LLM / silence).
+- `references/intel.md` — the crowd-conviction signal (sentiment + suggestedBet).
 - `references/catalogue.md` — the vetted, grouped browse surface (5 categories).
 - `references/quote.md` — live odds + cost breakdown, ladder rungs, tokenSnapshot.
 - `references/trading.md` — the x402 trade flow on Base (402 → sign → 200) + errors.

--- a/hunch/references/discovery.md
+++ b/hunch/references/discovery.md
@@ -162,12 +162,33 @@ loosely related market. Posts that correctly return no match: greetings ("gm"),
 opinions, already-settled facts, airdrop/scam shills, and anything with no
 resolvable future claim.
 
+> **Silence is the *injection* gate, not an existence check.** A `silent` `post`
+> means "don't inject a market into this reply" — **not** "no markets exist for
+> the tokens named in the post". An opinion post that name-drops several projects
+> returns `silent` while those projects' markets are alive and bettable. To answer
+> "which markets does Hunch have for X", query each named project with `?q=` (see
+> *Markets for named projects* below) — never report "no markets" off a `silent`.
+
 ### Multi-market
 
 A token with ≥2 live markets returns them all, ranked. Flip markets index **both**
 sides (the $HUNCH underdog *and* the target), so `$LFI` exact-matches
 "Will $HUNCH flip $LFI?" — not just a weak lexical hit. List each match; let the
 user pick; then `quote` → `trade`.
+
+### Markets for named projects (names work — one query per name)
+
+Discovery matches **project names**, not just cashtags: the project name and
+descriptive text are folded into the lexical haystack, so a plain `q=Venice`
+surfaces the `$VVV` markets, `q=Aeon` the `$AEON` markets, `q=Surplus` the
+`$SURPLUS` markets, `q=aixbt` the `$AIXBT` markets. To answer "which markets does
+Hunch have for these projects", call `?q=<name>` **once per named project** and
+union the results — don't pass the whole list as one query, and don't use `?post=`
+(that's the silence-gated injection path, which returns `silent` for an opinion
+post even when the named tokens have live markets). A name with `count: 0` is the
+*only* signal that Hunch has no market for it — never infer "no market", and never
+substitute Polymarket, from anything else. See SKILL.md → *Markets for named
+projects (catalogue lookup)*.
 
 ### Browse mode
 

--- a/hunch/references/intel.md
+++ b/hunch/references/intel.md
@@ -1,0 +1,69 @@
+# references/intel.md — Hunch Intelligence (crowd-conviction signal)
+
+`GET /api/partner/intel?token=$SYMBOL` — a single sentiment read for a token,
+synthesised from every live Hunch market's odds, pool-weighted by real on-chain
+betting depth. Free, read-only, CORS-open, flag-gated behind `HUNCH_PARTNER_API`
+(404 when off). Wraps its payload in the shared `meta` block.
+
+Accepts `$BNKR`, `BNKR`, or `bnkr`. Returns `422 invalid_token` for a malformed
+symbol.
+
+## Response
+
+```json
+{
+  "meta": { "version": "hunch-partner-api-v1", "generatedAt": "…" },
+  "token": "bnkr",
+  "intel": {
+    "hasSignal": true,
+    "marketCount": 7,
+    "sentiment": {
+      "score": 68,                 // 0-100, 50 = neutral
+      "lean": 18,                  // score - 50
+      "label": "strongly_bullish", // strongly_bullish·bullish·neutral·bearish·strongly_bearish
+      "basis": "pool_weighted",    // pool_weighted·equal_weight·none
+      "confidence": "low",         // high·medium·low·none (by USD backing the signal)
+      "directionalMarketCount": 4,
+      "directionalPoolUsd": 4
+    },
+    "suggestedBet": {
+      "marketId": "bankr-100m-mcap-2026-06-30",
+      "side": "yes",
+      "sideLabel": "YES",          // "UP"/"DOWN" for up/down rounds, else YES/NO
+      "impliedCents": 68,
+      "betUrl": "https://www.playhunch.xyz/quick/bankr-100m-mcap-2026-06-30?side=yes&ref=x402"
+    },
+    "quality": { "distinctBettors": 3, "topWalletPct": 71.4, "label": "concentrated" },
+    "activity": { "totalBets": 4, "totalPoolUsd": 5 },
+    "topMarket": { "id": "…", "shortTitle": "…", "kind": "binary", "yesPriceCents": 68, "appUrl": "…" },
+    "markets": [ /* per-market breakdown */ ],
+    "summary": "$BNKR — Hunch crowd: 68/100 (strongly bullish, low confidence) across 7 markets · $5 pooled.",
+    "asOf": "…"
+  }
+}
+```
+
+## How the score works
+
+- Only the token's DIRECTIONAL price markets feed the score (market-cap
+  milestones, close-above-strike, up/down rounds — "YES = number up"). Flips,
+  ladders, and chain-metric markets count as activity, not the directional read.
+- It's a pool-weighted average of the implied YES odds across those markets;
+  with no money down it falls back to an equal-weight average (low confidence).
+- `quality` is computed from the directional markets' settled trades —
+  `broad` (many wallets), `mixed`, `concentrated` (one whale / ≤ 2 wallets), or
+  `none`. It says how solid the conviction behind the score is.
+
+## Using it in a reply
+
+1. Lead with `summary` verbatim.
+2. If `suggestedBet` is present, offer it with `betUrl` as the one-tap link:
+   "Back {sideLabel} on {shortTitle}? Tag @bankrbot to bet — settles in USDC on
+   Base."
+3. Caveat a `concentrated` pool (one whale); `broad` conviction is stronger.
+4. `hasSignal: false` → Hunch has no market on that token yet; don't invent a
+   signal — fall back to the normal discover flow.
+
+Read-only — no payment, no money path. The paid x402 Cloud edge (`hunch-intel`)
+wraps this exact read for agents that pay per call; the reply path here uses the
+free endpoint.

--- a/hunch/references/transcripts.md
+++ b/hunch/references/transcripts.md
@@ -49,6 +49,26 @@ deadlines), each with its disclosure line. User taps one → quote → trade.
    → trade. (Discovery indexes both sides of a flip, so the token's flip market
    surfaces as an exact match, not a weak lexical one.)
 
+### Markets for the projects in a post (catalogue lookup)
+
+> **user:** @bankrbot which markets do we have for the projects in this post?
+> (quoting a post that name-drops @AskVenice, @AskSurplus, @claudeai, @aixbt_agent, @aeonframework)
+
+This asks **what exists**, not "inject one market" — so query each named project
+with `?q=`, never `?post=` (the post is an opinion → `?post=` returns `silent`
+even though markets exist). One call per project:
+
+1. `discover?q=Venice` → $VVV markets ($1B mcap, staked-share, DIEM supply, ladder).
+2. `discover?q=Surplus` → $SURPLUS markets ($10M mcap, SI payments/txs, up/down, flip).
+3. `discover?q=Aeon` → $AEON markets ($5M mcap, ladder, flip, AEON-ecosystem basket).
+4. `discover?q=aixbt` → $AIXBT markets ($50M mcap, up/down).
+5. `discover?q=Claude` → `count: 0` → the *only* "no market" — Claude has none.
+
+Reply with the found markets grouped by project (lead each with its `headline`),
+and name **only** Claude as having no market. **Never** say "no markets" for a
+project you didn't `discover`, and never substitute Polymarket — Hunch's discover
+endpoint is the sole source of truth for what exists.
+
 ---
 
 ## Proactive injection — fire vs silent


### PR DESCRIPTION
## What

Adds a **"Ground replies in Hunch Intelligence"** section to `hunch/SKILL.md`, the `/api/partner/intel` endpoint row, and a new `hunch/references/intel.md`.

Before answering a token sentiment / "is \$X bullish?" question, the bot reads the **Hunch crowd-conviction signal** — a single 0–100 score for a token, pool-weighted by real on-chain betting depth — and weaves in:
- the render-ready `summary`,
- a `suggestedBet` (the one market + side to act on, with a one-tap quick-bet link, settling in USDC on Base),
- a `quality` read (how many wallets back the score vs one whale).

It stays silent when `hasSignal: false` (no Hunch market on that token), exactly like the existing discovery silence gate.

## Why

It makes the bot's take on a token grounded in real money, and turns a price answer into something the user can act on — read → conviction → bet → settle on Base.

## Safety

**Additive only.** `SKILL.md` is **+27 lines, zero deletions**; `x402-registry.json` is **byte-identical** (no money-path / security change). The signal is read-only and free (`GET /api/partner/intel`).

---

## Also in this PR — answer market-existence from `discover`, never from memory

**Incident (2026-06-20):** @bankrbot was asked *"which markets do we have for the projects in this post"* (a post naming Venice, Surplus, Claude, aixbt, Aeon) and replied that Hunch has **no markets** for them — reasoning from its own knowledge / Polymarket. But `/api/partner/discover` returns live markets for every one of those project **names**: `Venice`→$VVV (3), `Surplus`→$SURPLUS (8), `Aeon`→AEON (5), `aixbt`→$AIXBT (2); only `Claude` correctly has none. The API was right — the skill just had no procedure for "list the markets for these named projects," and no rule that **market existence is decided only by `discover`**.

Adds, additively:
- **`SKILL.md` → new "Markets for named projects (catalogue lookup)" section** — call `GET /api/partner/discover?q=<name>` **once per named project** (project **names** resolve — no cashtag needed), list every result, and treat **only** a `count: 0` as "no market." Hard rule: never answer market existence from your own knowledge or another venue (no Polymarket substitution) — the discover API is the sole source of truth. Plus a routing trigger in the `description`.
- Clarifies that **`?post=` is the silence-gated *injection* path, not an existence check** — an opinion post that name-drops several projects returns `silent` even though those projects' markets are live; harvest `signal.entities` and `?q=` each.
- **`references/discovery.md` + `references/transcripts.md`** — name-based discovery docs + a worked transcript of the exact failing scenario, answered correctly.

**Safety:** additive only (+79 lines across 3 docs, one-line description reflow); **`x402-registry.json` byte-identical**; read-only, no money-path or security change.
