### PR TITLE
Add thor-exchange skill — buy/sell Thor Exchange tokens on Robinhood Chain

### DIFF
--- a/thor-exchange/SKILL.md
+++ b/thor-exchange/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: thor-exchange
+description: Buy and sell Thor Exchange tokens on Robinhood Chain (chainId 4663). Use whenever the user wants to buy, sell, or price a Thor Exchange / Thor token — including pump.fun-style bonding-curve tokens that a normal DEX swap CANNOT trade. If a swap fails with "no liquidity" / "no pool" for a token on Robinhood Chain, use THIS skill instead. Trades the bonding curve directly (pre-graduation) or the Thor V3 pool (post-graduation).
+---
+
+# Thor Exchange
+
+Thor Exchange tokens on **Robinhood Chain (chainId 4663)** are **bonding-curve
+tokens**, not standard DEX-pool tokens. A normal swap/aggregator will report
+"zero pool liquidity / no market" and fail — because the liquidity lives inside
+a bonding-curve contract, not a Uniswap-style pool.
+
+**When the user asks to buy/sell a Thor token, do NOT use the swap aggregator.**
+Make direct contract calls as described below, then submit from the user's wallet.
+
+All addresses are on Robinhood Chain (chainId **4663**). Token amounts are 18
+decimals; ETH values are in wei.
+
+## Key contracts
+
+| Purpose | Address |
+|---|---|
+| LaunchpadFactory (token → curve lookup) | `0x7A5f1e159E441c5D769b903643E23E5e13967CDc` |
+| SwapRouter (graduated tokens only) | `0x2754d2E19c6283617206d4dAD35A70061065A206` |
+| WETH | `0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73` |
+
+## Step 1 — resolve the token (read calls)
+
+Given the token address the user names:
+
+1. `LaunchpadFactory.isThorToken(token) -> bool`. If false, it's not a Thor
+   token — fall back to a normal swap.
+2. `LaunchpadFactory.bondingCurveOf(token) -> curve` (the curve address).
+3. `curve.graduated() -> bool`.
+
+## Step 2 — route
+
+### A) NOT graduated → trade the bonding curve
+
+Read `curve.virtualEthReserve()` and `curve.virtualTokenReserve()` (both uint256)
+to size the trade and set slippage. The curve is constant-product `x*y=k` with a
+**1% fee on the ETH side**.
+
+**BUY (ETH → token):** call `curve.buy(uint256 minTokensOut)` — **payable**, send
+the user's ETH as `value`.
+- Estimate tokens out: `k = vEth*vTok`; `ethAfterFee = ethIn*99/100`;
+  `newVEth = vEth + ethAfterFee`; `newVTok = ceil(k / newVEth)`;
+  `tokensOut = vTok - newVTok`.
+- Set `minTokensOut = tokensOut * 98 / 100` (≈2% slippage).
+
+**SELL (token → ETH):**
+1. First `token.approve(curve, tokensIn)` (or a large allowance).
+2. Then `curve.sell(uint256 tokensIn, uint256 minEthOut)`.
+- Estimate ETH out: `newVTok = vTok + tokensIn`; `newVEth = ceil(k / newVTok)`;
+  `ethGross = vEth - newVEth`; `ethOut = ethGross * 99/100`.
+- Set `minEthOut = ethOut * 98 / 100`.
+
+### B) Graduated → trade the Thor V3 pool
+
+A real V3 pool exists (0.30% fee tier), so a normal swap may work. To be explicit,
+use `SwapRouter.exactInputSingle` with `fee = 3000`:
+- **BUY:** `tokenIn = WETH`, `tokenOut = token`, `recipient = user`, payable with
+  `value = amountIn`; set `amountOutMinimum` ≈ 2% below a quote.
+- **SELL:** first `token.approve(SwapRouter, amountIn)`, then `exactInputSingle`
+  with `tokenIn = token`, `tokenOut = WETH`; unwrap WETH to ETH for the user.
+
+## Step 3 — confirm & submit
+
+Show the user the estimated output and the slippage floor, then submit the
+transaction on chainId 4663 from their wallet.
+
+## Function signatures
+
+```
+LaunchpadFactory.isThorToken(address) -> bool
+LaunchpadFactory.bondingCurveOf(address) -> address
+BondingCurve.graduated() -> bool
+BondingCurve.virtualEthReserve() -> uint256
+BondingCurve.virtualTokenReserve() -> uint256
+BondingCurve.buy(uint256 minTokensOut) payable -> uint256
+BondingCurve.sell(uint256 tokensIn, uint256 minEthOut) -> uint256
+ERC20.approve(address spender, uint256 amount) -> bool
+ERC20.balanceOf(address) -> uint256
+SwapRouter.exactInputSingle((address tokenIn,address tokenOut,uint24 fee,address recipient,uint256 deadline,uint256 amountIn,uint256 amountOutMinimum,uint160 sqrtPriceLimitX96)) payable -> uint256
+```
+
+## Example
+
+User: *"buy 0.001 ETH of HOOD (0x5e798Dd12eDbcD5566cd3772aE5CE682e700750e) on Thor Exchange"*
+
+1. `bondingCurveOf(0x5e79…750e)` → curve `0x87D3028081fB018608a8634Ed5c052a3270fb3B0`.
+2. `graduated()` → false → use the curve.
+3. Read reserves, estimate ~594,000 HOOD, set `minTokensOut` ≈ 2% below.
+4. Call `buy(minTokensOut)` on the curve, `value = 0.001 ETH`, chainId 4663.
+5. Confirm and submit. (Verified working: tx `0xc0e7848b…830be1b`.)

