### PR TITLE
docs(bankr): cross-chain & Solana wallet swaps + latest LLM gateway models

### DIFF
--- a/bankr/SKILL.md
+++ b/bankr/SKILL.md
@@ -225,8 +225,8 @@ Omit `threadId` to start a new conversation. CLI equivalent: `bankr agent prompt
 |----------|--------|------|-------------|
 | `/wallet/me` | GET | Read | Wallet info (address, chains) |
 | `/wallet/portfolio` | GET | Read | Portfolio balances, supports `?include=pnl,nfts` for progressive loading |
-| `/wallet/swap-quote` | POST | Read | Quote a same-chain EVM swap without executing |
-| `/wallet/swap` | POST | Write | Execute a same-chain EVM swap (output returns to your wallet) |
+| `/wallet/swap-quote` | POST | Read | Quote a swap (same-chain EVM, cross-chain, or Solana) without executing |
+| `/wallet/swap` | POST | Write | Execute a swap — same-chain EVM, cross-chain, or any Solana leg (output returns to your wallet) |
 | `/wallet/transfer` | POST | Write | Transfer tokens (multi-chain, supports `allowedRecipients` enforcement) |
 | `/wallet/sign` | POST | Write | Sign messages, typed data, or transactions |
 | `/wallet/submit` | POST | Write | Submit raw transactions to chain |
@@ -291,7 +291,7 @@ For full API details (request/response schemas, job states, rich data, polling s
 | `bankr wallet portfolio --json` | Output raw JSON |
 | `bankr wallet transfer --to <recipient> --token <symbol> --amount <amount>` | Transfer tokens; `--to` accepts a 0x address or ENS-style name (`.eth`, `.base.eth`, `.cb.id`), `--token` resolves symbols to contracts. Social handles work via the AI agent only. |
 | `bankr wallet transfer --to vitalik.eth --token USDC --amount 50 --chain base` | ENS recipient with explicit chain |
-| `bankr wallet swap --from <symbol/addr> --to <symbol/addr> --amount <amount>` | Swap tokens on a single EVM chain (same-chain). Resolves symbols to contracts; `--from`/`--to`/`--amount` required; `--chain` defaults to `base`. Solana is not supported. |
+| `bankr wallet swap --from <symbol/addr> --to <symbol/addr> --amount <amount>` | Swap tokens on a single EVM chain (same-chain). Resolves symbols to contracts; `--from`/`--to`/`--amount` required; `--chain` defaults to `base`. Solana is not supported (use the Wallet API or agent for cross-chain and Solana swaps). |
 | `bankr wallet swap --from ETH --to USDC --amount 0.1 --chain base --quote-only` | Print the swap quote (you pay / you receive / min received) without executing |
 | `bankr wallet sign` | Sign messages/typed data/transactions |
 | `bankr wallet submit` | Submit raw transactions |
@@ -1070,7 +1070,7 @@ curl -X POST "https://api.bankr.bot/wallet/transfer" \
 
 ### Swap (Direct)
 
-Swap tokens on a single EVM chain (same-chain) via CLI or Wallet API without AI processing. Both legs must be on the same EVM chain — Solana and cross-chain routes go through the AI agent. The CLI resolves token symbols to contracts and uses the quote's `minBuyAmount` as slippage protection when executing.
+Swap tokens via CLI or Wallet API without AI processing. The **CLI** (`bankr wallet swap`) executes **same-chain EVM** swaps only. The **Wallet API** (`/wallet/swap`, `/wallet/swap-quote`) also handles **cross-chain and Solana** legs: same-chain EVM stays on the fast direct path, while cross-chain or any Solana leg routes through Relay behind the same endpoints. The CLI resolves token symbols to contracts and uses the quote's `minBuyAmount` as slippage protection when executing.
 
 ```bash
 # CLI — quote only (no execution)
@@ -1090,9 +1090,15 @@ curl -X POST "https://api.bankr.bot/wallet/swap" \
   -H "X-API-Key: $API_KEY" \
   -H "Content-Type: application/json" \
   -d '{"fromChain": "base", "fromToken": "0x...", "toChain": "base", "toToken": "0x...", "amount": "0.1", "minBuyAmount": "..."}'
