### PR TITLE
Add CODEOWNERS for maintainer review of config and Bankr-owned files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,20 +1,10 @@
 # Claude Code configuration: settings.json applies to anyone who opens this
 # repo with Claude Code, so changes here require maintainer review.
-/.claude/ @sidrisov @igoryuzo @saltoriousSIG
+/.claude/ @igoryuzo @saltoriousSIG @sidrisov
 
-# Protect repo automation and this file itself.
-/.github/ @sidrisov @igoryuzo @saltoriousSIG
+# Bankr-official skill: agent-facing instructions maintained by the team.
+/bankr/ @igoryuzo @saltoriousSIG
 
-# Bankr-official skills: agent-facing instructions maintained by the team.
-# An unreviewed edit here reaches every agent using the official skills.
-# (bankr-communities is community-owned and intentionally not listed.)
-/bankr/ @sidrisov @igoryuzo @saltoriousSIG
-/signals/ @sidrisov @igoryuzo @saltoriousSIG
-/bankr-shopify/ @sidrisov @igoryuzo @saltoriousSIG
-/bankr-token-scam-analysis/ @sidrisov @igoryuzo @saltoriousSIG
-/bankr-twitter-agent/ @sidrisov @igoryuzo @saltoriousSIG
-
-# Root marketplace files. Community skill PRs add their README row, so once
-# code-owner review is enforced those PRs need an owner approval to merge.
-/README.md @sidrisov @igoryuzo @saltoriousSIG
-/.gitignore @sidrisov @igoryuzo @saltoriousSIG
+# Root marketplace files.
+/README.md @igoryuzo @saltoriousSIG
+/.gitignore @igoryuzo @saltoriousSIG @sidrisov

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,17 @@
 
 # Protect repo automation and this file itself.
 /.github/ @sidrisov @igoryuzo @saltoriousSIG
+
+# Bankr-official skills: agent-facing instructions maintained by the team.
+# An unreviewed edit here reaches every agent using the official skills.
+# (bankr-communities is community-owned and intentionally not listed.)
+/bankr/ @sidrisov @igoryuzo @saltoriousSIG
+/signals/ @sidrisov @igoryuzo @saltoriousSIG
+/bankr-shopify/ @sidrisov @igoryuzo @saltoriousSIG
+/bankr-token-scam-analysis/ @sidrisov @igoryuzo @saltoriousSIG
+/bankr-twitter-agent/ @sidrisov @igoryuzo @saltoriousSIG
+
+# Root marketplace files. Community skill PRs add their README row, so once
+# code-owner review is enforced those PRs need an owner approval to merge.
+/README.md @sidrisov @igoryuzo @saltoriousSIG
+/.gitignore @sidrisov @igoryuzo @saltoriousSIG

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Claude Code configuration: settings.json applies to anyone who opens this
+# repo with Claude Code, so changes here require maintainer review.
+/.claude/ @sidrisov @igoryuzo @saltoriousSIG
+
+# Protect repo automation and this file itself.
+/.github/ @sidrisov @igoryuzo @saltoriousSIG


### PR DESCRIPTION
## Summary
Adds `.github/CODEOWNERS` so changes to repo configuration and Bankr-owned files require maintainer review:

| Path | Owners |
|------|--------|
| `/.claude/` | @igoryuzo @saltoriousSIG @sidrisov |
| `/bankr/` | @igoryuzo @saltoriousSIG |
| `/README.md` | @igoryuzo @saltoriousSIG |
| `/.gitignore` | @igoryuzo @saltoriousSIG |

## Why
- `.claude/settings.json` (added in #541) configures Claude Code for anyone who opens this repo — a community PR quietly editing it should not merge unreviewed.
- `bankr/` is the official Bankr skill: agent-facing instructions where an unreviewed edit reaches every agent using the skill.
- `README.md` and `.gitignore` are root marketplace files maintained by the team.

## Note for admins
CODEOWNERS only enforces review once **Require review from Code Owners** is enabled in branch protection for `main`. Community skill PRs that add their README row will then need an owner approval to merge.

---
_Generated by [Claude Code](https://claude.ai/code/session_018c7sx3Lzd1hpXsWvtj291h)_