### PR TITLE
Add wallettriage skill — real-time wallet risk check, x402 pay-per-query

### DIFF
--- a/wallettriage/SKILL.md
+++ b/wallettriage/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: wallettriage
+description: |
+  Real-time wallet risk check for AI agents BEFORE they act on an address.
+  WalletTriage cross-references a wallet's active ERC20 approvals with a live
+  exploit threat feed (contracts under attack right now) and returns a
+  risk_score (0-100), risk_level and actionable findings — including which
+  approvals to revoke first. Use before sending funds to an address, before
+  interacting with a counterparty wallet, when auditing your own agent
+  wallet, or on any "is this address safe / risky right now?" question.
+  Triggers: "check this address", "is 0x... safe", "wallet risk", "am I
+  exposed to the exploit", "audit my approvals", "should I revoke".
+  Paid per query via x402 — $0.01 USDC on Base. Stateless: no signup,
+  no API key, nothing stored.
+---
+
+# WalletTriage
+
+Real-time wallet risk engine. One paid GET answers: **"how risky is this
+address right now?"** — dangerous ERC20 approvals cross-referenced with a
+live exploit threat feed, ranked worst-first with recommended actions.
+
+**Base URL:** `https://api.wallettriage.com`
+**Docs (OpenAPI):** `https://api.wallettriage.com/openapi.yaml` · Site: `https://wallettriage.com`
+**Payment:** x402 — USDC on Base mainnet (`eip155:8453`), pay-per-call, no account needed.
+
+## Endpoints
+
+| Endpoint | Price | What it returns |
+|---|---|---|
+| `GET /scan?address=0x...&chain=eth` | $0.01 | Full risk assessment: score, level, findings, summary |
+| `GET /health` | free | Service status, current price, threat-feed freshness |
+| `GET /openapi.yaml` | free | Machine-readable API spec |
+
+`chain` is optional (default `eth`). Supported: `eth`, `base`, `polygon`,
+`arbitrum`, `optimism`, `bsc`, `avalanche`.
+
+## How to Call (x402)
+
+No API key, no signup. A wallet with USDC on Base is all you need — the
+x402 client intercepts the 402, pays, and retries automatically.
+
+**TypeScript:**
+```typescript
+import { withPaymentInterceptor } from "x402-axios";
+import axios from "axios";
+
+const client = withPaymentInterceptor(axios.create(), walletClient);
+
+const { data } = await client.get(
+  "https://api.wallettriage.com/scan?address=0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045&chain=eth"
+);
+```
+
+**Python:**
+```python
+from x402.client import x402_client
+
+client = x402_client(wallet=YOUR_WALLET)
+risk = client.get(
+    "https://api.wallettriage.com/scan",
+    params={"address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045", "chain": "eth"},
+).json()
+```
+
+**MCP (for MCP-capable agents):** the same query is exposed as an MCP tool —
+`npx wallettriage-mcp` (npm), or via the official MCP Registry
+(`io.github.wallettriage/wallettriage-mcp`).
+
+## Response
+
+```json
+{
+  "address": "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045",
+  "chain": "eth",
+  "risk_score": 12,
+  "risk_level": "low",
+  "checked_at": "2026-07-11T01:37:01.464Z",
+  "findings": [],
+  "summary": {
+    "total_approvals": 100,
+    "spam_suppressed": 5,
+    "low_noise_approvals": 95,
+    "low_value_at_risk_usd": 5549.92
+  },
+  "stateless": true
+}
+```
+
+**Key fields:**
+
+- `risk_score` — 0-100, higher is riskier.
+- `risk_level` — `low` / `medium` / `high` / `critical`. Treat `high`+ as
+  "do not proceed without human review"; `critical` means an active
+  approval touches a contract currently flagged by the live threat feed.
+- `findings[]` — actionable items (medium+), worst-first. Each carries
+  `type` (e.g. `exploit_exposure`), `severity`, `detail`, the `token` and
+  `spender` involved, `usd_at_risk`, and a `recommended_action`
+  (e.g. `revoke_approval`).
+- `summary` — approval counts with spam/noise suppressed so agents don't
+  over-react to dust.
+- `stateless: true` — nothing about the query is persisted server-side.
+
+## Agent Decision Pattern
+
+```
+risk = GET /scan?address=<counterparty>
+if risk.risk_level in ("high", "critical"):
+    abort or escalate to human; surface risk.findings[0].detail
+elif risk.risk_level == "medium":
+    proceed with reduced limits; consider findings' recommended_action
+else:
+    proceed
+```
+
+## Why this complements Bankr Agent Safety
+
+Bankr's built-in safety (honeypots, allowances) protects the **transaction
+you're about to sign**. WalletTriage answers a different question: whether
+the **address itself** is exposed to an exploit that is live right now —
+its standing approvals cross-checked against a continuously updated threat
+feed. Use both: Bankr guards the action, WalletTriage triages the
+counterparty (or your own wallet) before the action is even composed.
+
+## Requirements
+
+- USDC on Base mainnet (~$0.01 per query)
+- TypeScript: `npm install x402-axios` · Python: `pip install x402`
+- No API key, no signup, no data stored