+
+# REST API — cross-chain (Base → Solana): distinct fromChain/toChain, base58 mint on the Solana leg
+curl -X POST "https://api.bankr.bot/wallet/swap-quote" \
+  -H "X-API-Key: $API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"fromChain": "base", "fromToken": "0x...", "toChain": "solana", "toToken": "<base58-mint>", "amount": "25"}'
 ```
 
-The `/wallet/swap*` endpoints take token **contract addresses** (use the zero address for the chain's native token); the CLI resolves symbols for you. Swap output is always returned to your own wallet, so `allowedRecipients` does not apply. Supported EVM chains include `base`, `mainnet`, `polygon`, `unichain`, `arbitrum`, `bnb`, `worldchain`, and `robinhood`. Swaps of tokenized stocks on `robinhood` require a passed location check — without one the endpoint returns `403` with instructions to verify at the Bankr console. Execution is also checked against your Bankr Terminal per-transaction and daily spend limits (a `403` is returned when a limit would be exceeded).
+The `/wallet/swap*` endpoints take token **contract addresses** — EVM legs use a 0x address (zero address for the chain's native token), Solana legs use a base58 mint; the CLI resolves symbols for you. For a **cross-chain or Solana** swap, set `fromChain`/`toChain` to different chains (or to `solana`) and the endpoints quote/execute the route automatically. Swap output is always returned to your own wallet, so `allowedRecipients` does not apply. Supported EVM chains include `base`, `mainnet`, `polygon`, `unichain`, `arbitrum`, `bnb`, `worldchain`, and `robinhood`, plus `solana`. Swaps of tokenized stocks on `robinhood` require a passed location check on **either leg** — without one the endpoint returns `403` with instructions to verify at the Bankr console. Execution is also checked against your Bankr Terminal per-transaction and daily spend limits (a `403` is returned when a limit would be exceeded).
 
 ### Sign API (Synchronous)
 

--- a/bankr/references/llm-gateway.md
+++ b/bankr/references/llm-gateway.md
@@ -56,7 +56,10 @@ bankr config get llmKey
 | `gemini-2.5-flash` | Google | Speed, high throughput |
 | `gemma-4-31b-it` | Google | Multimodal, cost-effective (262K) |
 | `gemma-4-26b-a4b-it` | Google | MoE, cost-effective (262K) |
-| `gpt-5.5` | OpenAI | Latest, most capable (1M context, image input) |
+| `gpt-5.6-sol` | OpenAI | Latest flagship, most capable (1M context, image input) |
+| `gpt-5.6-terra` | OpenAI | Latest balanced tier (1M context, image input) |
+| `gpt-5.6-luna` | OpenAI | Latest fast/economical tier (1M context, image input) |
+| `gpt-5.5` | OpenAI | Previous flagship (1M context, image input) |
 | `gpt-5.4` | OpenAI | Advanced reasoning (1M context, image input) |
 | `gpt-5.4-mini` | OpenAI | Fast, economical (400K context, image input) |
 | `gpt-5.4-nano` | OpenAI | Ultra-fast, lowest cost (400K context, image input) |
@@ -64,7 +67,8 @@ bankr config get llmKey
 | `gpt-5.2-codex` | OpenAI | Code generation (400K context) |
 | `gpt-5-mini` | OpenAI | Previous gen, economical (400K) |
 | `gpt-5-nano` | OpenAI | Previous gen, ultra-fast (400K) |
-| `grok-4.20` | xAI | Latest, deep reasoning (2M context) |
+| `grok-4.20` | xAI | Deep reasoning, largest context (2M context) |
+| `grok-4.5` | xAI | Latest, balanced multimodal (500K context, image input) |
 | `grok-4.3` | xAI | Balanced performance (1M context) |
 | `deepseek-v4-pro` | DeepSeek | Long context reasoning (1M, 384K output) |
 | `deepseek-v4-flash` | DeepSeek | High throughput, cost-effective (1M) |
@@ -74,7 +78,8 @@ bankr config get llmKey
 | `qwen3.5-plus` | Alibaba | Long-context reasoning (1M) |
 | `qwen3.5-flash` | Alibaba | Fast, economical (1M) |
 | `qwen3-coder` | Alibaba | Code generation, debugging (262K) |
-| `kimi-k2.7-code` | Moonshot AI | Latest, code-focused long-context (262K) |
+| `kimi-k3` | Moonshot AI | Latest flagship, long-context multimodal (1M context, image input) |
+| `kimi-k2.7-code` | Moonshot AI | Code-focused long-context (262K) |
 | `kimi-k2.6` | Moonshot AI | Long-context (262K) |
 | `kimi-k2.5` | Moonshot AI | Long-context reasoning (262K) |
 | `minimax-m3` | MiniMax | Flagship multimodal reasoning (512K context) |


### PR DESCRIPTION
Weekly sync of the **bankr** skill with capabilities that are now live, keeping the docs accurate for CLI / REST API / agent consumers.

## What changed

### `SKILL.md` — Wallet API swaps now cover cross-chain and Solana
The direct Wallet API swap endpoints (`/wallet/swap`, `/wallet/swap-quote`) previously only handled same-chain EVM swaps; cross-chain and Solana had to go through the AI agent. They now quote and execute cross-chain and Solana legs directly.

- Endpoint summary table: `/wallet/swap` and `/wallet/swap-quote` descriptions updated to cover same-chain EVM, cross-chain, and Solana.
- "Swap (Direct)" section: clarifies that the **CLI** (`bankr wallet swap`) stays same-chain EVM, while the **Wallet API** also handles cross-chain and Solana behind the same endpoints; added a cross-chain (Base → Solana) request example and notes on EVM 0x address vs. Solana base58 mint, `fromChain`/`toChain`, `solana` as a supported value, and the location check applying to either leg.
- CLI `bankr wallet swap` row: points cross-chain/Solana users to the Wallet API or agent.

### `references/llm-gateway.md` — refreshed model snapshot
Added newly available models to the curated model table (the doc still defers to `bankr llm models` for the authoritative live list):

- OpenAI **GPT-5.6** tiers (`gpt-5.6-sol`, `gpt-5.6-terra`, `gpt-5.6-luna`); `gpt-5.5` relabeled as previous flagship.
- xAI **`grok-4.5`**.
- Moonshot **`kimi-k3`**.

## Scope
Docs-only. No changes to `catalog.json` or other reference files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JPnLw5f6QeRi4JB84SScw2)_