--- a/thor-exchange/catalog.json
+++ b/thor-exchange/catalog.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": 1,
+  "slug": "thor-exchange",
+  "provider": "Thor Exchange",
+  "providerUrl": "https://thorexchange.xyz",
+  "logo": "logo.svg",
+  "demo": {
+    "title": "thor-trade.sh",
+    "language": "bash",
+    "code": "# Quote a buy (read-only, no key): 0.01 ETH into a Thor token\npython3 scripts/thor-quote.py buy \\\n  0x5e798Dd12eDbcD5566cd3772aE5CE682e700750e 0.01\n\n# Execute: buy 0.05 ETH of the token (2% slippage default)\npython3 scripts/thor-trade.py buy \\\n  0x5e798Dd12eDbcD5566cd3772aE5CE682e700750e 0.05\n\n# Execute: sell 2,000,000 tokens with a tighter 1% slippage\npython3 scripts/thor-trade.py sell \\\n  0x5e798Dd12eDbcD5566cd3772aE5CE682e700750e 2000000 100"
+  },
+  "setup": [
+    "Set `BANKR_API_KEY` env var (or `~/.bankr/config.json`) — Thor Exchange uses Bankr to submit transactions",
+    "Requires Bankr wallet support for Robinhood Chain (chainId 4663); quotes work without it",
+    "Install Python 3 and the scripts from the thor-exchange skill directory",
+    "Run thor-quote.py to preview output before trading",
+    "Run thor-trade.py buy|sell — outputs a tx hash and Blockscout link"
+  ],
+  "install": {
+    "type": "bankr",
+    "repoPath": "thor-exchange",
+    "command": "install the thor-exchange skill from https://github.com/BankrBot/skills/tree/main/thor-exchange"
+  }
+}

--- a/thor-exchange/logo.svg
+++ b/thor-exchange/logo.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="Thor Exchange">
+  <defs>
+    <linearGradient id="t" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#059669"/>
+      <stop offset="1" stop-color="#022c22"/>
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="14" fill="url(#t)"/>
+  <path d="M35 9 L20 35 h9 l-4 20 19-28 h-9 l5-18 Z" fill="#d1fae5"/>
+</svg>

--- a/thor-exchange/references/contracts-and-chain.md
+++ b/thor-exchange/references/contracts-and-chain.md
@@ -1,0 +1,64 @@
+# Thor Exchange — Contracts & Chain Reference
+
+All addresses are deployed and **verified on Blockscout**. This skill only ever
+reads public getters and builds standard calldata against these contracts.
+
+## Chain
+
+| Field | Value |
+|-------|-------|
+| Network | Robinhood Chain |
+| Chain ID | `4663` |
+| RPC (public) | `https://rpc.mainnet.chain.robinhood.com` |
+| Explorer | `https://robinhoodchain.blockscout.com` |
+| Native/WETH | `0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73` |
+
+Override the RPC with the `THOR_RPC_URL` env var if needed.
+
+## Contracts
+
+| Contract | Address | Used for |
+|----------|---------|----------|
+| LaunchpadFactory | `0x7A5f1e159E441c5D769b903643E23E5e13967CDc` | resolve token → bonding curve; validate Thor token |
+| SwapRouter (Thor V3) | `0x2754d2E19c6283617206d4dAD35A70061065A206` | graduated-token swaps |
+| QuoterV2 (Thor V3) | `0x8fA3aeC8E5D5F4B63c3b1F625ddBA2a7E9E713D0` | graduated-token quotes |
+| BondingCurve | per-token (from `bondingCurveOf`) | pre-graduation buy/sell |
+
+The V3 graduation pool uses the **0.30% fee tier** (`3000`).
+
+## Functions this skill calls
+
+**Reads (RPC `eth_call`):**
+
+```
+LaunchpadFactory.isThorToken(address) -> bool
+LaunchpadFactory.bondingCurveOf(address) -> address
+BondingCurve.graduated() -> bool
+BondingCurve.virtualEthReserve() -> uint256
+BondingCurve.virtualTokenReserve() -> uint256
+ERC20.symbol() -> string
+ERC20.decimals() -> uint8
+ERC20.allowance(address owner, address spender) -> uint256
+QuoterV2.quoteExactInputSingle((address tokenIn,address tokenOut,uint256 amountIn,uint24 fee,uint160 sqrtPriceLimitX96))
+        -> (uint256 amountOut, uint160, uint32, uint256)
+```
+
+**Writes (submitted via the Bankr Submit API):**
+
+```
+BondingCurve.buy(uint256 minTokensOut) payable            # pre-grad buy
+BondingCurve.sell(uint256 tokensIn, uint256 minEthOut)    # pre-grad sell
+ERC20.approve(address spender, uint256 amount)            # sells only
+SwapRouter.exactInputSingle((tokenIn,tokenOut,fee,recipient,deadline,amountIn,amountOutMinimum,sqrtPriceLimitX96)) payable
+SwapRouter.multicall(bytes[])                             # graduated sell: swap→WETH + unwrapWETH9
+SwapRouter.unwrapWETH9(uint256 amountMinimum, address recipient)
+```
+
+Selectors are hardcoded in `scripts/thorlib.py` and were validated against the
+live contracts; the V3 `exactInputSingle` and `multicall` calldata were checked
+byte-for-byte against `cast` (Foundry).
+
+## Resources
+
+- App: https://thorexchange.xyz
+- Docs: https://docs.thorexchange.xyz

