### PR TITLE
Add Charon Bankr skill

### DIFF
--- a/charon-bankr/SKILL.md
+++ b/charon-bankr/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: charon-bankr
+description: >
+  Charon policy checks for Bankr actions. Use before Bankr runs coding tasks,
+  shell commands, file edits, git operations, HTTP/API calls, browser actions,
+  automations, wallet actions, token launches, signing, or any tool call with
+  external side effects. Normalizes the requested action, evaluates editable
+  PASS / PAUSE / DENY policy, and records a receipt. This is a skill-level
+  policy layer, not native Bankr runtime enforcement.
+metadata:
+  clawdbot:
+    emoji: "🛡️"
+    homepage: "https://github.com/CharonAI-code/charon"
+    requires:
+      bins: ["node"]
+---
+
+# Charon for Bankr
+
+Charon gives a Bankr agent a policy checkpoint before it acts.
+
+Bankr can do more than wallet operations: coding, repo work, API calls, browser tasks, automations,
+research, signing, token launches, and trading. Charon treats all of those as one thing: an action with
+resources and side effects.
+
+This skill is for action review inside Bankr. It does not claim hard runtime enforcement. Native
+enforcement needs a Bankr pre-execution hook or an external Charon runtime.
+
+## When to use
+
+Use Charon before:
+
+- editing, deleting, generating, or publishing code
+- running shell commands or package scripts
+- changing git state, pushing, opening PRs, or modifying remotes
+- calling unknown APIs or webhooks
+- opening browser sessions against unknown domains
+- creating recurring automations
+- moving funds, swapping, signing, launching tokens, or calling contracts
+- handling secrets, API keys, private data, or user credentials
+
+Do not use Charon for read-only explanations, brainstorming, plain summaries, or harmless formatting.
+
+## Workflow
+
+1. Convert the user request into a normalized action. Use `references/action-model.md`.
+2. Pick or edit a policy. Start with `templates/charon.policy.json`.
+3. Run the policy check:
+
+```bash
+node scripts/charon_policy_check.js action.json templates/charon.policy.json
+```
+
+4. Follow the verdict:
+
+| Verdict | Meaning |
+|---|---|
+| `PASS` | Continue. |
+| `PAUSE` | Ask the user for explicit confirmation. |
+| `DENY` | Stop. Do not execute the action. |
+
+5. Write a receipt:
+
+```bash
+node scripts/charon_receipt.js action.json verdict.json
+```
+
+## Action examples
+
+Code delete:
+
+```json
+{
+  "type": "code.delete",
+  "category": "code",
+  "operation": "delete",
+  "path": "src/server.ts",
+  "intent": "remove old server"
+}
+```
+
+Git push:
+
+```json
+{
+  "type": "git.push",
+  "category": "git",
+  "operation": "push",
+  "remote": "origin",
+  "branch": "main"
+}
+```
+
+API call:
+
+```json
+{
+  "type": "http.request",
+  "category": "network",
+  "operation": "post",
+  "domain": "api.example.com",
+  "url": "https://api.example.com/v1/job"
+}
+```
+
+Wallet transfer:
+
+```json
+{
+  "type": "wallet.transfer",
+  "category": "wallet",
+  "operation": "transfer",
+  "chain": "base",
+  "asset": "ETH",
+  "amount_usd": 250,
+  "recipient": "0x2222222222222222222222222222222222222222"
+}
+```
+
+## Install
+
+```text
+install the charon-bankr skill from https://github.com/BankrBot/skills/tree/main/charon-bankr
+```
+
+## Files
+
+- `references/action-model.md` — normalized action schema and examples.
+- `references/policy-format.md` — rule format and match operators.
+- `references/receipt-format.md` — receipt fields.
+- `references/operating-model.md` — how an agent should use Charon inside Bankr.
+- `templates/charon.policy.json` — editable default policy.
+- `scripts/charon_policy_check.js` — deterministic policy evaluator.
+- `scripts/charon_receipt.js` — receipt generator.

