### PR TITLE
Add vigil-security-scanner skill (onchain security on Base)

### DIFF
--- a/vigil-security-scanner/SKILL.md
+++ b/vigil-security-scanner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vigil-security-scanner
-description: Onchain security scanner for Base tokens and wallets. Scan token approvals, detect honeypots, find rugpull indicators, check liquidity locks, score contract safety 0-100, and get a multi-source consensus verdict. Use when a user asks an agent to evaluate, scan, or check a Base token or wallet before trading, swapping, signing an approval, or investing. 13 read-only tools, keyless and free. Read-only intelligence — not financial advice.
+description: Onchain security scanner for Base tokens and wallets. Scan token approvals, detect honeypots, find rugpull indicators, check liquidity locks, owner-modifiable tax, dangerous owner permissions, copy-paste scam clones, simulate approvals, score contract safety 0-100, and get a multi-source consensus verdict. Use when a user asks an agent to evaluate, scan, or check a Base token or wallet before trading, swapping, signing an approval, or investing. 17 read-only tools, keyless and free. Read-only intelligence — not financial advice.
 tags: [security, defi, base, rugpull, honeypot, onchain]
 version: 1
 visibility: public
@@ -16,7 +16,7 @@ metadata:
 # VIGIL Security Scanner
 
 Onchain security scanner for DeFi traders and autonomous agents on Base. Paste a
-token or wallet address, get a verdict before you sign. VIGIL exposes 13
+token or wallet address, get a verdict before you sign. VIGIL exposes 17
 read-only tools over a keyless JSON-RPC endpoint — no API key, no signup, no
 account.
 
