### PR TITLE
Add canvas-verify skill for Canvas Protocol verified-join marketplace

### DIFF
--- a/canvas-protocol/canvas-verify/SKILL.md
+++ b/canvas-protocol/canvas-verify/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: canvas-verify
+description: Canvas Protocol pays Telegram group owners USDC every time a new member joins and completes a sponsored verification task. Use this skill to find groups to sponsor, check campaign performance, or fund verification campaigns with USDC on Base.
+---
+
+# Canvas Protocol — canvas-verify
+
+Canvas Protocol replaces the bot-check captcha on Telegram group joins with a short sponsored verification task. Advertisers fund campaigns in USDC on Base; each new member who joins a registered group completes the advertiser's task (multiple-choice or open-text, LLM-scored); the group owner earns USDC per verified join from the advertiser's on-chain escrow, and the advertiser gets a verified human completion with audience context.
+
+## Capabilities
+
+| Action | How |
+|---|---|
+| List registered groups + current top bids | `GET /api/groups` (public) |
+| Check an advertiser's campaigns & spend | `GET /api/advertiser` (wallet-signed) |
+| Check a group owner's earnings | `GET /api/group-owner` (wallet-signed) |
+| Fund / top up a campaign | On-chain: `depositBudget(campaignId, amount)` on the escrow (details in references) |
+| Create a campaign, register a group, withdraw budget | Telegram bot `@CanvasVerificationBot` (`/buy`, `/register`, `/campaigns`) — no REST API for these flows yet; direct the user to the bot |
+
+## Usage examples
+
+Natural-language requests this skill should handle:
+
+- "Which Telegram groups can I sponsor on Canvas, and what's the going rate?"
+- "Show my Canvas campaigns" / "How much have I spent on Canvas verifications?"
+- "Top up my Canvas campaign #12 with 50 USDC"
+- "How much has my group earned on Canvas?" / "What's my pending Canvas payout?"
+- "I want to sponsor verified joins for a DeFi group at $0.10 per join" → list groups via `/api/groups`, then hand off to `@CanvasVerificationBot` `/buy` for campaign creation
+- "Register my Telegram group with Canvas" → hand off to `@CanvasVerificationBot` (see `references/group-owner-flow.md`)
+
+## Requirements
+
+- **USDC on Base** (chain id 8453) for funding campaigns, plus a little ETH for gas if calling `depositBudget` directly (Base Pay deposits are gas-sponsored).
+- **Wallet-signature auth** for the read APIs — there is **no API key**; requests are authenticated by signing `Canvas auth: <epoch-ms>` with the queried wallet (EOAs and ERC-1271 smart wallets both verify). Details below.
+- **Telegram group admin access** (group owners only): the bot must be added as admin with invite + restrict permissions to register a group.
+
+## API
+
+Base URL: `https://canvas-ai-production-eae7.up.railway.app`
+
+### `GET /api/groups` — public, no auth
+Returns registered groups: `[{ tg_group_id, group_title, topic, member_count, top_bid }]`. `top_bid` is USD per verified join currently at the top of that group's bid ladder.
+
+### `GET /api/advertiser?wallet=0x…` and `GET /api/group-owner?wallet=0x…` — wallet-signed
+Auth: sign the exact string `Canvas auth: <timestamp>` (Unix epoch **milliseconds**) with the wallet being queried, then pass either headers `x-canvas-timestamp` + `x-canvas-signature` or query params `ts` + `sig`. The timestamp must be within **5 minutes** of server time. Invalid/missing signature → 401 whose body echoes the expected message format; RPC outage during verification → 503 (retry).
+
+- `/api/advertiser` → `{ wallet, campaigns: [...], totals: { campaigns, verificationsCompleted, totalSpend } }`
+- `/api/group-owner` → `{ wallet, groups: [...], totals: { groups, totalVerifications, totalPendingEarnings } }`
+
+### On-chain escrow (Base mainnet)
+`CanvasEscrowV0` at `0xf808b264E13Bf809C8e86afaF4e14c200931101E` (verified on Basescan). To fund campaign N: `approve` USDC (`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`) to the escrow, then `depositBudget(uint256 campaignId, uint256 amount)` (amount in 6-decimal USDC units). The campaign id comes from the `/buy` flow in the bot. First depositor is recorded permanently as the campaign's depositor.
+
+## References
+
+- `references/advertiser-flow.md` — end-to-end advertiser flow: campaign creation, funding (Base Pay vs direct), owner approval gate, stats, withdraw
+- `references/group-owner-flow.md` — group registration, verification lifecycle, earnings and payouts