--- a/charon-bankr/references/action-model.md
+++ b/charon-bankr/references/action-model.md
@@ -1,0 +1,72 @@
+# Action Model
+
+Normalize every Bankr operation before policy evaluation.
+
+```json
+{
+  "id": "bankr_action_001",
+  "type": "code.write",
+  "category": "code",
+  "operation": "write",
+  "target": "src/app.ts",
+  "path": "src/app.ts",
+  "intent": "implement the requested feature",
+  "source": "bankr"
+}
+```
+
+## Core fields
+
+| Field | Meaning |
+|---|---|
+| `id` | Optional caller-provided action id. |
+| `type` | Specific action type, e.g. `code.write`, `git.push`, `wallet.transfer`. |
+| `category` | Broad class: `code`, `shell`, `git`, `network`, `browser`, `wallet`, `automation`, `secret`, `research`. |
+| `operation` | Verb: `read`, `write`, `delete`, `run`, `push`, `post`, `sign`, `transfer`, `launch`. |
+| `target` | Main object touched by the action. |
+| `intent` | Short user intent. |
+| `source` | Usually `bankr`. |
+
+## Resource fields
+
+Use the fields that apply.
+
+| Field | Examples |
+|---|---|
+| `path` | `src/server.ts`, `.env`, `package.json` |
+| `paths` | `["src/a.ts", "src/b.ts"]` |
+| `command` | `npm`, `git`, `python`, `bash` |
+| `args` | `["run", "build"]` |
+| `script` | `rm -rf dist && npm run build` |
+| `domain` | `api.github.com` |
+| `url` | `https://api.github.com/repos/...` |
+| `remote` | `origin` |
+| `branch` | `main` |
+| `chain` | `base`, `ethereum`, `solana` |
+| `asset` | `ETH`, `USDC`, token contract |
+| `amount_usd` | numeric USD estimate |
+| `recipient` | address, account, API target, contract |
+| `capability` | external skill/tool/capability name |
+| `risk` | `low`, `medium`, `high`, `critical` |
+
+## Common action types
+
+| Type | Use for |
+|---|---|
+| `code.read` | Read source files. |
+| `code.write` | Create or edit files. |
+| `code.delete` | Delete files or directories. |
+| `shell.run` | Run a command or script. |
+| `git.status` | Read git state. |
+| `git.commit` | Commit changes. |
+| `git.push` | Push to a remote. |
+| `http.request` | Call an HTTP API. |
+| `browser.open` | Open or interact with a page. |
+| `automation.create` | Create recurring or delayed work. |
+| `wallet.transfer` | Send funds. |
+| `wallet.sign` | Sign a message or transaction. |
+| `token.swap` | Swap assets. |
+| `token.launch` | Launch a token. |
+| `secret.read` | Read credentials or sensitive data. |
+
+The model is intentionally flat. Agents should not hide side effects inside nested prose.

--- a/charon-bankr/references/control-catalog.md
+++ b/charon-bankr/references/control-catalog.md
@@ -1,0 +1,59 @@
+# Control Catalog
+
+Use these controls as policy building blocks.
+
+## Code and Files
+
+Pause writes outside the project root.
+
+Deny deletes of source, config, lockfiles, secrets, and git metadata unless explicitly allowed.
+
+Pause broad rewrites, generated code over many files, or dependency changes.
+
+Deny reads of `.env`, key files, wallet files, and private configs.
+
+## Shell and Package Scripts
+
+Pause unknown shell commands.
+
+Deny destructive commands such as recursive delete, disk formatting, permission changes, and process killing.
+
+Pause package scripts before expansion when they can run arbitrary commands.
+
+## Git
+
+Pass status, diff, log, and branch reads.
+
+Pause commits.
+
+Pause pushes.
+
+Deny force pushes by default.
+
+Deny remote changes unless explicitly requested.
+
+## Network and Browser
+
+Pass allowlisted domains.
+
+Pause unknown domains.
+
+Deny webhook and exfiltration-style domains.
+
+Deny requests carrying secret-looking values.
+
+## Wallet and Signing
+
+Pass read-only portfolio checks.
+
+Pause transfers, swaps, contract calls, and signatures.
+
+Deny transfers above hard limits.
+
+Deny unknown chains or recipients when policy requires allowlists.
+
+## Automations
+
+Pause any recurring job, scheduled job, watcher, or trading automation.
+
+Deny automations without an end condition, spend cap, or scope.