--- a/thor-exchange/references/how-it-works.md
+++ b/thor-exchange/references/how-it-works.md
@@ -1,0 +1,71 @@
+# How the Thor Exchange skill works
+
+## Lifecycle → routing
+
+A Thor token lives in one of two states, and the skill routes to the right venue
+automatically by reading the chain:
+
+1. **On the bonding curve** (`graduated() == false`)
+   - Buy: send ETH to `BondingCurve.buy{value}(minTokensOut)`.
+   - Sell: `approve` the curve, then `BondingCurve.sell(tokensIn, minEthOut)`.
+   - Quotes use the live `virtualEthReserve` / `virtualTokenReserve` with the
+     public 1% ETH-side fee (constant-product `x*y=k`).
+
+2. **Graduated to a Thor V3 pool** (`graduated() == true`)
+   - Buy: `SwapRouter.exactInputSingle(WETH → token)` with `value = amountIn`
+     (the router wraps the ETH).
+   - Sell: `approve` the router, then `multicall([exactInputSingle(token → WETH,
+     recipient = router), unwrapWETH9(minEthOut, wallet)])` so you receive native ETH.
+   - Quotes use `QuoterV2.quoteExactInputSingle`.
+
+## Execution path (Bankr Wallet Submit API)
+
+Every write goes through Bankr's raw-transaction submit endpoint:
+
+```
+POST https://api.bankr.bot/wallet/submit
+X-API-Key: <bankr key>          # key needs Wallet API enabled, non-read-only
+{
+  "transaction": { "to": <contract>, "chainId": 4663, "value": <wei>, "data": <calldata> },
+  "description": "<human summary>",
+  "waitForConfirmation": true
+}
+```
+
+`chainId: 4663` (Robinhood Chain) is an officially documented value for this
+endpoint. The wallet address comes from `GET /wallet/me`. No private keys are
+handled by the skill — Bankr signs and broadcasts from the user's Bankr wallet.
+
+**Why this works where the chat "buy" flow fails:** `/wallet/submit` *bypasses the
+AI agent* and its swap aggregator. The natural-language "buy <token>" flow routes
+through the aggregator, which flags a pre-graduation curve token as "zero pool
+liquidity / no market" (there is no DEX pool — liquidity lives in the curve
+contract). Submitting our pre-built `BondingCurve.buy` calldata sidesteps that
+check entirely.
+
+> If the Bankr key has an **allowed-recipients allowlist**, `/wallet/submit`
+> rejects *all* raw submissions. In that case add the Thor contracts to the
+> allowlist, or route via `POST /agent/prompt` instead.
+
+## Chain support
+
+Bankr **already supports Robinhood Chain** — it is a first-class EVM chain in
+Bankr's live chains config (`GET https://api.bankr.bot/chains` returns a
+`"robinhood"` entry pointing at `robinhoodchain.blockscout.com`, our chain).
+
+So the **read/quote path works today** (public RPC), and the **execute path**
+targets a chain Bankr's wallet already knows. The only thing left to confirm is
+a real end-to-end submit: with a Bankr API key, run one small `thor-trade.py buy`
+and verify `/agent/submit` accepts the `chainId: 4663` transaction and Bankr
+signs + broadcasts it. Token resolution, routing, quoting, slippage, and calldata
+are all complete and verified against the live contracts.
+
+## Slippage & the graduation edge
+
+- Default slippage is **200 bps (2%)**; override as the last CLI arg.
+- `minOut = quote * (10000 - slippage_bps) / 10000` is passed into the on-chain
+  call, which reverts if the market moves past it.
+- The one buy large enough to **graduate** the curve is clamped and partially
+  refunded on-chain, so it can return fewer tokens than the pre-trade estimate.
+  If that trips your slippage, the trade reverts safely (no bad fill) — retry
+  with a smaller size or looser slippage.