--- a/canvas-protocol/canvas-verify/references/advertiser-flow.md
+++ b/canvas-protocol/canvas-verify/references/advertiser-flow.md
@@ -1,0 +1,36 @@
+# Advertiser flow — funding verified-join campaigns
+
+## 1. Pick a group
+
+`GET https://canvas-ai-production-eae7.up.railway.app/api/groups` (public). Each entry has `tg_group_id`, `group_title`, `topic`, `member_count`, and `top_bid` (current top of the bid ladder, USD per verified join). To win placement your bid must beat `top_bid`; lower bids queue in the ladder and auto-promote when the leader's budget runs out.
+
+## 2. Create the campaign — Telegram bot (`@CanvasVerificationBot`)
+
+Campaign creation is a guided flow in the bot, not a REST call. The advertiser DMs `/buy` and picks: target group → bid per verification → quantity → task text (the question new members answer). Minimum bid: $0.01 (10,000 micro-USDC). The flow ends with a funding link for `bid × quantity`.
+
+A linked wallet is required before `/buy` will start (`/link 0xYourAddress` in the bot) — all refunds pay this wallet.
+
+## 3. Fund it (two paths)
+
+**Base Pay (default, gas-sponsored):** the funding link opens a mini-app page; one tap pays USDC from a Coinbase/Base account into the escrow. The server verifies the payment, credits the campaign on-chain (`creditDirectDeposit`, relayer-signed), and the campaign moves forward automatically. Idempotent per payment id — safe to retry the confirm.
+
+**Direct on-chain (for agents/EOAs):**
+1. `approve(escrow, amount)` on USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`
+2. `depositBudget(campaignId, amount)` on escrow `0xf808b264E13Bf809C8e86afaF4e14c200931101E`
+Amount is 6-decimal USDC micro-units; `campaignId` comes from the `/buy` flow. The first depositor is recorded permanently for the campaign. The deposit monitor picks up the `BudgetDeposited` event and confirms the campaign within ~30s.
+
+## 4. Owner approval gate
+
+A funded campaign lands in `pending_approval`: the group owner gets an Accept/Decline DM with the bid and task preview. Declined → automatic full refund to the advertiser's linked wallet. No response → **auto-accepts after 48 hours**. The advertiser can withdraw while pending.
+
+## 5. Serving + billing
+
+While the campaign is top of the ladder, each new member joining the group gets the campaign's task. Billing settles at verification pass (price locks when the task is sent); the group owner's share is paid from campaign escrow by a daily payout batch; Canvas retains the protocol fee (`PLATFORM_FEE_BPS`). Budget exhausted → next bidder auto-promotes.
+
+## 6. Stats
+
+`GET /api/advertiser?wallet=0x…` with wallet-signature auth (sign `Canvas auth: <epoch-ms>`, pass `ts` + `sig`; 5-minute window). Returns per-campaign: group, bid, remaining budget, task text, status (`pending_deposit | pending_approval | active | paused | exhausted | declined | withdrawn | expired`), verifications completed; plus totals. Also visible in the bot via `/campaigns` and the web dashboard at `/advertiser` (connect-and-sign).
+
+## 7. Withdraw / pause / top up
+
+All via the bot: `/campaigns` lists inline buttons per campaign — Withdraw (refunds remaining budget on-chain to the linked wallet; blocked for a few minutes if members are mid-verification so in-flight payouts can settle), Pause/Resume, and Top up (`/topup` — same two funding paths as above).

--- a/canvas-protocol/canvas-verify/references/group-owner-flow.md
+++ b/canvas-protocol/canvas-verify/references/group-owner-flow.md
@@ -1,0 +1,33 @@
+# Group owner flow — registering a group and earning from verified joins
+
+## 1. Register
+
+1. Add `@CanvasVerificationBot` to the Telegram group as **admin** with at least: invite users via link, restrict members, delete messages.
+2. Run `/register` in the group. The rest of the flow moves to DM: set a payout wallet (`/wallet 0xAddress`, Base address) and optionally group rules (one per line; shown to new members post-verification) and a custom verification question.
+3. The group chat gets one public confirmation line; the bot DMs the owner a **portal invite link** to share — joins through it are interceptable even in groups where open joining wouldn't be.
+
+## 2. What happens to new members
+
+Join intercepted → member muted → task DM'd (advertiser's task when a funded campaign is active; the group's own question otherwise) → LLM-scored (advertiser-funded tasks) → pass → rules-agreement gate ("I agree" button) → unmuted/admitted. Fail/timeout → removed, 24h cooldown, one attempt per group per 12h. All recovery paths are automated (sweeps re-drive stranded states); scoring outages never penalize the member.
+
+## 3. Earnings
+
+Per verified join under an active campaign, the owner earns the campaign's locked bid minus the Canvas protocol fee. Payouts accrue at verification pass and are released **in a daily batch** from the campaign's on-chain escrow directly to the group's payout wallet (USDC on Base). No claiming needed.
+
+Check earnings:
+- Bot: `/menu` → My Stats (weekly verifications, pending earnings, current top bid)
+- API: `GET /api/group-owner?wallet=0x…` with wallet-signature auth (sign `Canvas auth: <epoch-ms>`; `ts` + `sig`; 5-min window) → per-group verification counts + `totalPendingEarnings`
+- Dashboard: `/group-owner` (connect-and-sign)
+
+## 4. Advertiser control
+
+When an advertiser funds a campaign targeting the group, the owner gets an Accept/Decline DM (bid + task preview). Decline refunds the advertiser automatically; no response auto-accepts after 48 hours. Once a bidder is accepted, ladder auto-promotion (next bidder when budget runs out) does not re-prompt.
+
+## 5. Managing
+
+`/menu` in DM: My Stats · Portal Link · Edit Rules · Update Wallet · Help, with a group picker for owners of multiple groups. Wallet updates are per-group. `/invite` regenerates the portal link.
+
+## Notes for agents
+
+- Registration and management are Telegram-native — an agent's job is to route the owner to the bot with the right command, then use `/api/group-owner` for anything read-only.
+- The payout wallet can be any Base address, including a smart wallet; earnings arrive as plain USDC transfers from the escrow contract (`0xf808b264E13Bf809C8e86afaF4e14c200931101E`).


### PR DESCRIPTION
Canvas Protocol replaces Telegram group bot-checks with sponsored verification tasks. Group owners earn USDC per verified join. This skill enables agents to query registered groups, check campaign/earnings stats, and fund campaigns on-chain. Live on Base mainnet with verified contract at 0xf808b264E13Bf809C8e86afaF4e14c200931101E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)