### PR TITLE
Add chancy skill — onchain tile-reveal game with x402 payments

### DIFF
--- a/babylonagent/chancy/SKILL.md
+++ b/babylonagent/chancy/SKILL.md
@@ -1,0 +1,252 @@
+---
+name: chancy
+description: |
+  Host and play onchain tile-reveal games on Base. Pay per action with
+  x402 — no pre-funding, no accounts, no API keys. Sign EIP-3009 USDC
+  transfers and call the endpoints directly.
+
+  Triggers: "play chancy", "host a game", "create a chancy game",
+  "list open chancy games", "join a chancy game", "play minesweeper onchain".
+emoji: 💣
+tags: [games, base, x402, usdc, onchain, mining, tiles]
+version: 1
+visibility: public
+metadata:
+  openclaw:
+    requires:
+      bins: [curl, jq]
+---
+
+# chancy
+
+Onchain minesweeper on Base L2. Pay per action with x402 — no deposit,
+no account, no API key. Every game action is a single paid HTTP call
+settled on-chain via the Coinbase CDP facilitator.
+
+**Live on Base mainnet. Real USDC. Real settlement.**
+
+## What is Chancy?
+
+A tile-reveal game. The board hides bombs and prizes. Reveal tiles to
+win USDC. Hit 3 bombs → game over. Each tile costs a small amount of
+USDC (paid via x402), and the prize pot grows with every safe reveal.
+
+**Game modes:**
+
+| Mode | Board | Bombs | Prize |
+|---|---|---|---|
+| Easy | 5×5 (25 tiles) | 3 | $5.00 |
+| Normal | 7×7 (49 tiles) | 2 | $10.00 |
+| Hardcore | 10×10 (100 tiles) | 1 | $20.00 |
+
+## Base URL
+
+```
+https://chancy.cash
+```
+
+## Payment — x402 (EIP-3009 USDC)
+
+All paid endpoints use the standard x402 flow:
+
+1. Call the endpoint without payment → get `402` + `PAYMENT-REQUIRED` header
+2. Decode the base64 header → read `accepts[]` for payment details
+3. Sign an EIP-3009 `TransferWithAuthorization` for the USDC amount
+4. Retry the request with `X-Payment: <base64-encoded payment payload>`
+5. Facilitator verifies → settles on-chain → game action executes
+
+**Bankr wallet layer handles signing automatically.** When calling via
+the Bankr agent, the wallet layer intercepts the 402, signs the
+appropriate primitive, and retries — no manual signing code needed.
+
+If signing manually (non-Bankr), the EIP-712 typed data is:
+
+```json
+{
+  "domain": {
+    "name": "USD Coin",
+    "version": "2",
+    "chainId": 8453,
+    "verifyingContract": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+  },
+  "types": {
+    "TransferWithAuthorization": [
+      { "name": "from", "type": "address" },
+      { "name": "to", "type": "address" },
+      { "name": "value", "type": "uint256" },
+      { "name": "validAfter", "type": "uint256" },
+      { "name": "validBefore", "type": "uint256" },
+      { "name": "nonce", "type": "bytes32" }
+    ]
+  },
+  "primaryType": "TransferWithAuthorization",
+  "message": {
+    "from": "<your_wallet>",
+    "to": "0xbcd9b0ba388608598f9eaab43bfc7ba44324f860",
+    "value": "<amount_from_402_envelope>",
+    "validAfter": 0,
+    "validBefore": "<now + 1 hour>",
+    "nonce": "<random_bytes32>"
+  }
+}
+```
+
+## Endpoints
+
+### Free endpoints (no payment)
+
+```bash
+# List open games — see what's available to join
+curl -sS https://chancy.cash/v2/x402/sessions
+```
+
+```bash
+# Check a wallet's credits (winnings)
+curl -sS https://chancy.cash/v2/x402/credits/<wallet_address>
+```
+
+### Paid endpoints (x402)
+
+#### Create a game (host)
+
+```bash
+curl -sS -X POST https://chancy.cash/v2/x402/sessions/create \
+  -H "Content-Type: application/json" \
+  -d '{"host":"<your_wallet>","mode":"Easy","prizePot":"5000000"}'
+```
+
+| Param | Type | Values |
+|---|---|---|
+| `host` | address | Your wallet address |
+| `mode` | string | `"Easy"`, `"Normal"`, `"Hardcore"` |
+| `prizePot` | string | USDC amount in units (6 decimals). Easy=5000000 ($5), Normal=10000000 ($10), Hardcore=20000000 ($20) |
+
+**Cost:** `prizePot` amount in USDC (e.g., $5.00 for Easy).
+
+#### Join a game
+
+```bash
+curl -sS -X POST https://chancy.cash/v2/x402/sessions/<id>/join \
+  -H "Content-Type: application/json" \
+  -d '{"player":"<your_wallet>"}'
+```
+
+**Cost:** $0.05 (50000 units USDC).
+
+#### Reveal entropy (fairness seed — free)
+
+```bash
+curl -sS -X POST https://chancy.cash/v2/x402/sessions/<id>/reveal \
+  -H "Content-Type: application/json" \
+  -d '{"player":"<your_wallet>"}'
+```
+
+Must be called once before clicking tiles. Commits your fairness seed.
+
+#### Click a tile (reveal)
+
+```bash
+curl -sS -X POST https://chancy.cash/v2/x402/sessions/<id>/click \
+  -H "Content-Type: application/json" \
+  -d '{"player":"<your_wallet>","tile":12}'
+```
+
+| Param | Type | Description |
+|---|---|---|
+| `tile` | number | Tile index (0 to board_size - 1) |
+
+**Cost:** Dynamic — per-tile price based on mode. Read from the 402 envelope.
+
+**Response:** `{ "result": "safe", "prize": "10000" }` or `{ "result": "bomb", "bombCount": 1 }`
+
+#### Quit a game (cash out winnings — free)
+
+```bash
+curl -sS -X POST https://chancy.cash/v2/x402/sessions/<id>/quit \
+  -H "Content-Type: application/json" \
+  -d '{"player":"<your_wallet>"}'
+```
+
+Returns the player's accumulated winnings as credits.
+
+## Full game flow
+
+```bash
+# 1. Check available games
+curl -sS https://chancy.cash/v2/x402/sessions
+
+# 2. Create a game (host pays prize pot)
+curl -sS -X POST https://chancy.cash/v2/x402/sessions/create \
+  -H "Content-Type: application/json" \
+  -d '{"host":"0xYOUR_WALLET","mode":"Easy","prizePot":"5000000"}'
+# → { "sessionId": 42, "mode": "Easy", "board": 25, "bombs": 3 }
+
+# 3. Join the game (player pays entrance)
+curl -sS -X POST https://chancy.cash/v2/x402/sessions/42/join \
+  -H "Content-Type: application/json" \
+  -d '{"player":"0xYOUR_WALLET"}'
+
+# 4. Reveal entropy seed
+curl -sS -X POST https://chancy.cash/v2/x402/sessions/42/reveal \
+  -H "Content-Type: application/json" \
+  -d '{"player":"0xYOUR_WALLET"}'
+
+# 5. Click tiles (pay per click via x402)
+curl -sS -X POST https://chancy.cash/v2/x402/sessions/42/click \
+  -H "Content-Type: application/json" \
+  -d '{"player":"0xYOUR_WALLET","tile":0}'
+
+curl -sS -X POST https://chancy.cash/v2/x402/sessions/42/click \
+  -H "Content-Type: application/json" \
+  -d '{"player":"0xYOUR_WALLET","tile":1}'
+
+# ... continue clicking safe tiles until you have enough or quit
+
+# 6. Quit and cash out
+curl -sS -X POST https://chancy.cash/v2/x402/sessions/42/quit \
+  -H "Content-Type: application/json" \
+  -d '{"player":"0xYOUR_WALLET"}'
+```
+
+## Strategy
+
+- **Easy mode (25 tiles, 3 bombs):** 22 safe tiles. Bomb probability
+  starts at 12% and drops with each safe reveal. Expected value is
+  positive if you reveal 5+ tiles per game.
+- **Quit early:** Each safe tile adds to your winnings. Quit before
+  hitting 3 bombs to lock in credits.
+- **Bomb counter:** Each bomb hit shows `bombCount` (1, 2, or 3). At
+  3 bombs the game ends and you lose accumulated winnings from that
+  session.
+
+## Contract Addresses (Base Mainnet)
+
+| Contract | Address |
+|---|---|
+| Vault | `0xbE81cE9d9909A31184D1878075f60bbbf8571612` |
+| USDC | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` |
+| Randomness | `0x705dF0f1667Ed82bB25E5a51273a9Ea6dE5C6e96` |
+| Pyth Entropy | `0x6E7D74FA7d5c90FEF9F0512987605a6d546181Bb` |
+
+## Natural Language Commands
+
+When a user says any of these, load this skill and act:
+
+- "host a $5 easy game" → create Easy mode, $5 pot
+- "host a hardcore game" → create Hardcore mode, $20 pot
+- "play chancy" → list games, join one, play autonomously
+- "list open games" → GET /v2/x402/sessions
+- "join game #42" → POST join endpoint
+- "what's my chancy balance" → GET credits endpoint
+
+## Rules
+
+- 3 bombs = game over, lose session winnings
+- Quit anytime to keep what you've earned
+- Every tile click is a real on-chain USDC payment
+- Provably fair via Pyth entropy commit-reveal
+
+## Built by
+
+Babylon Agent — autonomous onchain infrastructure on Base.
+GitHub: github.com/babylonagent/chancy

--- a/babylonagent/chancy/references/api-reference.md
+++ b/babylonagent/chancy/references/api-reference.md
@@ -1,0 +1,218 @@
+# Chancy API Reference
+
+Base URL: `https://chancy.cash`
+
+## x402 Endpoints (pay-per-action)
+
+These endpoints require x402 payment. See `x402-payment.md` for the
+full payment flow.
+
+### POST /v2/x402/sessions/create
+
+Create a new game session. Host funds the prize pot.
+
+**Request:**
+```json
+{
+  "host": "0x1234...5678",
+  "mode": "Easy",
+  "prizePot": "5000000"
+}
+```
+
+**Response (200):**
+```json
+{
+  "sessionId": 42,
+  "mode": "Easy",
+  "board": 25,
+  "bombs": 3,
+  "host": "0x1234...5678",
+  "status": "open"
+}
+```
+
+**Cost:** Value of `prizePot` in USDC.
+
+---
+
+### POST /v2/x402/sessions/:id/join
+
+Join an open game session as a player. Pays entrance fee.
+
+**Request:**
+```json
+{
+  "player": "0x1234...5678"
+}
+```
+
+**Response (200):**
+```json
+{
+  "sessionId": 42,
+  "mode": "Easy",
+  "board": 25,
+  "bombs": 3,
+  "status": "active"
+}
+```
+
+**Cost:** $0.05 (50000 USDC units).
+
+---
+
+### POST /v2/x402/sessions/:id/reveal
+
+Reveal fairness entropy seed. Free — must be called once before clicking tiles.
+
+**Request:**
+```json
+{
+  "player": "0x1234...5678"
+}
+```
+
+**Response (200):**
+```json
+{
+  "sessionId": 42,
+  "revealed": true
+}
+```
+
+---
+
+### POST /v2/x402/sessions/:id/click
+
+Reveal a tile. Each click costs USDC via x402.
+
+**Request:**
+```json
+{
+  "player": "0x1234...5678",
+  "tile": 7
+}
+```
+
+**Response — safe (200):**
+```json
+{
+  "result": "safe",
+  "tile": 7,
+  "prize": "10000",
+  "bombCount": 0,
+  "tilesRevealed": 1,
+  "credits": "10000"
+}
+```
+
+**Response — bomb (200):**
+```json
+{
+  "result": "bomb",
+  "tile": 7,
+  "bombCount": 1,
+  "message": "Bomb hit! 2 lives remaining."
+}
+```
+
+**Response — game over (200):**
+```json
+{
+  "result": "gameover",
+  "bombCount": 3,
+  "message": "Game over. 3 bombs hit.",
+  "creditsLost": "50000"
+}
+```
+
+**Cost:** Mode-dependent (read from 402 envelope).
+
+---
+
+### POST /v2/x402/sessions/:id/quit
+
+Quit the game and cash out accumulated winnings to credits.
+
+**Request:**
+```json
+{
+  "player": "0x1234...5678"
+}
+```
+
+**Response (200):**
+```json
+{
+  "sessionId": 42,
+  "status": "closed",
+  "creditsEarned": "30000",
+  "message": "Cashed out $0.03"
+}
+```
+
+---
+
+## Free Endpoints
+
+### GET /v2/x402/sessions
+
+List open game sessions.
+
+**Response:**
+```json
+[
+  {
+    "sessionId": 42,
+    "mode": "Easy",
+    "host": "0xabcd...1234",
+    "prizePot": "5000000",
+    "status": "open",
+    "createdAt": "2026-06-25T14:00:00Z"
+  }
+]
+```
+
+---
+
+### GET /v2/x402/credits/:wallet
+
+Check credits (winnings) for a wallet address.
+
+**Response:**
+```json
+{
+  "wallet": "0x1234...5678",
+  "credits": "30000",
+  "creditsUSD": "0.03"
+}
+```
+
+---
+
+## Game Modes
+
+| Mode | Board | Bombs | Prize Pot | Tile Cost |
+|---|---|---|---|---|
+| Easy | 5×5 (25 tiles) | 3 | $5.00 (5000000) | $0.05 |
+| Normal | 7×7 (49 tiles) | 2 | $10.00 (10000000) | $0.05 |
+| Hardcore | 10×10 (100 tiles) |1 | $20.00 (20000000) | $0.10 |
+
+## Commit-Reveal Fairness
+
+Chancy uses Pyth Entropy for provably fair bomb placement:
+
+1. When a session starts, the host and server each generate a secret
+2. Both secrets are committed on-chain (hash committed)
+3. When the player reveals entropy, the combined seeds are revealed
+4. Bomb positions are deterministic from the combined seed
+5. Neither host nor server can manipulate placement alone
+
+This means the game is provably fair — no party can front-run or
+manipulate bomb positions.
+
+## Rate Limits
+
+- Free endpoints: 60 requests/minute
+- Paid endpoints: No rate limit (payment is the rate limiter)

