### PR TITLE
aeon-token-pick: add optional VIGIL pre-flight security check

### DIFF
--- a/aeon-token-pick/SKILL.md
+++ b/aeon-token-pick/SKILL.md
@@ -52,6 +52,16 @@ Would tip the call: a dated catalyst on $XYZ; a specific committee date for EIGE
 - Falsifiable thesis or no pick.
 - Cite the catalyst by name and date. "Sentiment turning" is not a catalyst.
 - Crowdedness penalty — if every newsletter is recommending it, the asymmetry is gone.
+- **Pre-flight security check (Base tokens).** Before publishing a Base token pick, scan it against [VIGIL](https://github.com/vigilcodes/vigil-mcp) (`mcp.vigil.codes`, keyless). If `vigil_detect_honeypot` flags or `vigil_consensus` returns `high`/`critical`, return `NO_PICK` and surface the VIGIL evidence. Missing data (e.g. `lock_status: unknown`) is **not** treated as safe — it lowers conviction. Optional but strongly recommended: never recommend a token you haven't checked.
 - NO_PICK is a valid output. Manufactured picks burn capital.
 
-Pairs naturally with `aeon-narrative-tracker` (narrative fit), `aeon-monitor-runners` (momentum candidates), `aeon-unlock-monitor` (supply-side risk), and Bankr Submit / AgenticBets for execution.
+### Pre-flight VIGIL check (Base tokens)
+
+```bash
+curl -s -m 30 -X POST https://mcp.vigil.codes/tools/call \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call",
+       "params":{"name":"vigil_consensus","arguments":{"token":"0xTOKEN","chain":"base"}}}' | jq '.result'
+```
+
+Pairs naturally with `aeon-narrative-tracker` (narrative fit), `aeon-monitor-runners` (momentum candidates), `aeon-unlock-monitor` (supply-side risk), `vigil-security-scanner` (pre-flight rugpull/honeypot guard, see above), and Bankr Submit / AgenticBets for execution.


### PR DESCRIPTION
## Summary

Adds a **pre-flight VIGIL security check** to `aeon-token-pick` so a token pick must pass an onchain security scan before it can be published. If the scan flags a honeypot or returns high/critical risk, the skill escalates to `NO_PICK` instead.

This is **additive only** — no existing rules, sample outputs, or thesis/entry/kill/sizing/horizon mechanics are changed. The check is documented as "optional but strongly recommended" so operators who don't want the dependency can skip it.

## Why this fits

`aeon-token-pick` already has a strong discipline: *"Falsifiable thesis or no pick"* and *"NO_PICK is a valid output. Manufactured picks burn capital."* The proposed rule extends that same discipline one step earlier — *if the token would fail a basic security check, the pick is not safe to publish either*. A token-pick skill recommending a honeypot is the exact failure mode the existing skip branch is designed to prevent.

## What VIGIL adds

- 6-source consensus verdict in one call (GoPlus + onchain bytecode + market liquidity + deployer verification + community scam DB + liquidity lock)
- Honeypot detection
- Liquidity-lock status (locked/burned/unlocked/**unknown** — never reports missing data as safe)
- Free, keyless, ~2-3s response, 13 tools live at `mcp.vigil.codes`
- Submitted to the Bankr catalog as `vigil-security-scanner` (#480)

## Diff

One rule added, one code-fenced example, plus `vigil-security-scanner` listed in the existing "Pairs naturally with" line. No deletions.

## Tested

- Endpoint live: `GET /health` → `{"tools":13}`
- Example call returns the documented JSON shape against USDC on Base
- Public stats: `mcp.vigil.codes/stats`