--- a/thor-exchange/scripts/thor-quote.py
+++ b/thor-exchange/scripts/thor-quote.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Quote a Thor Exchange buy or sell on Robinhood Chain (chainId 4663).
+
+Read-only: hits the public Robinhood Chain RPC, never submits anything and
+needs no Bankr key. Automatically routes a pre-graduation token through the
+bonding-curve math and a graduated token through the Thor V3 QuoterV2.
+
+Usage:
+  thor-quote.py buy  <token_address> <eth_amount>      # ETH  -> token
+  thor-quote.py sell <token_address> <token_amount>    # token -> ETH
+
+Examples:
+  thor-quote.py buy  0x5e798Dd12eDbcD5566cd3772aE5CE682e700750e 0.01
+  thor-quote.py sell 0x5e798Dd12eDbcD5566cd3772aE5CE682e700750e 1000000
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import thorlib as t  # noqa: E402
+
+
+def main():
+    if len(sys.argv) < 4 or sys.argv[1] not in ("buy", "sell"):
+        print(__doc__.strip())
+        sys.exit(1)
+
+    action, token, amount = sys.argv[1], sys.argv[2], sys.argv[3]
+    info = t.resolve_token(token)
+    sym = info["symbol"]
+    venue = "Thor V3 pool (graduated)" if info["graduated"] else "bonding curve"
+    print(f"Token:  {sym}  ({token})")
+    print(f"Venue:  {venue}")
+
+    if action == "buy":
+        eth_wei = t.to_wei(amount, 18)
+        if info["graduated"]:
+            out = t.v3_quote(t.WETH, token, eth_wei)
+        else:
+            out = t.curve_quote_buy(info["vEth"], info["vTok"], eth_wei)
+        print(f"\nBuy {amount} ETH  ->  ~{t.from_wei(out, 18)} {sym}")
+        if not info["graduated"]:
+            spot = info["vEth"] / info["vTok"]
+            print(f"Curve spot price: {spot:.3e} ETH per {sym}")
+    else:  # sell
+        tok_wei = t.to_wei(amount, 18)
+        if info["graduated"]:
+            out = t.v3_quote(token, t.WETH, tok_wei)
+        else:
+            out = t.curve_quote_sell(info["vEth"], info["vTok"], tok_wei)
+        print(f"\nSell {amount} {sym}  ->  ~{t.from_wei(out, 18)} ETH")
+
+    print("\n(Estimate only — run thor-trade.py to execute with slippage protection.)")
+
+
+if __name__ == "__main__":
+    main()