@@ -58,7 +58,7 @@ All scans go through a single JSON-RPC 2.0 endpoint. No auth for read-only tools
 ```bash
 # Health check — confirms the server is live and how many tools are available
 curl -s https://mcp.vigil.codes/health
-# -> {"status":"ok","service":"vigil-mcp","tools":13}
+# -> {"status":"ok","service":"vigil-mcp","tools":17}
 
 # Safety score for USDC on Base
 curl -s -X POST https://mcp.vigil.codes/tools/call \
@@ -73,12 +73,16 @@ curl -s -X POST https://mcp.vigil.codes/tools/call \
 
 ---
 
-## 🛠 The 13 Tools
+## 🛠 The 17 Tools
 
 | Tool | What it does |
 |---|---|
 | `vigil_safety_score` | 0-100 composite rating (code, ownership, registry, reputation) |
 | `vigil_detect_honeypot` | Simulate buy/sell to detect tokens that block selling |
+| `vigil_check_tax` | Flag punishing or owner-modifiable buy/sell/transfer tax ("0% now, 99% later") |
+| `vigil_check_ownership` | Owner powers: mint, pause, blacklist, reclaim ownership, modify balances, selfdestruct |
+| `vigil_detect_clone` | Flag copy-paste scam clones by bytecode fingerprint, cross-checked vs scam DB |
+| `vigil_simulate_approval` | Risk-assess a spender BEFORE you approve it — "what could it do if I sign?" |
 | `vigil_liquidity_lock` | Detect if LP is locked / burned / unlocked / unknown (rug vector) |
 | `vigil_consensus` | Multi-source verdict — 6 independent signals vote, risk escalates only on agreement |
 | `vigil_scan_token` | Rugpull indicators: hidden mint, proxy, tax manipulation, blacklist |
@@ -92,8 +96,10 @@ curl -s -X POST https://mcp.vigil.codes/tools/call \
 | `vigil_sentinel_status` | Autonomous Sentinel watchlist + loop config |
 
 Free core safety checks: `vigil_safety_score`, `vigil_detect_honeypot`,
-`vigil_liquidity_lock`. These stay barrier-free so agents always have a
-pre-trade guard.
+`vigil_check_tax`, `vigil_check_ownership`, `vigil_detect_clone`,
+`vigil_simulate_approval`, `vigil_liquidity_lock`. These stay barrier-free so
+agents always have a pre-trade guard. Premium tools (deeper aggregations) are
+optionally pay-per-call in USDC via x402 — no account needed.
 
 ---
 
@@ -106,6 +112,10 @@ When a user asks about a Base token, the agent should:
 3. **Run the right tool** for the question:
    - "Is this safe to buy?" → `vigil_consensus` (full verdict) or `vigil_safety_score` (quick)
    - "Can I sell it?" → `vigil_detect_honeypot`
+   - "Will it tax me / can the tax change?" → `vigil_check_tax`
+   - "Who controls this contract?" → `vigil_check_ownership`
+   - "Is this a copy-paste scam?" → `vigil_detect_clone`
+   - "Should I sign this approval?" → `vigil_simulate_approval` (spender + token)
    - "Can the dev rug the liquidity?" → `vigil_liquidity_lock`
    - "Check my wallet's approvals" → `vigil_scan_approvals` (wallet address)
 4. **Relay the verdict** including risk level, key reasons, and any critical flags

--- a/vigil-security-scanner/SKILL.md
+++ b/vigil-security-scanner/SKILL.md
@@ -1,0 +1,183 @@
+---
+name: vigil-security-scanner
+description: Onchain security scanner for Base tokens and wallets. Scan token approvals, detect honeypots, find rugpull indicators, check liquidity locks, score contract safety 0-100, and get a multi-source consensus verdict. Use when a user asks an agent to evaluate, scan, or check a Base token or wallet before trading, swapping, signing an approval, or investing. 13 read-only tools, keyless and free. Read-only intelligence — not financial advice.
+tags: [security, defi, base, rugpull, honeypot, onchain]
+version: 1
+visibility: public
+metadata:
+  emoji: 👁️
+  homepage: https://vigil.codes
+  network: base
+  chainId: 8453
+  requires:
+    bins: [curl, jq]
+---
+
+# VIGIL Security Scanner
+
+Onchain security scanner for DeFi traders and autonomous agents on Base. Paste a
+token or wallet address, get a verdict before you sign. VIGIL exposes 13
+read-only tools over a keyless JSON-RPC endpoint — no API key, no signup, no
+account.
+
+**Endpoint:** https://mcp.vigil.codes
+**Site:** https://vigil.codes
+**Source:** https://github.com/vigilcodes/vigil-mcp
+**Network:** Base (chainId 8453)
+
+The core thesis: most security tools tell you what happened *after* you lose
+money. VIGIL tells you *before* you sign. Risk only escalates to high/critical
+when multiple independent sources agree — a deliberate false-positive guard.
+
+---
+
+## 🎯 When to Use This Skill
+
+Use VIGIL when a user wants to:
+
+- Check a Base token before buying, swapping, or aping in
+- Audit a wallet's token approvals and flag unlimited/risky allowances
+- Detect honeypots (tokens that block selling)
+- Check whether DEX liquidity is locked, burned, or freely withdrawable (rug vector)
+- Score any contract 0-100 across code, ownership, registry, and reputation
+- Get a single aggregated verdict from 6 independent security sources
+
+**Do NOT use this skill for:**
+
+- Trade execution (VIGIL is read-only intelligence)
+- Revoking approvals (that's a separate write action requiring Bankr auth — see "Revocation" below)
+- Chains other than Base for deep scans (Base-first; a small Ethereum stablecoin registry exists for labels)
+- Price predictions or financial advice
+
+---
+
+## 🚀 Quick Start
+
+All scans go through a single JSON-RPC 2.0 endpoint. No auth for read-only tools.
+
+```bash
+# Health check — confirms the server is live and how many tools are available
+curl -s https://mcp.vigil.codes/health
+# -> {"status":"ok","service":"vigil-mcp","tools":13}
+
+# Safety score for USDC on Base
+curl -s -X POST https://mcp.vigil.codes/tools/call \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call",
+       "params":{"name":"vigil_safety_score",
+                 "arguments":{"contract":"0x833589fcd6edb6e08f4c7c32d4f71b54bda02913","chain":"base"}}}'
+# -> {"jsonrpc":"2.0","id":1,"result":{"score":92,"risk_level":"safe",...}}
+```
+
+`GET /tools/list` enumerates every tool. There is no REST API — use `POST /tools/call`.
+
+---
+
+## 🛠 The 13 Tools
+
+| Tool | What it does |
+|---|---|
+| `vigil_safety_score` | 0-100 composite rating (code, ownership, registry, reputation) |
+| `vigil_detect_honeypot` | Simulate buy/sell to detect tokens that block selling |
+| `vigil_liquidity_lock` | Detect if LP is locked / burned / unlocked / unknown (rug vector) |
+| `vigil_consensus` | Multi-source verdict — 6 independent signals vote, risk escalates only on agreement |
+| `vigil_scan_token` | Rugpull indicators: hidden mint, proxy, tax manipulation, blacklist |
+| `vigil_scan_approvals` | List all ERC-20/721 approvals, flag unlimited allowances |
+| `vigil_wallet_report` | Full wallet security posture assessment |
+| `vigil_monitor_wallet` | Alerts for new approvals, risky interactions, balance changes |
+| `vigil_token_market` | Price, liquidity, 24h volume, pool age via DexScreener |
+| `vigil_deployer_check` | Contract verification, name, deployer reputation via Basescan |
+| `vigil_batch_scan` | Score multiple tokens in one call, ranked by risk |
+| `vigil_check_scam` | Community scam reports for a token |
+| `vigil_sentinel_status` | Autonomous Sentinel watchlist + loop config |
+
+Free core safety checks: `vigil_safety_score`, `vigil_detect_honeypot`,
+`vigil_liquidity_lock`. These stay barrier-free so agents always have a
+pre-trade guard.
+
+---
+
+## 🔁 Recommended Agent Workflow
+
+When a user asks about a Base token, the agent should:
+
+1. **Detect the address** in the user's message (42-char 0x-prefixed hex)
+2. **Normalize to lowercase** before any call
+3. **Run the right tool** for the question:
+   - "Is this safe to buy?" → `vigil_consensus` (full verdict) or `vigil_safety_score` (quick)
+   - "Can I sell it?" → `vigil_detect_honeypot`
+   - "Can the dev rug the liquidity?" → `vigil_liquidity_lock`
+   - "Check my wallet's approvals" → `vigil_scan_approvals` (wallet address)
+4. **Relay the verdict** including risk level, key reasons, and any critical flags
+5. **Always note** this is read-only intelligence, not financial advice
+
+### Example: full pre-trade verdict
+
+```bash
+curl -s -X POST https://mcp.vigil.codes/tools/call \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call",
+       "params":{"name":"vigil_consensus",
+                 "arguments":{"token":"0xTOKEN","chain":"base"}}}' | jq '.result'
+```
+
+Returns `verdict` (safe → critical), `confidence`, per-source votes, and a
+`summary`. The 6 sources: GoPlus, onchain bytecode, market liquidity, deployer
+verification, community scam DB, and liquidity lock.
+
+### Example: liquidity lock check
+
+```bash
+curl -s -X POST https://mcp.vigil.codes/tools/call \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call",
+       "params":{"name":"vigil_liquidity_lock",
+                 "arguments":{"token":"0xTOKEN","chain":"base"}}}' | jq '.result'
+```
+
+Returns `lock_status` (locked/burned/unlocked/unknown), `locked_fraction`, and
+`pair_address`. `unknown` means data was insufficient — **never treated as
+safe**. Covers V2-style ERC-20 LP tokens; V3/NFT positions return `unknown`.
+
+---
+
+## 📊 Risk Levels
+
+| Level | Icon | Meaning |
+|-------|------|---------|
+| CRITICAL | 🔴 | Active threat — do not interact |
+| HIGH | 🟠 | Dangerous pattern — likely exploit vector |
+| MEDIUM | 🟡 | Suspicious — proceed with caution |
+| LOW | 🟢 | Minor concern — monitor |
+| SAFE | ✅ | No issues detected |
+
+---
+
+## ⚠ Important: Revocation is NOT included
+
+The Approval Revoker performs state-changing onchain transactions via Bankr. It
+is intentionally excluded from this read-only skill. To revoke approvals, use
+VIGIL's separate revoke flow (requires `BANKR_API_KEY` and explicit user
+confirmation). This skill never signs, sends, or moves funds.
+
+---
+
+## 🧩 Why VIGIL
+
+- **Consensus, not noise** — 6 independent sources vote; a single source caps at "medium". False positives are the enemy of a security tool.
+- **Liquidity lock detection** — fails safe to `unknown`, never fabricates a `safe` when LP data is missing.
+- **Keyless + free** — core pre-trade checks need no API key. Built for autonomous agents that must scan before they sign.
+- **MCP-native** — works in Claude Desktop, Cursor, Aeon, and any MCP client.
+
+---
+
+## 📞 Resources
+
+- **Endpoint:** https://mcp.vigil.codes
+- **Site:** https://vigil.codes
+- **Source:** https://github.com/vigilcodes/vigil-mcp
+- **Twitter:** https://x.com/vigilcodes
+
+For per-tool request/response details, see [references/api-reference.md](references/api-reference.md).
+
+*VIGIL is read-only onchain security intelligence. Not financial advice. Always verify independently before signing.*

--- a/vigil-security-scanner/SKILL.md
+++ b/vigil-security-scanner/SKILL.md
@@ -171,6 +171,19 @@ confirmation). This skill never signs, sends, or moves funds.
 
 ---
 
+## 🔗 Pairs with
+
+VIGIL slots in as the security layer for any skill that surfaces or acts on a token. Natural pairings already in the catalog:
+
+- **`aeon-token-pick`** — call VIGIL before publishing a pick. If `vigil_consensus` returns high/critical or `vigil_detect_honeypot` flags, escalate to NO_PICK with VIGIL evidence. Stops bad picks at the source.
+- **`aeon-monitor-runners`** — already drops honeypots from the top-runners list; VIGIL adds 6-source consensus + liquidity-lock checks for the same set, much deeper signal.
+- **`aeon-on-chain-monitor`** — when a watched wallet grants a new approval, run VIGIL's `vigil_scan_approvals` to classify the spender risk before the alert fires.
+- **`aeon-defi-monitor`** — before recommending a pool, run `vigil_liquidity_lock` on the LP to confirm liquidity isn't withdrawable by the deployer.
+
+The pattern is the same in every case: **scan before you sign**, and never let a missing data source get reported as "safe".
+
+---
+
 ## 📞 Resources
 
 - **Endpoint:** https://mcp.vigil.codes

--- a/vigil-security-scanner/references/api-reference.md
+++ b/vigil-security-scanner/references/api-reference.md
@@ -1,0 +1,114 @@
+# VIGIL API Reference
+
+VIGIL is an MCP server. The live, supported transport is a single JSON-RPC 2.0
+endpoint — no API key required for read-only scans.
+
+- **Call a tool:** `POST https://mcp.vigil.codes/tools/call`
+- **List tools:** `GET https://mcp.vigil.codes/tools/list`
+- **Health:** `GET https://mcp.vigil.codes/health`
+
+All calls share this envelope:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": { "name": "<tool>", "arguments": { ... } }
+}
+```
+
+The result is returned under `.result`. Errors come back as `.error`. A few
+premium tools (scan_token, deployer_check, token_market, batch_scan,
+wallet_report, consensus) may respond with an x402 payment-required body
+(`x402Version` + `accepts`) when paid mode is enabled; core safety checks
+(safety_score, detect_honeypot, liquidity_lock, check_scam, scan_approvals,
+monitor_wallet, sentinel_status) are always free.
+
+---
+
+## Tools
+
+### vigil_safety_score
+Args: `contract` (0x address), `chain` (default `base`).
+Returns: `score` (0-100), `risk_level`, `breakdown[]`, `risk_factors[]`,
+`positive_factors[]`, `recommendation`.
+
+### vigil_detect_honeypot
+Args: `token`, `chain`.
+Returns: `is_honeypot`, `can_buy`, `can_sell`, `buy_tax`, `sell_tax`,
+`block_reason`, `simulations[]`.
+
+### vigil_liquidity_lock
+Args: `token`, `chain`.
+Returns: `lock_status` (locked|burned|unlocked|unknown), `determined` (bool),
+`locked_fraction`, `pair_address`, `lp_token`, `locker_name`, `notes[]`.
+`unknown` means insufficient data — never a safety guarantee. Covers V2-style
+ERC-20 LP tokens; V3/NFT positions return `unknown`.
+
+### vigil_consensus
+Args: `token`, `chain`.
+Returns: `verdict` (safe|low|medium|high|critical|unknown), `confidence`,
+`risk_sources`, `safe_sources`, `total_sources`, `votes[]`, `summary`.
+Aggregates 6 independent sources: GoPlus, onchain bytecode, market liquidity,
+deployer verification, community scam DB, liquidity lock. A single source caps
+the verdict at "medium" — the false-positive guard.
+
+### vigil_scan_token
+Args: `token`, `chain`.
+Returns: rugpull indicators — hidden mint, proxy pattern, tax manipulation,
+blacklist functions, with severity-tagged findings.
+
+### vigil_scan_approvals
+Args: `wallet` (0x address), `chain`.
+Returns: `approvals[]` with risk levels, `total`, `summary` counts. Flags
+unlimited allowances and risky spenders.
+
+### vigil_wallet_report
+Args: `wallet`, `chain`.
+Returns: aggregate security posture — approvals summary, scam-DB hits, top
+risks, recommendations.
+
+### vigil_monitor_wallet
+Args: `wallet`, `chain`, `lookback_blocks` (default 1000).
+Returns: `alerts[]` (new approvals, risky interactions, balance changes),
+`summary`, `recommendations`.
+
+### vigil_token_market
+Args: `token`, `chain`.
+Returns: `price_usd`, `liquidity_usd`, `volume_24h_usd`, `pair_created_at`,
+`pool_age_hours`, `liquidity_risk`.
+
+### vigil_deployer_check
+Args: `contract`, `chain`.
+Returns: `verified`, contract `name`, `deployer`, `creation_tx`, reputation
+note (via Basescan; some fields need a paid Basescan plan).
+
+### vigil_batch_scan
+Args: `tokens` (array of 0x addresses), `chain`.
+Returns: per-token `score` + `risk_level`, ranked by risk. Capped at 25 tokens.
+
+### vigil_check_scam
+Args: `token`, `chain`.
+Returns: `reported` (bool), `report_count`, report summaries from the community
+scam database.
+
+### vigil_sentinel_status
+Args: none.
+Returns: autonomous Sentinel watchlist + loop configuration (interval, severity
+threshold, lookback).
+
+---
+
+## Chains
+
+Base-first (`chainid=8453`). The scanners target Base mainnet. A small set of
+Ethereum stablecoins are kept in the verified registry so multichain wallets
+get correct labels. Unsupported chains degrade gracefully (clear note, never a
+misleading verdict).
+
+## Address validation
+
+Every address argument must be `0x` + exactly 40 hex chars. Malformed input is
+rejected with an error rather than scored — a bad address never returns a fake
+verdict.

--- a/vigil-security-scanner/references/api-reference.md
+++ b/vigil-security-scanner/references/api-reference.md
@@ -22,8 +22,9 @@ The result is returned under `.result`. Errors come back as `.error`. A few
 premium tools (scan_token, deployer_check, token_market, batch_scan,
 wallet_report, consensus) may respond with an x402 payment-required body
 (`x402Version` + `accepts`) when paid mode is enabled; core safety checks
-(safety_score, detect_honeypot, liquidity_lock, check_scam, scan_approvals,
-monitor_wallet, sentinel_status) are always free.
+(safety_score, detect_honeypot, check_tax, check_ownership, detect_clone,
+simulate_approval, liquidity_lock, check_scam, scan_approvals, monitor_wallet,
+sentinel_status) are always free.
 
 ---
 
@@ -38,6 +39,35 @@ Returns: `score` (0-100), `risk_level`, `breakdown[]`, `risk_factors[]`,
 Args: `token`, `chain`.
 Returns: `is_honeypot`, `can_buy`, `can_sell`, `buy_tax`, `sell_tax`,
 `block_reason`, `simulations[]`.
+
+### vigil_check_tax
+Args: `token`, `chain`.
+Returns: `risk` (safe|caution|high|dangerous|unknown), `buy_tax`, `sell_tax`,
+`transfer_tax` (fractions; 0.05 == 5%), `tax_modifiable`,
+`personal_tax_modifiable`, `trading_cooldown`, `cannot_buy`, `notes[]`.
+Owner-modifiable tax ("0% now, 99% later") is treated as dangerous. Missing
+data returns `unknown`, never `safe`.
+
+### vigil_check_ownership
+Args: `token`, `chain`.
+Returns: `risk` (safe|caution|high|dangerous|unknown), `owner_address`,
+`ownership_renounced`, `owner_percent`, `powers[]` (mint, pause_transfers,
+blacklist, reclaim_ownership, hidden_owner, modify_balances, selfdestruct, ...),
+`notes[]`. A renounced owner (null address) neutralizes powers; reclaimable or
+hidden ownership is dangerous. Missing data returns `unknown`.
+
+### vigil_detect_clone
+Args: `token`, `chain`.
+Returns: `risk` (safe|suspicious|dangerous|unknown), `fingerprint`,
+`clone_count`, `clones[]`, `scam_siblings[]`, `notes[]`. Fingerprints bytecode
+and flags copy-paste clones; escalates to dangerous only when a sibling is a
+reported scam. Missing data returns `unknown`.
+
+### vigil_simulate_approval
+Args: `spender` (0x), `token` (0x), `amount` (`unlimited` or numeric), `chain`.
+Returns: `risk` (safe|suspicious|dangerous), `spender_profile`, `reasons[]`,
+`recommendation`. Answers "if I approve this spender right now, what could it
+do?" before you sign.
 
 ### vigil_liquidity_lock
 Args: `token`, `chain`.

--- a/vigil-security-scanner/scripts/smoke_test.sh
+++ b/vigil-security-scanner/scripts/smoke_test.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Smoke test all VIGIL tools against the live endpoint
+ENDPOINT="https://mcp.vigil.codes/tools/call"
+USDC="0x833589fcd6edb6e08f4c7c32d4f71b54bda02913"
+WETH="0x4200000000000000000000000000000000000006"
+AERO="0x940181a94a35a4569e4529a3cdfb74e38fd98631"
+VITALIK="0xd8da6bf26964af9d7eed9e03e53415d37aa96045"
+
+call() {
+    local name="$1"
+    local args="$2"
+    local label="$3"
+    echo "── $label ──"
+    local body
+    body=$(printf '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"%s","arguments":%s}}' "$name" "$args")
+    local resp
+    resp=$(curl -sS -m 45 -X POST "$ENDPOINT" -H "Content-Type: application/json" -d "$body")
+    echo "$resp" | python3 -c "import sys,json
+try:
+    d = json.load(sys.stdin)
+    if 'result' in d:
+        print('OK')
+        print(json.dumps(d['result'], indent=2)[:700])
+    elif 'error' in d:
+        print('ERROR')
+        print(json.dumps(d['error'], indent=2)[:700])
+    elif 'x402Version' in d or 'accepts' in d:
+        accepts = (d.get('accepts') or [{}])[0]
+        price = accepts.get('maxAmountRequired', '?')
+        print('PAYMENT_REQUIRED (expected — x402 paid tool)')
+        print('  price (USDC atomic units):', price)
+        print('  resource:', accepts.get('resource', '?'))
+    else:
+        print('UNEXPECTED:', json.dumps(d)[:300])
+except Exception as e:
+    print('PARSE_FAIL:', e)
+" 2>&1
+    echo ""
+}
+
+call vigil_scan_approvals  "{\"wallet\":\"$VITALIK\",\"chain\":\"base\"}"  "1. scan_approvals (vitalik on base)"
+call vigil_scan_token      "{\"token\":\"$USDC\",\"chain\":\"base\"}"      "2. scan_token (USDC base)"
+call vigil_detect_honeypot "{\"token\":\"$USDC\",\"chain\":\"base\"}"      "3. detect_honeypot (USDC base)"
+call vigil_safety_score    "{\"contract\":\"$USDC\",\"chain\":\"base\"}"   "4a. safety_score (USDC base)"
+call vigil_safety_score    "{\"contract\":\"$WETH\",\"chain\":\"base\"}"   "4b. safety_score (WETH base)"
+call vigil_safety_score    "{\"contract\":\"$AERO\",\"chain\":\"base\"}"   "4c. safety_score (AERO base)"
+call vigil_wallet_report   "{\"wallet\":\"$VITALIK\",\"chain\":\"base\"}"  "5. wallet_report (vitalik)"
+call vigil_monitor_wallet  "{\"wallet\":\"$VITALIK\",\"chain\":\"base\",\"lookback_blocks\":500}" "6. monitor_wallet (vitalik)"


### PR DESCRIPTION
## Summary

Adds **vigil-security-scanner** — a keyless onchain security scanner for Base, exposed as an HTTP JSON-RPC API at `mcp.vigil.codes`. Lets any agent check a token or wallet **before** it signs.

## What it does

13 read-only tools:
- `vigil_safety_score` — 0-100 contract rating
- `vigil_detect_honeypot` — can you sell? buy/sell tax
- `vigil_liquidity_lock` — LP locked / burned / unlocked / unknown
- `vigil_scan_approvals` — wallet approval risk
- `vigil_check_scam`, `vigil_deployer_check`, `vigil_token_market`, `vigil_monitor_wallet`, `vigil_wallet_report`, `vigil_consensus` (6-source verdict), and more

## Why it fits

- **Read-only & autonomous-safe.** No transaction is ever signed by this skill. Revoke (write) actions are intentionally excluded.
- **Fail-safe.** Undetermined results return `unknown`, never a false `safe` — important for a security tool.
- **Complements existing scanners.** `aeon-vuln-scanner` audits code/repos; VIGIL covers onchain token/wallet security on Base. Different surface, no overlap.
- Keyless for read-only scans — no API key required to install or use.

## Testing

Tested against the live endpoint (`mcp.vigil.codes`) via `scripts/smoke_test.sh`. Health check returns 13 tools; sample calls return real verdicts (e.g. USDC → safe 92/100).

## Structure

```
vigil-security-scanner/
├── SKILL.md
├── references/  (api-reference.md, contracts.md)
└── scripts/     (smoke_test.sh)
```

Homepage: https://github.com/vigilcodes/vigil-mcp