### PR TITLE
Update bankr skill for recent capability changes

### DIFF
--- a/bankr/SKILL.md
+++ b/bankr/SKILL.md
@@ -501,6 +501,7 @@ The [Bankr LLM Gateway](https://docs.bankr.bot/llm-gateway/overview) is a unifie
 - Check credits: `bankr llm credits` | Top up: `bankr llm credits add <amount>` | Auto top-up: `bankr llm credits auto --enable --amount 25 --tokens USDC`
 - In OpenClaw config, prefix model IDs with `bankr/` (e.g. `bankr/claude-sonnet-5`). In direct API calls, use bare IDs (e.g. `claude-sonnet-5`). Run `bankr llm models` for the current model list
 - **Per-model discounts** available for Bankr Club members and partners — applied automatically at billing time
+- **Image generation**: generate images via the OpenAI-native `/v1/images/generations` endpoint (model `gpt-image-2`), billed from the same LLM credit balance — see the reference
 - **Expiring credit grants**: promotional or developer grants may carry an expiry date. Your spendable balance is your permanent (purchased) credits plus any unexpired grants — grants are spent first (soonest-expiring first) and drop off automatically at expiry
 
 ### Quick Commands
@@ -591,6 +592,7 @@ For full details — setup paths, model list, provider config, SDK examples, key
 - Browse and search collections
 - View floor prices and listings
 - Purchase NFTs via OpenSea
+- Accept offers on NFTs you own
 - View your NFT portfolio
 - Transfer NFTs
 - Mint from supported platforms
@@ -630,7 +632,7 @@ Spot stocks work with swaps, transfers, limit orders, and DCA. Only Robinhood st
 
 ### Token Deployment
 
-- **EVM (Base, default)**: Launch ERC20 tokens via Doppler on a Uniswap V4 pool with customizable metadata and social links. Fixed **100 billion** supply, **0.7%** swap fee split **95% creator / 5% protocol**. Tokens deploy to Base by default. Legacy Clanker tokens remain claimable (claims auto-detect Doppler vs Clanker).
+- **EVM (Base default, or Robinhood Chain)**: Launch ERC20 tokens via Doppler on a Uniswap V4 pool with customizable metadata and social links. Fixed **100 billion** supply, **0.7%** swap fee split **95% creator / 5% protocol**. Tokens deploy to Base by default; pass a chain (`bankr launch --chain robinhood`) to launch on Robinhood Chain instead. Legacy Clanker tokens remain claimable (claims auto-detect Doppler vs Clanker).
 - **Solana**: Launch SPL tokens via Raydium LaunchLab with bonding curve and auto-migration to CPMM
 - Creator fee claiming on both chains
 - Fee Key NFTs for Solana (50% LP trading fees post-migration)
@@ -704,9 +706,9 @@ The agent can answer questions about Bankr itself — how features work, officia
 | World Chain | ETH          | Uniswap V3/V4 swaps          | Very Low |
 | Arbitrum    | ETH          | DeFi, low-cost transactions   | Very Low |
 | BNB Chain   | BNB          | BSC ecosystem trading         | Low      |
-| Robinhood Chain | ETH      | Tokenized stocks & ETFs (USDG), memecoins | Very Low |
+| Robinhood Chain | ETH      | Tokenized stocks & ETFs (USDG), memecoins, token launches | Very Low |
 
-**Robinhood Chain** is an EVM L2 (chainId `4663`) whose native stablecoin is **USDG** (Global Dollar). It hosts 95+ Robinhood-issued tokenized stocks and ETFs alongside memecoins. Tokenized-stock trades require location verification (see [Tokenized Stock Trading](#tokenized-stock-trading)); memecoin swaps, bridging, and transfers do not.
+**Robinhood Chain** is an EVM L2 (chainId `4663`) whose native stablecoin is **USDG** (Global Dollar). It hosts 95+ Robinhood-issued tokenized stocks and ETFs alongside memecoins, and supports Bankr token launches (Doppler). Tokenized-stock trades require location verification (see [Tokenized Stock Trading](#tokenized-stock-trading)); memecoin swaps, token launches, bridging, and transfers do not.
 
 ## Safety & Access Control
 
@@ -721,6 +723,7 @@ User-controlled settings that apply to every surface — chat, agent, API, CLI. 
 | Pause all transactions | Off | Blocks every outbound transaction until unpaused |
 | Daily spending limit | $500 / 24h | Rejects any tx that pushes rolling-24h USD outflow past the limit |
 | Per-transaction limit | $500 | Rejects any single tx priced above the limit |
+| Price impact limit | On (15%) | Rejects a swap whose estimated price impact exceeds the limit — guards against catastrophic fills in thin/low-liquidity pools. Adjustable 1–100% or turned off |
 | Permitted recipients | Off | Restricts transfers/swaps to an allowlist; new entries enter a configurable cooldown (default 24h) |
 | Disable arbitrary contract calls | Off | Blocks `write_contract`, raw `/wallet/submit`, and arbitrary transaction tools (named operations like swaps still work) |
 

--- a/bankr/references/llm-gateway.md
+++ b/bankr/references/llm-gateway.md
@@ -413,6 +413,26 @@ message = client.messages.create(
 )
 ```
 
+## Image Generation
+
+The gateway supports image generation through an OpenAI-native `POST /v1/images/generations` endpoint (model `gpt-image-2`). The request and response mirror OpenAI's images API, so the OpenAI SDK's `images.generate()` works against the gateway with just a base-URL swap:
+
+```bash
+curl -X POST "https://llm.bankr.bot/v1/images/generations" \
+  -H "Authorization: Bearer $BANKR_LLM_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "gpt-image-2", "prompt": "a neon city skyline at dusk"}'
+```
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="https://llm.bankr.bot/v1", api_key="your_bankr_key")
+img = client.images.generate(model="gpt-image-2", prompt="a neon city skyline at dusk")
+```
+
+Image-output models are billed from the same LLM credit balance as text models, priced per image (image-output usage is metered separately). Image-capable models advertise an `image` output modality and per-image pricing in `GET /v1/models` (`output_modalities`, `pricing.image_output`); run `bankr llm models` for the current list.
+
 ## Model Deprecation
 
 The gateway supports model deprecation with automatic redirect to replacement models:

--- a/bankr/references/nft-operations.md
+++ b/bankr/references/nft-operations.md
@@ -9,6 +9,7 @@ Browse, purchase, and manage NFTs across chains via OpenSea integration.
 - **Browse** - Search NFT collections
 - **View Listings** - Find best deals and floor prices
 - **Buy** - Purchase NFTs from marketplace listings
+- **Accept Offer** - Accept an offer on an NFT you own
 - **View Holdings** - Check your NFT portfolio
 - **Transfer** - Send NFTs to another wallet
 - **Mint** - Mint from supported platforms (Manifold, SeaDrop)
@@ -32,6 +33,10 @@ Browse, purchase, and manage NFTs across chains via OpenSea integration.
 - "Purchase this NFT: [OpenSea URL]"
 - "Buy Pudgy Penguin #1234"
 - "Get the floor Azuki"
+
+**Accept offers:**
+- "Accept the best offer on my Pudgy Penguin #1234"
+- "What's the highest offer on my Bored Ape?"
 
 **View holdings:**
 - "Show my NFTs"

--- a/bankr/references/safety.md
+++ b/bankr/references/safety.md
@@ -15,10 +15,15 @@ User-controlled wallet safety features configured at [bankr.bot](https://bankr.b
 | Pause all transactions | Off | Blocks every outbound transaction until unpaused |
 | Daily spending limit | $500 / 24h | Rejects any tx that pushes rolling-24h USD outflow past the limit |
 | Per-transaction limit | $500 | Rejects any single tx priced above the limit |
+| Price impact limit | On (15%) | Rejects a swap whose estimated price impact exceeds the limit |
 | Permitted recipients | Off | Restricts transfers/swaps to an allowlist; new entries enter a configurable cooldown |
 | Disable arbitrary contract calls | Off | Blocks `write_contract`, raw `/wallet/submit`, and arbitrary transaction tools (named operations like swaps still work) |
 
 USD limits accept `1` to `1,000,000`. Setting `0` is rejected — disable the limit instead. Cooldown accepts `0` to `168` hours (default 24h).
+
+### Price Impact Limit
+
+Enabled by default at **15%**, adjustable from **1% to 100%** or turned off on the Security page. Before a swap is signed, Bankr estimates its price impact (how far the trade moves the pool price) and rejects it when the estimate exceeds the limit — this protects against catastrophic fills on thin or low-liquidity pools while leaving normal trading (well under the threshold) untouched. The guard applies to user-initiated swaps across chains; when impact can't be estimated it fails open, and slippage plus minimum-received bounds still protect the fill.
 
 ### Pricing & Fail-Closed Behavior
 

--- a/bankr/references/token-deployment.md
+++ b/bankr/references/token-deployment.md
@@ -1,12 +1,13 @@
 # Token Deployment Reference
 
-Deploy and manage tokens on Base (via Doppler / Uniswap V4) and Solana (via Raydium LaunchLab). Older tokens launched through Clanker remain fully claimable; fee claims auto-detect Doppler vs Clanker.
+Deploy and manage tokens on Base and Robinhood Chain (via Doppler / Uniswap V4) and Solana (via Raydium LaunchLab). Older tokens launched through Clanker remain fully claimable; fee claims auto-detect Doppler vs Clanker.
 
 ## Supported Chains
 
 | Chain | Protocol | Token Standard | Best For |
 |-------|----------|----------------|----------|
 | **Base** (default) | Doppler (Uniswap V4) | ERC20 | Memecoins, social/agent tokens |
+| **Robinhood Chain** | Doppler (Uniswap V4) | ERC20 | Memecoins alongside tokenized stocks |
 | **Solana** | Raydium LaunchLab | SPL | High-speed trading, bonding curves |
 
 > **Builder exits:** selling a token you earn creator fees on through Bankr's ordinary swap/limit/stop/DCA/TWAP tools is intentionally restricted (buying and transferring still work). To take profit, builders use a **Glidepath** — a capped, AI-paced gradual sell managed from the token page at [bankr.bot](https://bankr.bot). Glidepath is a web feature, not a CLI/API action. Details: https://docs.bankr.bot/token-launching/glidepath
@@ -186,9 +187,9 @@ Users can launch additional tokens beyond sponsored limits by paying ~0.01 SOL g
 
 ---
 
-## EVM Token Launches (Base, via Doppler)
+## EVM Token Launches (Base & Robinhood Chain, via Doppler)
 
-Launch ERC20 tokens on Base. New launches create a Uniswap V4 pool via Doppler with a fixed supply and a single swap-fee tier shared between you and the protocol. Tokens deploy to Base by default.
+Launch ERC20 tokens on Base or Robinhood Chain. New launches create a Uniswap V4 pool via Doppler with a fixed supply and a single swap-fee tier shared between you and the protocol. Tokens deploy to **Base by default**; pass a chain to launch on Robinhood Chain instead (`bankr launch --chain robinhood`, or "launch a token on robinhood"). Robinhood Chain memecoin launches need no location verification — that gate only applies to Robinhood-issued tokenized stocks.
 
 ### Token Economics
 
@@ -221,6 +222,7 @@ Fees accumulate in your token and WETH and can be claimed anytime.
 - "Create a memecoin: name=DogeKiller, symbol=DOGEK"
 - "Deploy token with website myproject.com and Twitter @myproject"
 - "Create a token on Base"
+- "Launch a token called CoolBot on robinhood"
 - "Launch a token called CoolBot and route fees to @partner"
 
 **Claim fees:**
@@ -256,7 +258,7 @@ High-volume or bot-like deploy patterns can trigger automated spam protections a
 
 ### Taking Profit (Glidepath)
 
-Selling a token you earn creator fees on through Bankr's swap/limit/stop/DCA/TWAP tools is restricted (buying and transferring are unaffected). To take profit, builders use a **Glidepath** — a capped, AI-paced gradual sell that feeds a committed slice of your tokens back into the pool over time instead of dumping. Glidepath is managed from the token page at [bankr.bot](https://bankr.bot) (a web feature, not a CLI/API action). Details: https://docs.bankr.bot/token-launching/glidepath
+Selling a token you earn creator fees on through Bankr's swap/limit/stop/DCA/TWAP tools is restricted (buying and transferring are unaffected). To take profit, builders use a **Glidepath** — a capped, AI-paced gradual sell that feeds a committed slice of your tokens back into the pool over time instead of dumping. Glidepath is available for Base and Robinhood Chain launches and is managed from the token page at [bankr.bot](https://bankr.bot) (a web feature, not a CLI/API action). Details: https://docs.bankr.bot/token-launching/glidepath
 
 ---
 

--- a/bankr/references/tokenized-stocks.md
+++ b/bankr/references/tokenized-stocks.md
@@ -35,11 +35,13 @@ Robinhood Chain hosts 95+ tokenized stocks and ETFs issued by Robinhood — larg
 
 Prices track the underlying equity. Trades settle on-chain against **USDG (Global Dollar)**, Robinhood Chain's native stablecoin — Bankr routes through it automatically, so you can fund a purchase from ETH, USDG, or any token on the chain in a single command.
 
-Stocks work with automations too:
+Robinhood Chain supports the full set of advanced orders — **limit, stop (including trailing), DCA, and TWAP** — alongside spot swaps and transfers:
 
 ```
 "every monday, analyze the tokenized stock market and put $100 into your strongest pick"
 "DCA $50 into SPY every friday"
+"buy NVDA on robinhood if it drops to $150"
+"set a trailing stop on my TSLA on robinhood"
 ```
 
 ### Location verification

--- a/bankr/references/x402-cloud.md
+++ b/bankr/references/x402-cloud.md
@@ -215,6 +215,8 @@ curl -s https://x402.bankr.bot/0xOwner/service | jq .
 
 Returns `{ x402Version, accepts: [{ scheme, network, maxAmountRequired, asset, payTo }] }`.
 
+The Bankr agent can pay both **x402 v1 and v2** endpoints (Bankr-hosted or external), signing the payment in whichever protocol version the endpoint advertises.
+
 ## Endpoint URL Format
 
 ```


### PR DESCRIPTION
## Summary

Syncs the public `bankr` skill with recent Bankr agent / API / CLI capability changes so the docs match what the product now does. All updates are general capability facts — no internal specifics.

## Changes

- **Token deployment** — Doppler token launches are now supported on **Robinhood Chain** in addition to Base. Updated the supported-chains list, the EVM launch section (`bankr launch --chain robinhood`), the chains table, and the Glidepath note (now Base + Robinhood Chain).
- **Safety** — Documented the new wallet-level **price-impact limit** (on by default at 15%, adjustable 1–100% or off), which rejects a swap whose estimated price impact exceeds the limit to guard against catastrophic fills in thin/low-liquidity pools.
- **NFTs** — Added **accept-offer** as a supported operation, with prompt examples.
- **LLM Gateway** — Documented **image generation** via the OpenAI-native `/v1/images/generations` endpoint (`gpt-image-2`), billed from the same LLM credit balance.
- **x402** — Noted support for both **x402 v1 and v2** endpoints.
- **Tokenized stocks** — Robinhood Chain now supports the full **advanced order set** (limit, stop/trailing, DCA, TWAP).

## Files

- `bankr/SKILL.md`
- `bankr/references/token-deployment.md`
- `bankr/references/safety.md`
- `bankr/references/nft-operations.md`
- `bankr/references/llm-gateway.md`
- `bankr/references/x402-cloud.md`
- `bankr/references/tokenized-stocks.md`


---
_Generated by [Claude Code](https://claude.ai/code/session_01MHTRxYoeGYhYwbZrn5Q9Ey)_