--- a/babylonagent/chancy/references/x402-payment.md
+++ b/babylonagent/chancy/references/x402-payment.md
@@ -1,0 +1,174 @@
+# Chancy x402 Payment Flow
+
+## The 402 Envelope
+
+When you call a paid endpoint without a valid payment, Chancy returns:
+
+```http
+HTTP/1.1 402 Payment Required
+PAYMENT-REQUIRED: <base64-encoded JSON>
+Content-Type: application/json
+```
+
+Decoded, the `PAYMENT-REQUIRED` header looks like:
+
+```json
+{
+  "x402Version": 2,
+  "error": "Payment required",
+  "resource": {
+    "url": "https://chancy.cash/v2/x402/sessions/create",
+    "description": "Chancy — create game session (host funds prize pot)",
+    "mimeType": "application/json"
+  },
+  "accepts": [
+    {
+      "scheme": "exact",
+      "network": "eip155:8453",
+      "amount": "5000000",
+      "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+      "payTo": "0xbcd9b0ba388608598f9eaab43bfc7ba44324f860",
+      "maxTimeoutSeconds": 300,
+      "extra": {
+        "name": "USD Coin",
+        "version": "2"
+      }
+    }
+  ]
+}
+```
+
+### Reading the amount
+
+The `amount` field is in **USDC units (6 decimals)**. So `5000000` = $5.00.
+
+### Dynamic pricing
+
+For tile clicks, the amount changes per call based on game mode:
+
+| Mode | Per-tile cost |
+|---|---|
+| Easy | $0.05 (50000 units) |
+| Normal | $0.05 (50000 units) |
+| Hardcore | $0.10 (100000 units) |
+
+**Always read the amount from the 402 envelope** — never hard-code it.
+
+## Signing EIP-3009 TransferWithAuthorization
+
+USDC on Base supports gasless transfers via EIP-3009. The x402 flow uses
+the `TransferWithAuthorization` function.
+
+### EIP-712 typed data
+
+```json
+{
+  "domain": {
+    "name": "USD Coin",
+    "version": "2",
+    "chainId": 8453,
+    "verifyingContract": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"
+  },
+  "types": {
+    "TransferWithAuthorization": [
+      { "name": "from", "type": "address" },
+      { "name": "to", "type": "address" },
+      { "name": "value", "type": "uint256" },
+      { "name": "validAfter", "type": "uint256" },
+      { "name": "validBefore", "type": "uint256" },
+      { "name": "nonce", "type": "bytes32" }
+    ]
+  },
+  "primaryType": "TransferWithAuthorization",
+  "message": {
+    "from": "<payer_wallet>",
+    "to": "0xbcd9b0ba388608598f9eaab43bfc7ba44324f860",
+    "value": "<amount_from_402>",
+    "validAfter": 0,
+    "validBefore": "<current_time + 3600>",
+    "nonce": "<0x + 64 random hex chars>"
+  }
+}
+```
+
+### Bankr wallet signing
+
+On Bankr, the wallet layer handles this automatically. The agent calls
+the endpoint, the 402 is intercepted, and the retry happens with the
+signed payment. No manual EIP-712 code needed.
+
+For non-Bankr signing (e.g., viem):
+
+```javascript
+import { signTypedData } from 'viem/accounts';
+
+const signature = await signTypedData(client, {
+  domain: {
+    name: 'USD Coin',
+    version: '2',
+    chainId: 8453,
+    verifyingContract: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+  },
+  types: {
+    TransferWithAuthorization: [
+      { name: 'from', type: 'address' },
+      { name: 'to', type: 'address' },
+      { name: 'value', type: 'uint256' },
+      { name: 'validAfter', type: 'uint256' },
+      { name: 'validBefore', type: 'uint256' },
+      { name: 'nonce', type: 'bytes32' },
+    ],
+  },
+  primaryType: 'TransferWithAuthorization',
+  message: {
+    from: payerAddress,
+    to: '0xbcd9b0ba388608598f9eaab43bfc7ba44324f860',
+    value: amount,
+    validAfter: 0,
+    validBefore: Math.floor(Date.now() / 1000) + 3600,
+    nonce: randomNonce,
+  },
+});
+```
+
+## Building the X-Payment header
+
+The retry request includes an `X-Payment` header containing the signed
+payment payload as base64-encoded JSON:
+
+```json
+{
+  "signature": "0x...",
+  "from": "<payer_wallet>",
+  "to": "0xbcd9b0ba388608598f9eaab43bfc7ba44324f860",
+  "value": "5000000",
+  "validAfter": "0",
+  "validBefore": "1719300000",
+  "nonce": "0x...",
+  "authorizer": "<payer_wallet>"
+}
+```
+
+Base64-encode this JSON and pass as the `X-Payment` header value.
+
+## Settlement verification
+
+After a successful 200 response, the payment has been (or is being)
+settled on-chain via the Coinbase CDP facilitator. You can verify:
+
+```bash
+# Check the payer's USDC balance decreased
+# Check the payTo address received funds
+# Both happen via standard ERC-20 Transfer events on Base
+```
+
+## Error handling
+
+| HTTP Status | Meaning | Action |
+|---|---|---|
+| 200 | Success | Parse response body |
+| 402 | Payment required/invalid | Re-read envelope, re-sign, retry |
+| 403 | Forbidden | Wrong wallet for session |
+| 404 | Session not found | Session doesn't exist or expired |
+| 429 | Rate limited | Honor Retry-After header |
+| 502 | Facilitator unreachable | Back off and retry |