--- a/wallettriage/catalog.json
+++ b/wallettriage/catalog.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": 1,
+  "slug": "wallettriage",
+  "provider": "WalletTriage",
+  "providerUrl": "https://wallettriage.com",
+  "logo": "logo.svg",
+  "demo": {
+    "title": "wallettriage.sh",
+    "language": "bash",
+    "code": "# Is this address safe to interact with? ($0.01)\nbankr prompt \"Use wallettriage to scan 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045 on eth\"\n\n# Audit my own wallet's approvals against live exploits ($0.01)\nbankr prompt \"Run a wallettriage scan on my wallet on base — what should I revoke first?\"\n\n# Gate a transfer on counterparty risk ($0.01)\nbankr prompt \"Before sending, wallettriage-scan the recipient; abort if risk_level is high or critical\"\n\n# Service status + threat feed freshness (free)\nbankr prompt \"GET https://api.wallettriage.com/health and report threat feed status\""
+  },
+  "setup": [
+    "No install required — one HTTP endpoint behind x402",
+    "TypeScript: `npm install x402-axios` — Python: `pip install x402`",
+    "Fund a Base wallet with USDC (~$0.01 per query)",
+    "Optional MCP: `npx wallettriage-mcp` for MCP-capable agents"
+  ],
+  "install": {
+    "type": "bankr",
+    "repoPath": "wallettriage",
+    "command": "install the wallettriage skill from https://github.com/BankrBot/skills/tree/main/wallettriage"
+  }
+}

--- a/wallettriage/logo.svg
+++ b/wallettriage/logo.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128">
+  <rect width="128" height="128" rx="24" fill="#0E1116"/>
+  <!-- shield -->
+  <path d="M64 18 L100 32 V62 C100 86 84 102 64 110 C44 102 28 86 28 62 V32 Z"
+        fill="none" stroke="#2F6FED" stroke-width="6" stroke-linejoin="round"/>
+  <!-- pulse line (triage heartbeat) -->
+  <polyline points="38,66 52,66 58,48 68,82 74,60 90,60"
+            fill="none" stroke="#38D39F" stroke-width="6"
+            stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
## What this skill does

WalletTriage is a real-time wallet risk engine for AI agents: one x402-paid
GET ($0.01 USDC on Base) answers "how risky is this address right now?" —
the wallet's active ERC20 approvals cross-referenced with a live exploit
threat feed, returning a risk_score (0-100), risk_level and worst-first
actionable findings (what to revoke, USD at risk).

Built for the agent use case: an agent checks a counterparty address (or
its own wallet) BEFORE acting. Stateless — no signup, no API key, nothing
stored server-side.

## Why it fits the catalog

Same access model as other skills here (zerion, checkr, quicknode):
plain HTTP behind x402, USDC on Base, pay-per-call. It complements Bankr's
built-in Agent Safety: Bankr guards the transaction being signed; this
triages the address itself against live exploit exposure before the action
is composed.

## Live & testable

- Paid endpoint: `GET https://api.wallettriage.com/scan?address=0x...&chain=eth`
- Free status: `GET https://api.wallettriage.com/health`
- OpenAPI: `https://api.wallettriage.com/openapi.yaml`
- Also on npm (`wallettriage-mcp`) and the official MCP Registry
  (`io.github.wallettriage/wallettriage-mcp`)

In production since 2026-07-08 with end-to-end paid queries settling via
the CDP facilitator.