--- a/thor-exchange/scripts/thor-trade.py
+++ b/thor-exchange/scripts/thor-trade.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Buy or sell a Thor Exchange token on Robinhood Chain via the Bankr Submit API.
+
+Routes automatically:
+  - pre-graduation  -> the token's BondingCurve (buy/sell, 1% ETH-side fee)
+  - graduated       -> the Thor V3 0.30% pool (exactInputSingle / multicall-unwrap)
+
+Every trade is slippage-protected: the minimum output is computed from a live
+quote and the on-chain call reverts if the market moves past your tolerance.
+
+Usage:
+  thor-trade.py buy  <token_address> <eth_amount>   [slippage_bps]   # ETH  -> token
+  thor-trade.py sell <token_address> <token_amount> [slippage_bps]   # token -> ETH
+
+  slippage_bps defaults to 200 (2%).
+
+Auth: reads the Bankr API key from $BANKR_API_KEY, else ~/.bankr/config.json
+      ({"apiKey": "..."}), exactly like the other Bankr skills.
+
+NOTE: Bankr already lists Robinhood Chain as a supported EVM chain
+      (GET https://api.bankr.bot/chains -> "robinhood"). The final validation is
+      one real submit with a Bankr API key. See references/how-it-works.md.
+"""
+
+import json
+import os
+import sys
+import urllib.request
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import thorlib as t  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# Bankr Submit API.
+# --------------------------------------------------------------------------
+def load_bankr_key() -> str:
+    key = os.environ.get("BANKR_API_KEY")
+    if key:
+        return key
+    path = os.environ.get("BANKR_CONFIG", os.path.expanduser("~/.bankr/config.json"))
+    if not os.path.exists(path):
+        print(f"ERROR: no BANKR_API_KEY env and no Bankr config at {path}", file=sys.stderr)
+        sys.exit(1)
+    with open(path) as f:
+        return json.load(f)["apiKey"]
+
+
+def _post(url: str, payload: dict, headers: dict) -> dict:
+    hdrs = {"Content-Type": "application/json", "User-Agent": "thor-bankr-skill/1.0"}
+    hdrs.update(headers)
+    req = urllib.request.Request(url, data=json.dumps(payload).encode(), headers=hdrs)
+    with urllib.request.urlopen(req, timeout=90) as resp:
+        return json.loads(resp.read())
+
+
+def _get(url: str, headers: dict) -> dict:
+    hdrs = {"User-Agent": "thor-bankr-skill/1.0"}
+    hdrs.update(headers)
+    req = urllib.request.Request(url, headers=hdrs)
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read())
+
+
+def get_wallet(key: str) -> str:
+    res = _get(f"{t.BANKR_API}/wallet/me", {"X-API-Key": key})
+    for w in res.get("wallets", []):
+        if w.get("chain") == "evm":
+            return w["address"]
+    raise SystemExit("ERROR: this Bankr key has no associated EVM wallet.")
+
+
+def submit(key: str, to: str, value: int, data: str, description: str) -> dict:
+    res = _post(
+        f"{t.BANKR_API}/wallet/submit",
+        {
+            "transaction": {"to": to, "chainId": t.CHAIN_ID, "value": str(value), "data": data},
+            "description": description,
+            "waitForConfirmation": True,
+        },
+        {"X-API-Key": key},
+    )
+    if not res.get("success"):
+        print(f"ERROR: submit failed: {json.dumps(res)}", file=sys.stderr)
+        sys.exit(1)
+    return res
+
+
+def ensure_approval(key: str, token: str, owner: str, spender: str, need: int, label: str):
+    allowance = t.call_uint(token, t.encode_call(t.SEL["allowance"], t.w_addr(owner), t.w_addr(spender)))
+    if allowance >= need:
+        return
+    print(f"=== Approving {label} to spend token ===")
+    data = t.encode_call(t.SEL["approve"], t.w_addr(spender), t.w_uint(t.MAX_UINT256))
+    res = submit(key, token, 0, data, f"Approve {label} for Thor Exchange trade")
+    print(f"Approve tx: {res.get('transactionHash')}")
+
+
+# --------------------------------------------------------------------------
+# Calldata builders.
+# --------------------------------------------------------------------------
+def curve_buy_data(min_tokens_out: int) -> str:
+    return t.encode_call(t.SEL["buy"], t.w_uint(min_tokens_out))
+
+
+def curve_sell_data(tokens_in: int, min_eth_out: int) -> str:
+    return t.encode_call(t.SEL["sell"], t.w_uint(tokens_in), t.w_uint(min_eth_out))
+
+
+def v3_exact_input_single(token_in, token_out, recipient, dl, amount_in, min_out) -> str:
+    # struct is fully static -> 8 inline words after the selector.
+    return t.encode_call(
+        t.SEL["exactInputSingle"],
+        t.w_addr(token_in), t.w_addr(token_out), t.w_uint(t.V3_FEE_TIER),
+        t.w_addr(recipient), t.w_uint(dl), t.w_uint(amount_in),
+        t.w_uint(min_out), t.w_uint(0),   # sqrtPriceLimitX96 = 0 (no limit)
+    )
+
+
+def v3_sell_multicall(token, wallet, dl, tokens_in, min_eth_out) -> str:
+    # 1) swap token -> WETH, keeping WETH in the router (recipient = address(0) -> router)
+    swap = v3_exact_input_single(token, t.WETH, t.ZERO_ADDR, dl, tokens_in, min_eth_out)
+    # 2) unwrap the router's WETH to ETH and forward to the wallet
+    unwrap = t.encode_call(t.SEL["unwrapWETH9"], t.w_uint(min_eth_out), t.w_addr(wallet))
+    return "0x" + t.SEL["multicall"] + t.encode_bytes_array([swap, unwrap])
+
+
+# --------------------------------------------------------------------------
+# Main.
+# --------------------------------------------------------------------------
+def main():
+    if len(sys.argv) < 4 or sys.argv[1] not in ("buy", "sell"):
+        print(__doc__.strip())
+        sys.exit(1)
+
+    action, token, amount = sys.argv[1], sys.argv[2], sys.argv[3]
+    slippage = int(sys.argv[4]) if len(sys.argv) > 4 else 200
+
+    key = load_bankr_key()
+    wallet = get_wallet(key)
+    info = t.resolve_token(token)
+    sym = info["symbol"]
+    dl = t.deadline()
+    print(f"Wallet:    {wallet}")
+    print(f"Token:     {sym} ({token})")
+    print(f"Venue:     {'Thor V3 pool (graduated)' if info['graduated'] else 'bonding curve'}")
+    print(f"Slippage:  {slippage} bps\n")
+
+    if action == "buy":
+        eth_wei = t.to_wei(amount, 18)
+        expected = (t.v3_quote(t.WETH, token, eth_wei) if info["graduated"]
+                    else t.curve_quote_buy(info["vEth"], info["vTok"], eth_wei))
+        m = t.min_out(expected, slippage)
+        print(f"Buy {amount} ETH -> ~{t.from_wei(expected, 18)} {sym} (min {t.from_wei(m, 18)})")
+        if info["graduated"]:
+            data = v3_exact_input_single(t.WETH, token, wallet, dl, eth_wei, m)
+            res = submit(key, t.SWAP_ROUTER, eth_wei, data, f"Buy {sym} on Thor V3")
+        else:
+            data = curve_buy_data(m)
+            res = submit(key, info["curve"], eth_wei, data, f"Buy {sym} on Thor bonding curve")
+
+    else:  # sell
+        tok_wei = t.to_wei(amount, 18)
+        expected = (t.v3_quote(token, t.WETH, tok_wei) if info["graduated"]
+                    else t.curve_quote_sell(info["vEth"], info["vTok"], tok_wei))
+        m = t.min_out(expected, slippage)
+        print(f"Sell {amount} {sym} -> ~{t.from_wei(expected, 18)} ETH (min {t.from_wei(m, 18)})")
+        spender = t.SWAP_ROUTER if info["graduated"] else info["curve"]
+        ensure_approval(key, token, wallet, spender, tok_wei,
+                        "Thor V3 router" if info["graduated"] else "bonding curve")
+        if info["graduated"]:
+            data = v3_sell_multicall(token, wallet, dl, tok_wei, m)
+            res = submit(key, t.SWAP_ROUTER, 0, data, f"Sell {sym} on Thor V3")
+        else:
+            data = curve_sell_data(tok_wei, m)
+            res = submit(key, info["curve"], 0, data, f"Sell {sym} on Thor bonding curve")
+
+    tx = res.get("transactionHash", "")
+    print("\n=== SUCCESS ===")
+    print(f"Status: {res.get('status', 'submitted')}")
+    print(f"Tx:     {tx}")
+    print(f"Track:  {t.EXPLORER}/tx/{tx}")
+
+
+if __name__ == "__main__":
+    main()

--- a/thor-exchange/scripts/thorlib.py
+++ b/thor-exchange/scripts/thorlib.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Shared helpers for the Thor Exchange Bankr skill.
+
+Pure Python 3 standard library — no third-party dependencies (mirrors the
+symbiosis reference skill so it runs unmodified inside the Bankr agent runtime).
+
+Everything here is chain-read + ABI-encode + off-chain quoting. Transaction
+submission lives in thor-trade.py via the Bankr Wallet Submit API. The
+bonding-curve quote mirrors the on-chain (Blockscout-verified) BondingCurve
+contract and has been verified to reproduce live `buy()` output to the wei.
+"""
+
+import json
+import os
+import time
+import urllib.request
+
+# --------------------------------------------------------------------------
+# Thor Exchange — Robinhood Chain (chainId 4663) deployment.
+# All contracts are verified on Blockscout (see references/contracts-and-chain.md).
+# --------------------------------------------------------------------------
+CHAIN_ID = 4663
+DEFAULT_RPC = "https://rpc.mainnet.chain.robinhood.com"
+EXPLORER = "https://robinhoodchain.blockscout.com"
+
+LAUNCHPAD_FACTORY = "0x7A5f1e159E441c5D769b903643E23E5e13967CDc"
+SWAP_ROUTER = "0x2754d2E19c6283617206d4dAD35A70061065A206"
+QUOTER_V2 = "0x8fA3aeC8E5D5F4B63c3b1F625ddBA2a7E9E713D0"
+WETH = "0x0Bd7D308f8E1639FAb988df18A8011f41EAcAD73"
+
+# Graduation pool fee tier (0.30%).
+V3_FEE_TIER = 3000
+
+# Public trading fee: 1% on the ETH side of every bonding-curve trade.
+# (All other curve parameters are read live from the chain — nothing about the
+# curve's internal calibration is embedded here.)
+TRADING_FEE_BPS = 100
+BPS_DENOMINATOR = 10_000
+
+BANKR_API = "https://api.bankr.bot"
+
+# --------------------------------------------------------------------------
+# Function selectors (cast sig; validated against the live contracts).
+# --------------------------------------------------------------------------
+SEL = {
+    "bondingCurveOf":        "d9905b6c",  # bondingCurveOf(address)
+    "isThorToken":           "5a207646",  # isThorToken(address)
+    "graduated":             "e7c2b772",  # graduated()
+    "virtualEthReserve":     "52b86d2b",  # virtualEthReserve()
+    "virtualTokenReserve":   "343ee3b7",  # virtualTokenReserve()
+    "buy":                   "d96a094a",  # buy(uint256)
+    "sell":                  "d79875eb",  # sell(uint256,uint256)
+    "balanceOf":             "70a08231",  # balanceOf(address)
+    "allowance":             "dd62ed3e",  # allowance(address,address)
+    "approve":               "095ea7b3",  # approve(address,uint256)
+    "decimals":              "313ce567",  # decimals()
+    "symbol":                "95d89b41",  # symbol()
+    "exactInputSingle":      "414bf389",  # exactInputSingle((...))
+    "unwrapWETH9":           "49404b7c",  # unwrapWETH9(uint256,address)
+    "multicall":             "ac9650d8",  # multicall(bytes[])
+    "quoteExactInputSingle": "c6a5026a",  # quoteExactInputSingle((...))
+}
+
+MAX_UINT256 = (1 << 256) - 1
+ZERO_ADDR = "0x0000000000000000000000000000000000000000"
+
+
+# --------------------------------------------------------------------------
+# ABI encoding (hand-rolled; every value we encode is static — no dynamic
+# heads/tails except the multicall bytes[] wrapper, handled explicitly).
+# --------------------------------------------------------------------------
+def w_uint(x: int) -> str:
+    """Encode a uint as a 32-byte word (64 hex chars)."""
+    if x < 0 or x > MAX_UINT256:
+        raise ValueError(f"uint out of range: {x}")
+    return f"{x:064x}"
+
+
+def w_addr(a: str) -> str:
+    """Encode an address as a 32-byte word."""
+    a = a.lower().replace("0x", "")
+    if len(a) != 40:
+        raise ValueError(f"bad address: {a}")
+    return a.rjust(64, "0")
+
+
+def encode_call(selector: str, *words: str) -> str:
+    """selector + concatenated 32-byte words -> 0x-prefixed calldata."""
+    return "0x" + selector + "".join(words)
+
+
+def encode_bytes_array(calls: list) -> str:
+    """ABI-encode a bytes[] argument (used for Router.multicall).
+
+    `calls` is a list of 0x-prefixed calldata strings. Returns the fully
+    encoded argument region (offset + length + per-element offsets + data),
+    ready to be appended after the multicall selector.
+    """
+    raw = [bytes.fromhex(c[2:] if c.startswith("0x") else c) for c in calls]
+    n = len(raw)
+    # head: n element offsets, each relative to the start of the head region.
+    head_words = n
+    offsets = []
+    running = head_words * 32
+    tails = []
+    for b in raw:
+        offsets.append(running)
+        length_word = w_uint(len(b))
+        padded = b.hex()
+        if len(padded) % 64:
+            padded += "0" * (64 - (len(padded) % 64))
+        tail = length_word + padded
+        tails.append(tail)
+        running += len(tail) // 2
+    body = w_uint(n) + "".join(w_uint(o) for o in offsets) + "".join(tails)
+    # outer: one word pointing at the array (0x20), then the array body.
+    return w_uint(0x20) + body
+
+
+# --------------------------------------------------------------------------
+# JSON-RPC (read-only) against the Robinhood Chain node.
+# --------------------------------------------------------------------------
+def rpc_url() -> str:
+    return os.environ.get("THOR_RPC_URL", DEFAULT_RPC)
+
+
+def eth_call(to: str, data: str, value: int = 0, sender: str = None) -> str:
+    call_obj = {"to": to, "data": data}
+    if value:
+        call_obj["value"] = hex(value)
+    if sender:
+        call_obj["from"] = sender
+    payload = {"jsonrpc": "2.0", "id": 1, "method": "eth_call", "params": [call_obj, "latest"]}
+    req = urllib.request.Request(
+        rpc_url(),
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json", "User-Agent": "thor-bankr-skill/1.0"},
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        out = json.loads(resp.read())
+    if "error" in out:
+        raise RuntimeError(f"eth_call reverted: {out['error']}")
+    return out["result"]
+
+
+def call_uint(to: str, data: str, sender: str = None, value: int = 0) -> int:
+    return int(eth_call(to, data, value=value, sender=sender), 16)
+
+
+def call_addr(to: str, data: str) -> str:
+    return "0x" + eth_call(to, data)[-40:]
+
+
+def call_bool(to: str, data: str) -> bool:
+    return int(eth_call(to, data), 16) == 1
+
+
+def read_symbol(token: str) -> str:
+    """Best-effort ERC20 symbol (string). Falls back to a short address."""
+    try:
+        raw = eth_call(token, encode_call(SEL["symbol"]))[2:]
+        # dynamic string: [offset][len][data]
+        length = int(raw[64:128], 16)
+        data = raw[128:128 + length * 2]
+        return bytes.fromhex(data).decode("utf-8", "replace")
+    except Exception:
+        return token[:8] + "…"
+
+
+# --------------------------------------------------------------------------
+# Amount helpers.
+# --------------------------------------------------------------------------
+def to_wei(amount: str, decimals: int = 18) -> int:
+    parts = str(amount).split(".")
+    integer = parts[0] or "0"
+    frac = (parts[1] if len(parts) > 1 else "")[:decimals]
+    frac = frac + "0" * (decimals - len(frac))
+    return int(integer) * (10 ** decimals) + (int(frac) if frac else 0)
+
+
+def from_wei(amount_raw: int, decimals: int = 18) -> str:
+    s = str(amount_raw).zfill(decimals + 1)
+    int_part = s[: len(s) - decimals]
+    frac_part = s[len(s) - decimals:].rstrip("0")
+    return f"{int_part}.{frac_part}" if frac_part else int_part
+
+
+def min_out(expected: int, slippage_bps: int) -> int:
+    return expected * (BPS_DENOMINATOR - slippage_bps) // BPS_DENOMINATOR
+
+
+# --------------------------------------------------------------------------
+# Token resolution: token -> (curve, graduated, reserves).
+# --------------------------------------------------------------------------
+def resolve_token(token: str) -> dict:
+    if not call_bool(LAUNCHPAD_FACTORY, encode_call(SEL["isThorToken"], w_addr(token))):
+        raise SystemExit(f"ERROR: {token} is not a Thor Exchange token on Robinhood Chain (4663).")
+    curve = call_addr(LAUNCHPAD_FACTORY, encode_call(SEL["bondingCurveOf"], w_addr(token)))
+    graduated = call_bool(curve, encode_call(SEL["graduated"]))
+    info = {"token": token, "curve": curve, "graduated": graduated, "symbol": read_symbol(token)}
+    if not graduated:
+        info["vEth"] = call_uint(curve, encode_call(SEL["virtualEthReserve"]))
+        info["vTok"] = call_uint(curve, encode_call(SEL["virtualTokenReserve"]))
+    return info
+
+
+# --------------------------------------------------------------------------
+# Bonding-curve math — constant-product (x*y=k) with the public 1% ETH-side fee,
+# driven entirely by the live on-chain reserves. Matches the on-chain contract
+# to the wei for ordinary trades. (The single buy that graduates the curve is a
+# rare edge that the on-chain call clamps + refunds; slippage protection covers
+# it — see references/how-it-works.md.)
+# --------------------------------------------------------------------------
+def curve_quote_buy(vEth: int, vTok: int, eth_in_wei: int) -> int:
+    """tokens out for `eth_in_wei` of ETH on the curve."""
+    if eth_in_wei == 0:
+        return 0
+    k = vEth * vTok
+    fee = eth_in_wei * TRADING_FEE_BPS // BPS_DENOMINATOR
+    eth_after = eth_in_wei - fee
+    new_v_eth = vEth + eth_after
+    new_v_tok = (k + new_v_eth - 1) // new_v_eth
+    return vTok - new_v_tok
+
+
+def curve_quote_sell(vEth: int, vTok: int, tokens_in_wei: int) -> int:
+    """ETH out (net of 1% fee) for selling `tokens_in_wei` on the curve."""
+    if tokens_in_wei == 0:
+        return 0
+    k = vEth * vTok
+    new_v_tok = vTok + tokens_in_wei
+    new_v_eth = (k + new_v_tok - 1) // new_v_tok
+    eth_out_gross = vEth - new_v_eth
+    fee = eth_out_gross * TRADING_FEE_BPS // BPS_DENOMINATOR
+    return eth_out_gross - fee
+
+
+def v3_quote(token_in: str, token_out: str, amount_in_wei: int) -> int:
+    """Post-graduation quote via QuoterV2.quoteExactInputSingle (eth_call)."""
+    data = encode_call(
+        SEL["quoteExactInputSingle"],
+        w_addr(token_in), w_addr(token_out), w_uint(amount_in_wei),
+        w_uint(V3_FEE_TIER), w_uint(0),
+    )
+    raw = eth_call(QUOTER_V2, data)[2:]
+    return int(raw[0:64], 16)   # first return word = amountOut
+
+
+def deadline(seconds: int = 1200) -> int:
+    return int(time.time()) + seconds


### PR DESCRIPTION
## What this skill does

Lets Bankr users **buy and sell Thor Exchange tokens on Robinhood Chain (chainId 4663)** — pump.fun-style bonding-curve launchpad tokens that the generic swap aggregator cannot trade (they have no DEX pool pre-graduation; the aggregator reports "zero pool liquidity").

[Thor Exchange](https://thorexchange.xyz) is a bonding-curve launchpad + Uniswap-V3-style DEX live on Robinhood Chain. Tokens trade on a constant-product bonding curve until graduation, then migrate to a Thor V3 pool.

## How it works

- Resolves any token via `LaunchpadFactory.isThorToken` / `bondingCurveOf`, checks `graduated()`, and **routes automatically**: bonding curve (`buy`/`sell`) pre-graduation, Thor V3 SwapRouter (`exactInputSingle`, multicall + `unwrapWETH9`) post-graduation.
- Every trade is slippage-protected (min-out derived from a live quote; default 2%).
- `scripts/thor-quote.py` — read-only quotes against the public Robinhood Chain RPC, no key needed.
- `scripts/thor-trade.py` — executes via `POST /wallet/submit` (chainId 4663 is a documented supported value).
- SKILL.md also teaches the agent the direct-contract-call flow so it can trade without the scripts.
- Python 3 stdlib only, mirroring the symbiosis skill's structure.

## Tested end-to-end on mainnet

- Buy via Wallet Submit API: [0x815951b0…10faff](https://robinhoodchain.blockscout.com/tx/0x815951b019799eb82fbfa0c998aaf97844a2bfdb31e5daa1d195d2eb6610faff) — filled exactly at the quoted amount.
- Buy via the Bankr agent (direct contract call): [0xc0e7848b…30be1b](https://robinhoodchain.blockscout.com/tx/0xc0e7848b84ce6788ef71541527342a3f1cc497990347da614b5b52117830be1b).
- Off-chain curve quote verified to reproduce on-chain `buy()` output to the wei; V3 calldata checked byte-for-byte against Foundry's `cast`.

All contracts are Blockscout-verified; the skill only reads public getters and builds standard calldata.