--- a/charon-bankr/references/examples.md
+++ b/charon-bankr/references/examples.md
@@ -1,0 +1,86 @@
+# Examples
+
+## Code delete
+
+`action.json`
+
+```json
+{
+  "type": "code.delete",
+  "category": "code",
+  "operation": "delete",
+  "path": "src/server.ts",
+  "intent": "delete server file"
+}
+```
+
+Run:
+
+```bash
+node scripts/charon_policy_check.js action.json templates/charon.policy.json
+```
+
+Expected: `DENY`.
+
+## Git push
+
+```json
+{
+  "type": "git.push",
+  "category": "git",
+  "operation": "push",
+  "remote": "origin",
+  "branch": "main"
+}
+```
+
+Expected: `PAUSE`.
+
+## Unknown API call
+
+```json
+{
+  "type": "http.request",
+  "category": "network",
+  "operation": "post",
+  "domain": "api.unknown.example",
+  "url": "https://api.unknown.example/job"
+}
+```
+
+Expected: `PAUSE`.
+
+## Exfil-style webhook
+
+```json
+{
+  "type": "http.request",
+  "category": "network",
+  "operation": "post",
+  "domain": "webhook.site",
+  "contains_secret": true
+}
+```
+
+Expected: `DENY`.
+
+## Wallet transfer
+
+```json
+{
+  "type": "wallet.transfer",
+  "category": "wallet",
+  "operation": "transfer",
+  "chain": "base",
+  "amount_usd": 250,
+  "recipient": "0x2222222222222222222222222222222222222222"
+}
+```
+
+Expected: `PAUSE`.
+
+## Receipt
+
+```bash
+node scripts/charon_receipt.js action.json verdict.json
+```

--- a/charon-bankr/references/operating-model.md
+++ b/charon-bankr/references/operating-model.md
@@ -1,0 +1,47 @@
+# Operating Model
+
+Charon is a pre-action check.
+
+The agent should not ask "is this safe?" in prose. It should build an action object and run the policy
+script.
+
+## Agent loop
+
+1. Identify the next concrete action.
+2. Normalize it into the action model.
+3. Evaluate policy.
+4. Obey the verdict.
+5. Record a receipt.
+6. Continue only if allowed.
+
+## What counts as one action
+
+One action is the smallest unit with a side effect:
+
+- one file write
+- one delete set
+- one shell command
+- one git push
+- one HTTP request
+- one wallet transfer
+- one signature
+- one automation creation
+
+Batch related reads together. Split side effects.
+
+## Fail closed
+
+If the action cannot be normalized, return `PAUSE`.
+
+If policy cannot be loaded, return `PAUSE`.
+
+If a required field is missing for a risky action, return `PAUSE`.
+
+If the action contains secrets and the next step would expose them, return `DENY`.
+
+## Boundaries
+
+This skill can make Bankr policy-aware. It cannot force Bankr's runtime to obey the decision by itself.
+
+For hard enforcement, Charon needs a Bankr pre-execution hook, MCP routing, or another runtime boundary
+that sees actions before execution.

--- a/charon-bankr/references/policy-format.md
+++ b/charon-bankr/references/policy-format.md
@@ -1,0 +1,77 @@
+# Policy Format
+
+Policy is ordered rules plus a default verdict.
+
+```json
+{
+  "version": 1,
+  "default": "PASS",
+  "allowlists": {
+    "domains": ["api.bankr.bot", "github.com"],
+    "chains": ["base", "ethereum", "solana"],
+    "recipients": []
+  },
+  "blocklists": {
+    "domains": ["webhook.site", "pipedream.net", "interact.sh"],
+    "commands": ["rm", "chmod", "chown", "kill", "pkill"]
+  },
+  "thresholds": {
+    "pause_amount_usd": 100,
+    "deny_amount_usd": 1000
+  },
+  "rules": [
+    {
+      "id": "deny-source-delete",
+      "action": ["code.delete", "shell.run"],
+      "verdict": "DENY",
+      "when": {
+        "operation_in": ["delete"],
+        "path_glob": ["src/**", "package.json", ".env", ".git/**"]
+      }
+    }
+  ]
+}
+```
+
+Rules run in order. First match wins.
+
+## Verdicts
+
+`PASS`: continue.
+
+`PAUSE`: ask the user before execution.
+
+`DENY`: stop.
+
+## Match operators
+
+| Operator | Meaning |
+|---|---|
+| `category_in` | `category` is in list. |
+| `operation_in` | `operation` is in list. |
+| `type_in` | `type` is in list. |
+| `risk_in` | `risk` is in list. |
+| `command_in` | `command` is in list. |
+| `command_not_in` | `command` is not in list. |
+| `path_glob` | `path` or `paths` matches one or more globs. |
+| `domain_in` | `domain` is in list. |
+| `domain_not_in` | `domain` is not in list. |
+| `chain_in` | `chain` is in list. |
+| `chain_not_in` | `chain` is not in list. |
+| `recipient_in` | `recipient` is in list. |
+| `recipient_not_in` | `recipient` is not in list. |
+| `amount_usd_gt` | numeric greater-than check. |
+| `amount_usd_gte` | numeric greater-than-or-equal check. |
+| `field_exists` | action field exists. |
+| `field_missing` | action field is missing. |
+| `contains_secret` | action has `contains_secret: true`. |
+
+Policy values can reference top-level policy data:
+
+```json
+{
+  "domain_not_in": "$allowlists.domains",
+  "command_in": "$blocklists.commands",
+  "amount_usd_gt": "$thresholds.deny_amount_usd"
+}
+```