### PR DESCRIPTION
## Chancy — Onchain Minesweeper with x402 Pay-Per-Action

Chancy is a provably-fair tile-reveal game on Base L2. Players pay per action via x402 — no pre-funding, no accounts, no API keys. Every tile click is a real on-chain USDC payment settled by the Coinbase CDP facilitator.

### What it does
- **Host games:** Create Easy ($5), Normal ($10), or Hardcore ($20) games
- **Play games:** Join open games, click tiles, win USDC
- **Pay per action:** x402 flow with EIP-3009 USDC TransferWithAuthorization
- **Provably fair:** Pyth entropy commit-reveal for bomb placement

### Endpoints
| Endpoint | Cost | Description |
|---|---|---|
| `GET /v2/x402/sessions` | Free | List open games |
| `POST /v2/x402/sessions/create` | Prize pot | Host a new game |
| `POST /v2/x402/sessions/:id/join` | $0.05 | Join a game |
| `POST /v2/x402/sessions/:id/reveal` | Free | Reveal fairness seed |
| `POST /v2/x402/sessions/:id/click` | $0.05-$0.10 | Reveal a tile |
| `POST /v2/x402/sessions/:id/quit` | Free | Cash out winnings |

### Install command
```
install the chancy skill from https://github.com/babylonagent/chancy/tree/main/skills/bankr
```

### Verification
- Live at [chancy.cash](https://chancy.cash) on Base mainnet
- x402 endpoints verified: returns proper 402 + PAYMENT-REQUIRED headers
- Coinbase CDP facilitator integration confirmed (mainnet, eip155:8453)
- Smart contract vault: `0xbE81cE9d9909A31184D1878075f60bbbf8571612`

### Skill structure
```
babylonagent/
└── chancy/
    ├── SKILL.md
    └── references/
        ├── api-reference.md
        └── x402-payment.md
```

Built by [Babylon Agent](https://github.com/babylonagent) — autonomous onchain infrastructure on Base.