--- a/charon-bankr/references/receipt-format.md
+++ b/charon-bankr/references/receipt-format.md
@@ -1,0 +1,34 @@
+# Receipt Format
+
+A receipt is the local record of the policy decision.
+
+```json
+{
+  "schema": "charon.bankr.receipt.v1",
+  "receipt_id": "sha256:...",
+  "created_at": "2026-06-16T00:00:00.000Z",
+  "action": {
+    "type": "git.push",
+    "category": "git",
+    "operation": "push",
+    "remote": "origin",
+    "branch": "main"
+  },
+  "decision": {
+    "verdict": "PAUSE",
+    "matched_rule": "pause-git-push",
+    "reason": "pause-git-push matched"
+  },
+  "execution": {
+    "launched": false,
+    "status": "not_launched"
+  }
+}
+```
+
+Receipts are created before execution.
+
+`DENY` and `PAUSE` receipts must keep `execution.launched = false`.
+
+`PASS` receipts use `execution.status = "ready_to_launch"` because this skill cannot observe the final
+Bankr runtime execution state.

--- a/charon-bankr/scripts/charon_policy_check.js
+++ b/charon-bankr/scripts/charon_policy_check.js
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+function usage() {
+  console.error("usage: node scripts/charon_policy_check.js action.json policy.json|policy.yml");
+  process.exit(2);
+}
+
+function loadStructured(file) {
+  const raw = fs.readFileSync(file, "utf8");
+  if (/\.ya?ml$/i.test(file)) {
+    try {
+      return require("js-yaml").load(raw);
+    } catch (error) {
+      throw new Error(`YAML input requires js-yaml to be available: ${error.message}`);
+    }
+  }
+  return JSON.parse(raw);
+}
+
+function asArray(value) {
+  if (value === undefined || value === null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function getPath(root, dottedPath) {
+  return dottedPath.split(".").reduce((value, key) => {
+    if (value && Object.prototype.hasOwnProperty.call(value, key)) return value[key];
+    return undefined;
+  }, root);
+}
+
+function resolveRef(value, policy) {
+  if (typeof value === "string" && value.startsWith("$")) {
+    return getPath(policy, value.slice(1));
+  }
+  return value;
+}
+
+function normalizeString(value) {
+  return String(value || "").toLowerCase();
+}
+
+function includesNormalized(list, value) {
+  const normalized = normalizeString(value);
+  return asArray(list).map(normalizeString).includes(normalized);
+}
+
+function globToRegExp(glob) {
+  const escaped = String(glob)
+    .replace(/[.+^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*\*/g, "\u0000")
+    .replace(/\*/g, "[^/]*")
+    .replace(/\u0000/g, ".*");
+  return new RegExp(`^${escaped}$`);
+}
+
+function pathMatches(action, patterns) {
+  const candidates = [...asArray(action.path), ...asArray(action.paths), ...asArray(action.target)]
+    .filter((value) => value !== undefined && value !== null)
+    .map(String);
+  if (candidates.length === 0) return false;
+  return asArray(patterns).some((pattern) => {
+    const re = globToRegExp(pattern);
+    return candidates.some((candidate) => re.test(candidate));
+  });
+}
+
+function compareNumber(actionValue, expectedValue, operator) {
+  const left = Number(actionValue);
+  const right = Number(expectedValue);
+  if (!Number.isFinite(left) || !Number.isFinite(right)) return false;
+  if (operator === "gt") return left > right;
+  if (operator === "gte") return left >= right;
+  if (operator === "lt") return left < right;
+  if (operator === "lte") return left <= right;
+  return false;
+}
+
+function actionMatches(ruleAction, actionType) {
+  if (ruleAction === undefined || ruleAction === null || ruleAction === "*") return true;
+  return asArray(ruleAction).some((candidate) => candidate === "*" || normalizeString(candidate) === normalizeString(actionType));
+}
+
+function conditionMatches(action, policy, key, expectedRaw) {
+  const expected = resolveRef(expectedRaw, policy);
+  if (key === "category_in") return includesNormalized(expected, action.category);
+  if (key === "operation_in") return includesNormalized(expected, action.operation);
+  if (key === "risk_in") return includesNormalized(expected, action.risk);
+  if (key === "command_in") return includesNormalized(expected, action.command);
+  if (key === "command_not_in") return !includesNormalized(expected, action.command);
+  if (key === "path_glob") return pathMatches(action, expected);
+  if (key === "contains_secret") return Boolean(action.contains_secret) === Boolean(expected);
+  if (key === "amount_usd_gt") return compareNumber(action.amount_usd, expected, "gt");
+  if (key === "amount_usd_gte") return compareNumber(action.amount_usd, expected, "gte");
+  if (key === "amount_usd_lt") return compareNumber(action.amount_usd, expected, "lt");
+  if (key === "amount_usd_lte") return compareNumber(action.amount_usd, expected, "lte");
+  if (key === "chain_in") return includesNormalized(expected, action.chain);
+  if (key === "chain_not_in") return !includesNormalized(expected, action.chain);
+  if (key === "asset_in") return includesNormalized(expected, action.asset);
+  if (key === "recipient_in") return includesNormalized(expected, action.recipient);
+  if (key === "recipient_not_in") return !includesNormalized(expected, action.recipient);
+  if (key === "type_in") return includesNormalized(expected, action.type);
+  if (key === "method_in") return includesNormalized(expected, action.method);
+  if (key === "domain_in") return includesNormalized(expected, action.domain);
+  if (key === "domain_not_in") return !includesNormalized(expected, action.domain);
+  if (key === "field_exists") return action[expected] !== undefined && action[expected] !== null && action[expected] !== "";
+  if (key === "field_missing") return action[expected] === undefined || action[expected] === null || action[expected] === "";
+  return false;
+}
+
+function matchesWhen(action, policy, when) {
+  const entries = Object.entries(when || {});
+  return entries.every(([key, expected]) => conditionMatches(action, policy, key, expected));
+}
+
+function evaluate(action, policy) {
+  for (const rule of policy.rules || []) {
+    if (!actionMatches(rule.action, action.type)) continue;
+    if (!matchesWhen(action, policy, rule.when || {})) continue;
+    return {
+      verdict: String(rule.verdict || "PAUSE").toUpperCase(),
+      matched_rule: rule.id || null,
+      reason: rule.id ? `${rule.id} matched` : "rule matched",
+    };
+  }
+  return {
+    verdict: String(policy.default || "PASS").toUpperCase(),
+    matched_rule: null,
+    reason: "default verdict",
+  };
+}
+
+function main() {
+  const [, , actionFile, policyFile] = process.argv;
+  if (!actionFile || !policyFile) usage();
+
+  const action = loadStructured(path.resolve(actionFile));
+  const policy = loadStructured(path.resolve(policyFile));
+  const decision = evaluate(action, policy);
+  process.stdout.write(`${JSON.stringify(decision, null, 2)}\n`);
+  process.exit(decision.verdict === "DENY" ? 126 : decision.verdict === "PAUSE" ? 125 : 0);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+module.exports = { evaluate };

--- a/charon-bankr/scripts/charon_receipt.js
+++ b/charon-bankr/scripts/charon_receipt.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+"use strict";
+
+const crypto = require("node:crypto");
+const fs = require("node:fs");
+const path = require("node:path");
+
+function usage() {
+  console.error("usage: node scripts/charon_receipt.js action.json verdict.json");
+  process.exit(2);
+}
+
+function loadJson(file) {
+  return JSON.parse(fs.readFileSync(file, "utf8"));
+}
+
+function stableJson(value) {
+  if (Array.isArray(value)) return `[${value.map(stableJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableJson(value[key])}`).join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function receiptFor(action, decision, now = new Date()) {
+  const executionAllowed = String(decision.verdict || "").toUpperCase() === "PASS";
+  const unsigned = {
+    schema: "charon.bankr.receipt.v1",
+    created_at: now.toISOString(),
+    action,
+    decision: {
+      verdict: String(decision.verdict || "PAUSE").toUpperCase(),
+      matched_rule: decision.matched_rule || null,
+      reason: decision.reason || null,
+    },
+    execution: {
+      launched: false,
+      status: executionAllowed ? "ready_to_launch" : "not_launched",
+    },
+  };
+  const digest = crypto.createHash("sha256").update(stableJson(unsigned)).digest("hex");
+  return { receipt_id: `sha256:${digest}`, ...unsigned };
+}
+
+function main() {
+  const [, , actionFile, decisionFile] = process.argv;
+  if (!actionFile || !decisionFile) usage();
+
+  const action = loadJson(path.resolve(actionFile));
+  const decision = loadJson(path.resolve(decisionFile));
+  process.stdout.write(`${JSON.stringify(receiptFor(action, decision), null, 2)}\n`);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}
+
+module.exports = { receiptFor, stableJson };

--- a/charon-bankr/templates/charon.policy.json
+++ b/charon-bankr/templates/charon.policy.json
@@ -1,0 +1,128 @@
+{
+  "version": 1,
+  "default": "PASS",
+  "allowlists": {
+    "commands": ["git", "node", "npm", "pnpm", "bun", "python", "python3", "curl"],
+    "domains": ["api.bankr.bot", "bankr.bot", "github.com", "api.github.com"],
+    "chains": ["base", "ethereum", "polygon", "arbitrum", "bnb", "solana", "unichain", "worldchain"],
+    "recipients": []
+  },
+  "blocklists": {
+    "commands": ["rm", "chmod", "chown", "kill", "pkill", "sudo", "dd"],
+    "domains": ["webhook.site", "pipedream.net", "interact.sh", "ngrok.io", "ngrok-free.app"]
+  },
+  "thresholds": {
+    "pause_amount_usd": 100,
+    "deny_amount_usd": 1000
+  },
+  "rules": [
+    {
+      "id": "deny-secret-exfil",
+      "action": "*",
+      "verdict": "DENY",
+      "when": {
+        "contains_secret": true,
+        "domain_not_in": "$allowlists.domains",
+        "field_exists": "domain"
+      }
+    },
+    {
+      "id": "deny-exfil-domain",
+      "action": ["http.request", "browser.open"],
+      "verdict": "DENY",
+      "when": {
+        "domain_in": "$blocklists.domains"
+      }
+    },
+    {
+      "id": "deny-protected-delete",
+      "action": ["code.delete", "shell.run"],
+      "verdict": "DENY",
+      "when": {
+        "operation_in": ["delete", "remove", "wipe"],
+        "path_glob": ["src/**", "package.json", "package-lock.json", "pnpm-lock.yaml", "bun.lockb", ".env", ".env.*", ".git/**", "charon.yml"]
+      }
+    },
+    {
+      "id": "deny-dangerous-command",
+      "action": "shell.run",
+      "verdict": "DENY",
+      "when": {
+        "command_in": "$blocklists.commands"
+      }
+    },
+    {
+      "id": "deny-wallet-hard-limit",
+      "action": ["wallet.transfer", "token.swap", "contract.call"],
+      "verdict": "DENY",
+      "when": {
+        "amount_usd_gt": "$thresholds.deny_amount_usd"
+      }
+    },
+    {
+      "id": "deny-unsupported-chain",
+      "action": ["wallet.transfer", "wallet.sign", "token.swap", "token.launch", "contract.call"],
+      "verdict": "DENY",
+      "when": {
+        "chain_not_in": "$allowlists.chains",
+        "field_exists": "chain"
+      }
+    },
+    {
+      "id": "pause-unknown-command",
+      "action": "shell.run",
+      "verdict": "PAUSE",
+      "when": {
+        "command_not_in": "$allowlists.commands",
+        "field_exists": "command"
+      }
+    },
+    {
+      "id": "pause-code-write",
+      "action": "code.write",
+      "verdict": "PAUSE",
+      "when": {}
+    },
+    {
+      "id": "pause-git-side-effect",
+      "action": ["git.commit", "git.push", "git.remote", "git.tag"],
+      "verdict": "PAUSE",
+      "when": {}
+    },
+    {
+      "id": "pause-unknown-domain",
+      "action": ["http.request", "browser.open"],
+      "verdict": "PAUSE",
+      "when": {
+        "domain_not_in": "$allowlists.domains",
+        "field_exists": "domain"
+      }
+    },
+    {
+      "id": "pause-automation",
+      "action": "automation.create",
+      "verdict": "PAUSE",
+      "when": {}
+    },
+    {
+      "id": "pause-signing",
+      "action": ["wallet.sign", "contract.call"],
+      "verdict": "PAUSE",
+      "when": {}
+    },
+    {
+      "id": "pause-medium-wallet-action",
+      "action": ["wallet.transfer", "token.swap"],
+      "verdict": "PAUSE",
+      "when": {
+        "amount_usd_gt": "$thresholds.pause_amount_usd"
+      }
+    },
+    {
+      "id": "pause-token-launch",
+      "action": "token.launch",
+      "verdict": "PAUSE",
+      "when": {}
+    }
+  ]
+}

--- a/charon-bankr/templates/charon.policy.yml
+++ b/charon-bankr/templates/charon.policy.yml
@@ -1,0 +1,85 @@
+version: 1
+default: PASS
+allowlists:
+  commands: [git, node, npm, pnpm, bun, python, python3, curl]
+  domains: [api.bankr.bot, bankr.bot, github.com, api.github.com]
+  chains: [base, ethereum, polygon, arbitrum, bnb, solana, unichain, worldchain]
+  recipients: []
+blocklists:
+  commands: [rm, chmod, chown, kill, pkill, sudo, dd]
+  domains: [webhook.site, pipedream.net, interact.sh, ngrok.io, ngrok-free.app]
+thresholds:
+  pause_amount_usd: 100
+  deny_amount_usd: 1000
+rules:
+  - id: deny-secret-exfil
+    action: "*"
+    verdict: DENY
+    when:
+      contains_secret: true
+      domain_not_in: "$allowlists.domains"
+      field_exists: domain
+  - id: deny-exfil-domain
+    action: [http.request, browser.open]
+    verdict: DENY
+    when:
+      domain_in: "$blocklists.domains"
+  - id: deny-protected-delete
+    action: [code.delete, shell.run]
+    verdict: DENY
+    when:
+      operation_in: [delete, remove, wipe]
+      path_glob: [src/**, package.json, package-lock.json, pnpm-lock.yaml, bun.lockb, .env, .env.*, .git/**, charon.yml]
+  - id: deny-dangerous-command
+    action: shell.run
+    verdict: DENY
+    when:
+      command_in: "$blocklists.commands"
+  - id: deny-wallet-hard-limit
+    action: [wallet.transfer, token.swap, contract.call]
+    verdict: DENY
+    when:
+      amount_usd_gt: "$thresholds.deny_amount_usd"
+  - id: deny-unsupported-chain
+    action: [wallet.transfer, wallet.sign, token.swap, token.launch, contract.call]
+    verdict: DENY
+    when:
+      chain_not_in: "$allowlists.chains"
+      field_exists: chain
+  - id: pause-unknown-command
+    action: shell.run
+    verdict: PAUSE
+    when:
+      command_not_in: "$allowlists.commands"
+      field_exists: command
+  - id: pause-code-write
+    action: code.write
+    verdict: PAUSE
+    when: {}
+  - id: pause-git-side-effect
+    action: [git.commit, git.push, git.remote, git.tag]
+    verdict: PAUSE
+    when: {}
+  - id: pause-unknown-domain
+    action: [http.request, browser.open]
+    verdict: PAUSE
+    when:
+      domain_not_in: "$allowlists.domains"
+      field_exists: domain
+  - id: pause-automation
+    action: automation.create
+    verdict: PAUSE
+    when: {}
+  - id: pause-signing
+    action: [wallet.sign, contract.call]
+    verdict: PAUSE
+    when: {}
+  - id: pause-medium-wallet-action
+    action: [wallet.transfer, token.swap]
+    verdict: PAUSE
+    when:
+      amount_usd_gt: "$thresholds.pause_amount_usd"
+  - id: pause-token-launch
+    action: token.launch
+    verdict: PAUSE
+    when: {}


### PR DESCRIPTION
Adds the Charon Bankr skill.

Charon gives Bankr agents a policy checkpoint before executing actions with side effects. The skill includes:

- a normalized action model for code, shell, git, network, browser, automation, wallet, signing, and token actions
- editable PASS / PAUSE / DENY policy templates
- a deterministic policy checker script
- a receipt generation script
- references and examples for agents

Tested locally:

- protected code deletion returns DENY
- Transfer of WETH paused 
- receipt generation returns a Charon receipt object