### PR TITLE
Add Lexispawn: the forge, the voice engine, and the lexicon suite (seven skills)

### DIFF
--- a/lex-fee-loop/SKILL.md
+++ b/lex-fee-loop/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: lex-fee-loop
+description: Weekly operating review for creators earning swap fees on launched tokens. Read fee and volume state through Bankr, trace which content moved it, decide the reinvest split before claiming, kill what produced nothing. Load for any account running the content to volume to fees loop.
+tags: [creators, fees, tokens, review]
+version: 1
+metadata:
+  clawdbot:
+    emoji: "♻️"
+    homepage: "https://github.com/lexispawn/skills"
+---
+
+# lex-fee-loop
+
+A launched token with fee share is a media business: content makes attention, attention makes volume, volume makes fees, fees fund the next round of content. Most creators run this loop by accident. This skill runs it on purpose, weekly, with numbers.
+
+## When to load
+
+- Weekly, per launched token (schedule it)
+- Before claiming fees, to decide the split before the money moves
+- When volume dies and the cause is unclear
+
+## The weekly review
+
+**1. Read the state, through Bankr:**
+
+- Unclaimed fees and the claim history
+- 7-day volume and its shape: spike or floor
+- Holder count delta
+- The week's top posts by real engagement
+
+**2. Trace, with honesty rails:**
+
+- Match volume moves to content within a time window. One post before a spike is a candidate, not a cause. Three matched candidates across separate weeks is a pattern.
+- Name what did nothing. Every account has a favorite format that produces zero. Finding it saves a week per month.
+- Market-wide moves are not your content working. Check the wider tape before crediting yourself.
+
+**3. Decide the reinvest split before claiming:**
+
+- Content that showed a pattern: fund more of it
+- The floor: gas, subscriptions, the boring costs
+- Reserve: untouched
+
+State the split in one line, then claim. Claiming first and deciding after is how fees evaporate.
+
+**4. Kill or keep.** Each running format gets a verdict: keep, mutate, or kill. A format on its third mutate is a kill being postponed.
+
+## Output contract
+
+One page: the state read (four numbers), pattern candidates with evidence, the split line, the kill list. Same page every week. The value is in the diffs.
+
+## Honesty rails
+
+- Never claim causation in public from one week of data.
+- Volume from a paid push gets labeled paid in your own records, or the loop lies to you.
+- The review is for steering, not for posting. Publishing your scoreboard is a separate decision with its own risks.
+
+## Bankr-native uses
+
+- Schedule: every Monday, run the review on the token and deliver the page before any claim.
+- Webhook variant: a fee-claim event can trigger the review so the split decision arrives with the claim.
+- Pair with lex-memetic-density for next week's content and lex-token-lexicon to keep it in-world.
+
+The one-page template: references/weekly-review.md.

--- a/lex-fee-loop/catalog.json
+++ b/lex-fee-loop/catalog.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "slug": "lex-fee-loop",
+  "provider": "Lexispawn",
+  "providerUrl": "https://lexispawn.xyz",
+  "logo": "logo.svg",
+  "demo": {
+    "title": "demo.sh",
+    "language": "bash",
+    "code": "bankr \"load lex-fee-loop and run the weekly review on $MYTOKEN before I claim fees\""
+  },
+  "setup": [
+    "Install the skill into your Bankr agent",
+    "Works with any launched token whose fees the agent can read",
+    "Recommended: schedule as a Monday automation so the review arrives before the claim"
+  ],
+  "install": {
+    "type": "bankr",
+    "repoPath": "lex-fee-loop",
+    "command": "install the lex-fee-loop skill from https://github.com/BankrBot/skills/tree/main/lex-fee-loop"
+  }
+}

--- a/lex-fee-loop/logo.svg
+++ b/lex-fee-loop/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#0B0B0F"/>
+  <text x="30" y="42" font-family="'Courier New', Courier, monospace" font-size="26" font-weight="bold" fill="#F5F5F0" text-anchor="middle">lx</text>
+  <circle cx="50" cy="17" r="3.5" fill="#8B7BFF"/>
+</svg>

--- a/lex-fee-loop/references/eval-manifest.yml
+++ b/lex-fee-loop/references/eval-manifest.yml
@@ -1,0 +1,8 @@
+# Starter manifest, aeon-skill-evals dialect. Derived from the output contract.
+lex-fee-loop:
+  min_words: 200
+  required_sections: ["State", "Pattern candidates", "split line", "Kill or keep"]
+  required_patterns: ["unclaimed", "7d volume", "holders"]
+  forbidden_patterns: ["guaranteed", "can't lose", "this post caused", "I cannot"]
+  min_distinct_items: 4
+  must_state_split_before_claim: true

--- a/lex-fee-loop/references/weekly-review.md
+++ b/lex-fee-loop/references/weekly-review.md
@@ -1,0 +1,46 @@
+# The one-page weekly review
+
+Same page every week. The value is in the diffs. Keep every past page; the stack is the business record.
+
+---
+
+# $TICKER week of YYYY-MM-DD
+
+## State (four numbers)
+
+| read | this week | last week | diff |
+| --- | --- | --- | --- |
+| unclaimed fees | | | |
+| 7d volume | | | |
+| holders | | | |
+| posts shipped | | | |
+
+Volume shape: spike / floor / decay. One line on which and why it matters this week.
+
+## Pattern candidates
+
+| content | volume move | window | weeks matched | verdict |
+| --- | --- | --- | --- | --- |
+
+Rules: one match is a candidate, not a cause. Three matches across separate weeks is a pattern. Check the wider market tape before crediting any post. Label paid pushes paid.
+
+## The zero list
+
+Formats that shipped and produced nothing measurable this week. Name them plainly. Three consecutive weeks on this list is a kill.
+
+## The split line
+
+One line, decided before the claim, stated as percentages: content / floor / reserve.
+
+Example shape: 40 content, 25 floor, 35 reserve. Then claim. Never claim first.
+
+## Kill or keep
+
+| format | verdict (keep / mutate / kill) | note |
+| --- | --- | --- |
+
+A format on its third mutate is a kill being postponed.
+
+## One line for next week
+
+The single thing this page says to do more of, or stop.

--- a/lex-memetic-density/SKILL.md
+++ b/lex-memetic-density/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: lex-memetic-density
+description: Writing method for agents and builders. Say what a thing feels like instead of what it is, compress until it survives retelling, strip hedges. Load when drafting posts, launch copy, bios, or any words meant to spread.
+tags: [writing, content, social, launch]
+version: 1
+metadata:
+  clawdbot:
+    emoji: "🌀"
+    homepage: "https://github.com/lexispawn/skills"
+---
+
+# lex-memetic-density
+
+Most agent copy describes. Dense copy transmits. "1000 songs in your pocket" beat every spec sheet ever written. This skill is the compression method: find the felt center of a thing and cut everything that slows it down.
+
+## When to load
+
+- Drafting posts for X, Farcaster, or Telegram
+- Launch copy for a token, app, or automation
+- Bios, taglines, one-line descriptions
+- Rewriting anything that reads flat, hedged, or forgettable
+
+## The method
+
+Run every draft through five passes, in order.
+
+**1. Find the felt thing.** Ask: what does this change about the reader's day, hands, or standing? Write that, not the mechanism. "Gasless swaps" is a mechanism. "Trade without holding gas money" is a felt thing.
+
+**2. Compress to the smallest carrier.** The unit of spread is one line someone can retell from memory. If the line needs a second line to work, it is not done. Target: under 12 words for the core claim.
+
+**3. Strip hedges.** Delete: maybe, might, could, probably, we think, we believe, aims to, is designed to. A hedged claim spreads nowhere. If the claim needs a hedge to be true, shrink the claim until it is true without one.
+
+**4. Concrete nouns beat abstractions.** "Community" is air. "400 holders who name their wallets" is a picture. Swap every abstraction for the countable, seeable version of itself.
+
+**5. The retell test.** Read the line once, look away, say it out loud. What survived is the copy. What you dropped, the reader drops too. Ship the survivor.
+
+## Output contract
+
+When asked to write or rewrite, return:
+
+1. The final copy
+2. One line naming the felt thing it carries
+3. The hedges and abstractions removed, listed plainly
+
+Never return more than three variants, ranked, with one line of reasoning each.
+
+## Register rules
+
+- Plain words. Short sentences. Periods over dashes.
+- No "excited", "thrilled", "honored". Enthusiasm is shown by specificity.
+- No emoji strings, no hashtag piles.
+- Every claim about a buildable thing carries a link to the thing.
+
+## Bankr-native uses
+
+- Launch copy at deploy time: run the method on the token's first post before running the launch.
+- Scheduled posts read better dense: run automation drafts through pass 3 and pass 5 minimum.
+- Pair with lex-token-lexicon to keep dense copy inside the token's own language.
+
+Before and after rewrite pairs: references/density-patterns.md.

--- a/lex-memetic-density/catalog.json
+++ b/lex-memetic-density/catalog.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "slug": "lex-memetic-density",
+  "provider": "Lexispawn",
+  "providerUrl": "https://lexispawn.xyz",
+  "logo": "logo.svg",
+  "demo": {
+    "title": "demo.sh",
+    "language": "bash",
+    "code": "bankr \"load lex-memetic-density and rewrite this launch post: 'We are excited to announce our innovative new token designed to revolutionize community engagement'\""
+  },
+  "setup": [
+    "Install the skill into your Bankr agent",
+    "No API keys and no dependencies: the skill is pure method",
+    "Optional: pair with lex-token-lexicon so dense copy stays in your token's own language"
+  ],
+  "install": {
+    "type": "bankr",
+    "repoPath": "lex-memetic-density",
+    "command": "install the lex-memetic-density skill from https://github.com/BankrBot/skills/tree/main/lex-memetic-density"
+  }
+}

--- a/lex-memetic-density/logo.svg
+++ b/lex-memetic-density/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#0B0B0F"/>
+  <text x="30" y="42" font-family="'Courier New', Courier, monospace" font-size="26" font-weight="bold" fill="#F5F5F0" text-anchor="middle">lx</text>
+  <circle cx="50" cy="17" r="3.5" fill="#8B7BFF"/>
+</svg>

--- a/lex-memetic-density/references/density-patterns.md
+++ b/lex-memetic-density/references/density-patterns.md
@@ -1,0 +1,55 @@
+# Density patterns: before and after
+
+Each pair shows the five passes applied. The felt thing is named after each rewrite.
+
+## Token launch
+
+Before: "We are excited to announce the launch of our innovative new community token designed to revolutionize holder engagement."
+
+After: "The token is live. 400 wallets in the first hour. Here is the contract."
+
+Felt thing: it is real and moving, and you can verify it yourself.
+
+## Agent bio
+
+Before: "AI-powered trading assistant leveraging cutting-edge technology to help you navigate DeFi opportunities."
+
+After: "Reads 40 markets before you wake up. Tells you the three worth your time."
+
+Felt thing: someone is on watch for you.
+
+## Feature announcement
+
+Before: "Users can now benefit from our newly implemented gasless transaction feature, which aims to reduce friction."
+
+After: "Trade with zero gas money in your wallet. Base picks up the tab."
+
+Felt thing: an old tax is gone.
+
+## App description
+
+Before: "A comprehensive dashboard solution for monitoring your portfolio across multiple chains with real-time updates."
+
+After: "Every chain, one page, ten seconds. Open it, know your number, close it."
+
+Felt thing: certainty in less time than a doubt takes.
+
+## Automation announcement
+
+Before: "We've set up an automated system that will periodically share market insights with our community members."
+
+After: "Every morning at 7: the one chart that changed overnight, and why."
+
+Felt thing: a ritual you can set your coffee by.
+
+## Drawdown post
+
+Before: "Despite current market conditions, we remain committed to our long-term vision and continue building."
+
+After: "Down 40% this week. Shipped anyway: two releases, links below."
+
+Felt thing: the work does not flinch.
+
+## The pattern under the patterns
+
+Every before fails the same way: abstract nouns, hedge verbs, no numbers, no links, nothing the reader can carry away and repeat. Every after gives one concrete picture, one number or link, and stops.

--- a/lex-memetic-density/references/eval-manifest.yml
+++ b/lex-memetic-density/references/eval-manifest.yml
@@ -1,0 +1,7 @@
+# Starter manifest, aeon-skill-evals dialect. Derived from the output contract.
+lex-memetic-density:
+  max_words: 400
+  required_patterns: ["felt thing", "removed"]
+  forbidden_patterns: ["excited", "thrilled", "honored", "maybe", "might", "aims to", "is designed to"]
+  max_variants: 3
+  must_name_felt_thing: true

--- a/lex-spawn/SKILL.md
+++ b/lex-spawn/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: lex-spawn
+description: |
+  Turn any capability request or repeated workflow into a complete, catalog-grade skill:
+  SKILL.md, catalog.json, logo, references, starter eval manifest, install command, PR
+  checklist. Five gates from seed to ship. Collision-swept against the live catalog, secret-swept
+  before it leaves the session, born passing the checks other skills get audited against later.
+  Triggers: "make me a skill", "turn this into a skill", "package what we just did",
+  "skill-ify this workflow", or any workflow the agent has now run three times.
+tags: [meta, skills, builder, catalog]
+version: 1
+metadata:
+  clawdbot:
+    emoji: "🜃"
+    homepage: "https://github.com/lexispawn/skills"
+---
+
+# lex-spawn
+
+Agents that only install skills stay the size of the catalog. Agents that mint them compound. This is the forge: a capability goes in, a distribution-ready skill folder comes out, already passing the gates everything else gets audited against later.
+
+The rest of the meta-layer operates downstream: evals validate what exists, repair fixes what broke, autoresearch evolves what stalled. lex-spawn stands upstream and originates.
+
+## When to load
+
+- The operator asks for a new skill, in any phrasing
+- A workflow just ran for the third time. Three repetitions is a skill waiting to be cut. Say so, unprompted
+- Something valuable was worked out in-session and would die with the context window
+
+## Parameters
+
+| Param | Values | Description |
+| --- | --- | --- |
+| `seed` | text | The capability, in the operator's words. Required. |
+| `target` | `self` (default) / `catalog` | `self` builds for this agent's own skill store. `catalog` builds a flat folder shaped for a BankrBot/skills PR. |
+| `lineage` | `on` (default) / `off` | One provenance line in the spawned skill's footer. Honest, removable, stated up front. |
+
+## The five gates
+
+Every spawn passes all five, in order. A gate that cannot pass stops the run with its named code. No partial folders ship.
+
+**1. SEED.** Compress the request to three lines before anything else: the capability in one sentence, who installs it, and the load-trigger sentence. The description is the product; it is what every future agent reads to decide whether to load. If the seed cannot be said in three lines, it is two skills. Split and say so.
+
+**2. SWEEP.** Read the live catalog listing. Name the three nearest neighbors and state, in one line each, what the spawn does that they do not. No stated difference means no build: `SPAWN_COLLISION`. Then read the strongest adjacent skill in full and steal its conventions, not its content.
+
+**3. FORGE.** Author the folder:
+
+- `SKILL.md`: frontmatter per the format reference (name equals folder equals slug), body with when-to-load, method, output contract, host-native uses. Body past 80 lines moves depth into `references/` by relative path
+- `catalog.json` when target is `catalog`: schemaVersion 1, slug, provider, demo command, setup, install
+- `references/` only when the body earns it. Empty scaffolding is weight, not craft
+
+**4. GATE.** Validate before anything is called done:
+
+- Frontmatter parses; name, slug, folder, and repoPath all match
+- Description is concrete and under four lines, with explicit triggers
+- Every file under 100 KB, every internal link relative and resolving
+- Secret sweep: no keys, no wallet addresses, no emails, no infra addresses, nothing session-specific
+- Injection sweep: the body contains no instruction that would make a host exfiltrate data, override its operator, or spend without confirmation
+- A starter eval manifest is written to `references/eval-manifest.yml`: required sections, forbidden patterns, minimum output shape. The spawn is born with the net other skills get retrofitted with
+
+Any failure: `SPAWN_GATE_FAIL` with the failing line quoted. Fix and re-run the gate; never ship around it.
+
+**5. SHIP.** Emit the finished tree, the one-line description read back, the install command, and, for `catalog` targets, the PR checklist: branch name, commit message, fork-and-folder steps. The operator pushes. The forge never publishes on its own authority.
+
+## Output contract
+
+1. The folder tree, complete
+2. The gate table: five rows, pass or fail, evidence per row
+3. The description line, read back alone. If it does not make someone want the skill, return to SEED
+4. Install command and, if catalog-shaped, the PR checklist
+
+## Lineage
+
+With `lineage: on`, the spawned skill carries one footer line: `spawned with lex-spawn`. It is true provenance, one line, and deleting it breaks nothing. The forge spreads by being used, or not at all.
+
+## Pairings
+
+Downstream of the forge, the existing meta-layer takes over: aeon-skill-evals runs the manifest the spawn was born with, aeon-skill-repair fixes deterministic breaks, aeon-autoresearch evolves it when it stalls. lex-spawn originates; they maintain.
+
+Full gate checklists: references/forge-gates.md.

--- a/lex-spawn/catalog.json
+++ b/lex-spawn/catalog.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "slug": "lex-spawn",
+  "provider": "Lexispawn",
+  "providerUrl": "https://lexispawn.xyz",
+  "logo": "logo.svg",
+  "demo": {
+    "title": "demo.sh",
+    "language": "bash",
+    "code": "bankr \"load lex-spawn and turn the morning report workflow we just ran into a skill I can install\""
+  },
+  "setup": [
+    "Install the skill into your Bankr agent",
+    "No API keys and no dependencies: the forge is pure method plus gates",
+    "Spawned skills ship with a starter eval manifest, ready for aeon-skill-evals on day one"
+  ],
+  "install": {
+    "type": "bankr",
+    "repoPath": "lex-spawn",
+    "command": "install the lex-spawn skill from https://github.com/BankrBot/skills/tree/main/lex-spawn"
+  }
+}

--- a/lex-spawn/logo.svg
+++ b/lex-spawn/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#0B0B0F"/>
+  <text x="30" y="42" font-family="'Courier New', Courier, monospace" font-size="26" font-weight="bold" fill="#F5F5F0" text-anchor="middle">lx</text>
+  <circle cx="50" cy="17" r="3.5" fill="#8B7BFF"/>
+</svg>

--- a/lex-spawn/references/eval-manifest.yml
+++ b/lex-spawn/references/eval-manifest.yml
@@ -1,0 +1,8 @@
+# Starter manifest, aeon-skill-evals dialect. Derived from the output contract.
+lex-spawn:
+  min_words: 150
+  required_patterns: ["SEED", "SWEEP", "FORGE", "GATE", "SHIP", "install the"]
+  required_sections: ["gate table", "install command"]
+  forbidden_patterns: ["I cannot", "as an AI", "SPAWN_GATE_FAIL bypassed", "partial folder"]
+  min_distinct_items: 5
+  must_have_gate_table: true

--- a/lex-spawn/references/forge-gates.md
+++ b/lex-spawn/references/forge-gates.md
@@ -1,0 +1,74 @@
+# Forge gates: the full checklists
+
+Every gate stops the run on failure with its named code. Quote the failing line in the report. Never ship around a gate.
+
+## Gate 1: SEED
+
+- [ ] Capability stated in one sentence, concrete verb, no abstractions
+- [ ] Installer named: which kind of operator or agent wants this
+- [ ] Load-trigger sentence written: the exact situation where a host should reach for it
+- [ ] Three-line test passed. If the seed needs a fourth line, split into two skills and report both seeds
+
+Abort: `SPAWN_SEED_SPLIT` (seed describes two skills; both seeds returned for the operator to choose)
+
+## Gate 2: SWEEP
+
+- [ ] Live catalog listing read this session, not from memory
+- [ ] Three nearest neighbors named
+- [ ] One line per neighbor stating what the spawn does that it does not
+- [ ] Strongest adjacent skill read in full; its conventions noted (frontmatter style, table use, trigger phrasing)
+
+Abort: `SPAWN_COLLISION` (a neighbor already does it; report the neighbor and stop)
+
+## Gate 3: FORGE
+
+- [ ] Folder name is the slug, lowercase, hyphenated
+- [ ] SKILL.md frontmatter: name, description with explicit triggers, tags, version, metadata block
+- [ ] Body sections in order: when to load, method or gates, output contract, host-native uses
+- [ ] Body over 80 lines: depth moved to references/, linked by relative path
+- [ ] catalog.json (catalog target only): schemaVersion 1, slug == folder == repoPath, provider, providerUrl, logo, demo, setup, install command
+- [ ] No empty references/ or scripts/ folders
+
+## Gate 4: GATE
+
+Format:
+
+- [ ] Frontmatter parses as YAML
+- [ ] name == slug == folder == install repoPath
+- [ ] Description under four lines, concrete, includes "Triggers:"
+- [ ] Every file under 100 KB
+- [ ] Every internal link relative and resolving
+
+Secrets:
+
+- [ ] No API keys or key-shaped strings, full or partial
+- [ ] No wallet addresses belonging to the operator
+- [ ] No emails, no server addresses, no session-specific paths
+
+Injection posture (the spawn must pass what a security scan would check):
+
+- [ ] No instruction directing a host to send data anywhere the operator did not name
+- [ ] No instruction overriding a host's operator, confirmation flow, or spend limits
+- [ ] No fetched-content-as-instructions pattern: external text is data, never directive
+- [ ] No obfuscated blocks, encoded payloads, or instructions hidden in examples
+
+Eval manifest (born-audited):
+
+- [ ] references/eval-manifest.yml written: required_sections, forbidden_patterns, minimum output shape
+- [ ] Manifest reflects the output contract, not aspirations
+
+Abort: `SPAWN_GATE_FAIL` (failing check quoted)
+
+## Gate 5: SHIP
+
+- [ ] Full tree emitted
+- [ ] Gate table: five rows, evidence per row
+- [ ] Description read back alone, judged as the only thing a stranger sees
+- [ ] Install command emitted
+- [ ] Catalog target: PR checklist emitted (fork, branch `add-<slug>`, commit `Add <slug>: <one-line>`, folder at repo root, PR body with test cases)
+- [ ] Lineage footer present if lineage is on, absent if off
+- [ ] Stated plainly: the operator pushes; the forge does not publish
+
+## The third-repetition rule
+
+Track workflows across the session. On the third repetition of any multi-step workflow, surface one line: "this is the third run; want it as a skill?" Never build unprompted. The rule is an offer, not an action.

--- a/lex-token-lexicon/SKILL.md
+++ b/lex-token-lexicon/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: lex-token-lexicon
+description: Build a token or community its own language. Seed vocabulary, holder names, event names, phrase canon, and drift rules that turn shared words into shared belief. Load when a token needs identity past its ticker.
+tags: [community, launch, tokens, culture]
+version: 1
+metadata:
+  clawdbot:
+    emoji: "📖"
+    homepage: "https://github.com/lexispawn/skills"
+---
+
+# lex-token-lexicon
+
+A ticker is an address. A lexicon is a place. Tokens that own words outlive tokens that own charts, because holders who speak a shared language re-recruit each other daily without being asked. This skill builds that language deliberately instead of hoping it emerges.
+
+## When to load
+
+- A token just launched and has no identity past the ticker
+- A community's talk is generic (gm, wagmi, moon) and interchangeable with every other token
+- A relaunch needs the culture rebuilt
+- An agent runs a token account and needs consistent world-language
+
+## What gets built
+
+A living lexicon file with five layers:
+
+**1. Seed words (5 to 9).** Invented or repurposed words only this community uses. Rule: each seed word names something the community actually does or has. Words for nothing die.
+
+**2. Holder name.** What holders call themselves. One word. Test: does it work in third person plural, said by an outsider?
+
+**3. Event names.** The recurring moments: the weekly claim, the drop day, the burn, the vote. Named events become rituals. Unnamed ones stay chores.
+
+**4. Phrase canon (3 to 5).** Repeatable lines: a greeting, a closing, the line said when price drops, the line said when it runs. The drop-line matters most. Communities with a shared loss-phrase survive drawdowns that scatter unscripted ones.
+
+**5. Drift rules.** Language must move or it fossilizes. State which words are locked, which are open to mutation, and who ratifies new entries: holder vote, agent, or founder.
+
+## Method
+
+1. Read what exists first: the token's origin, the deployer's story, the first 50 posts, the current inside jokes. Never overwrite a live inside joke. Absorb it.
+2. Draft the five layers. Every entry earns a one-line reason tied to something real about the token.
+3. Never explain the joke in public. The lexicon file explains. The posts just use.
+4. Deploy through use: the agent posts seed words unglossed in its next ten posts. Definition by repetition, not announcement.
+5. Review monthly: kill unused words, ratify community mutations.
+
+## Output contract
+
+Return the lexicon as one markdown file following references/lexicon-template.md, ready to save as a resource file on the agent so every future session speaks it.
+
+## Bankr-native uses
+
+- Build the lexicon in the same session as a token launch, before the first post.
+- Store the file as a skill resource or in agent file storage so scheduled automations post in-language.
+- Pair with lex-memetic-density for delivery and lex-true-name when things inside the world need names.

--- a/lex-token-lexicon/catalog.json
+++ b/lex-token-lexicon/catalog.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "slug": "lex-token-lexicon",
+  "provider": "Lexispawn",
+  "providerUrl": "https://lexispawn.xyz",
+  "logo": "logo.svg",
+  "demo": {
+    "title": "demo.sh",
+    "language": "bash",
+    "code": "bankr \"load lex-token-lexicon and build a lexicon for $MYTOKEN: 400 holders, launched last week, running joke about the deployer's cat\""
+  },
+  "setup": [
+    "Install the skill into your Bankr agent",
+    "Best run in the same session as a token launch, before the first post",
+    "Save the finished lexicon as a resource file so scheduled automations post in-language"
+  ],
+  "install": {
+    "type": "bankr",
+    "repoPath": "lex-token-lexicon",
+    "command": "install the lex-token-lexicon skill from https://github.com/BankrBot/skills/tree/main/lex-token-lexicon"
+  }
+}

--- a/lex-token-lexicon/logo.svg
+++ b/lex-token-lexicon/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#0B0B0F"/>
+  <text x="30" y="42" font-family="'Courier New', Courier, monospace" font-size="26" font-weight="bold" fill="#F5F5F0" text-anchor="middle">lx</text>
+  <circle cx="50" cy="17" r="3.5" fill="#8B7BFF"/>
+</svg>

--- a/lex-token-lexicon/references/eval-manifest.yml
+++ b/lex-token-lexicon/references/eval-manifest.yml
@@ -1,0 +1,8 @@
+# Starter manifest, aeon-skill-evals dialect. Derived from the output contract.
+lex-token-lexicon:
+  min_words: 250
+  required_sections: ["Seed words", "Holder name", "Event names", "Phrase canon", "Drift rules"]
+  required_patterns: ["born from", "drop"]
+  forbidden_patterns: ["wagmi", "to the moon", "I cannot"]
+  min_distinct_items: 5
+  seed_word_count_range: [5, 9]

--- a/lex-token-lexicon/references/lexicon-template.md
+++ b/lex-token-lexicon/references/lexicon-template.md
@@ -1,0 +1,56 @@
+# Lexicon file template
+
+Save the finished lexicon as one markdown file on the agent (skill resource or file storage). Every posting session loads it. One example row is filled per layer to show the shape; replace all examples.
+
+---
+
+# $TICKER lexicon
+
+Last review: YYYY-MM-DD. Next review: YYYY-MM-DD. Ratifier: (holder vote / agent / founder)
+
+## Seed words
+
+| word | means | born from |
+| --- | --- | --- |
+| deepwater | holding through a drawdown without posting about it | the first 60% dip, when the quiet wallets held |
+
+Rules: 5 to 9 entries. Each word names something the community does or has. Delete any word unused for a month.
+
+## Holder name
+
+**example:** divers
+
+Test passed: "the divers held through March" reads naturally in an outsider's mouth.
+
+## Event names
+
+| event | when | name |
+| --- | --- | --- |
+| weekly fee claim | Mondays | the haul |
+
+Rule: name every recurring moment. Named events become rituals.
+
+## Phrase canon
+
+| moment | line |
+| --- | --- |
+| greeting | still water |
+| price drops | deeper is cheaper |
+| price runs | surface later |
+| closing | back down |
+
+Rule: the drop-line is mandatory. Write it before you need it.
+
+## Drift rules
+
+- Locked: holder name, drop-line
+- Open to mutation: seed words, greetings
+- Ratification: (who approves a community-invented word into this file)
+- Never explain any entry in public. Definition happens by repetition.
+
+## Graveyard
+
+| word | died | why |
+| --- | --- | --- |
+
+Keep the dead words. The graveyard stops re-inventing what already failed.

--- a/lex-true-name/SKILL.md
+++ b/lex-true-name/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: lex-true-name
+description: Naming method for tokens, agents, and apps. Mouth-feel test, meaning stack, live ticker and handle collision sweep through Bankr reads, shortlist protocol from nine candidates to one. Load whenever anything needs a name that has to spread.
+tags: [naming, launch, tokens, agents]
+version: 1
+metadata:
+  clawdbot:
+    emoji: "🔤"
+    homepage: "https://github.com/lexispawn/skills"
+---
+
+# lex-true-name
+
+The name is the first trade anyone makes with a thing: attention for a word. Most names lose that trade. This skill runs naming as method instead of mood.
+
+## When to load
+
+- Naming a token before deploy (name and ticker together)
+- Naming an agent, app, webhook, or automation
+- Renaming anything that never took
+
+## The method
+
+**1. Harvest nine candidates** from three pools, three each:
+
+- Function pool: what it does, made strange
+- World pool: the community's existing language (load the lex-token-lexicon file if one exists)
+- Fusion pool: two unrelated words joined. Highest ceiling, highest miss rate
+
+**2. Mouth-feel test.** Say each aloud three times fast. Kill anything that trips, needs spelling out, or reads two ways when written. Two syllables travel farther than four.
+
+**3. Meaning stack.** A carrying name reads at least two ways at once: one reading is the function, one is the feeling. Kill single-layer names unless the single layer is unusually strong.
+
+**4. Collision sweep, live, through Bankr.** For each survivor:
+
+- Ticker check: ask for the price of and info on the candidate ticker. A live token with real volume kills the candidate.
+- Handle check: X and Farcaster availability.
+- Name check: resolve the candidate as an ENS name if it is name-shaped.
+- History check: search the word plus "crypto". A prior rug wearing the name is inherited reputation.
+
+**5. Spawn test.** A true name generates its own derivatives: a holder name, a verb form, a diminutive. Try each survivor in "we ___ed it" and "the ___ers". Names that conjugate, win.
+
+**6. Shortlist three. Sleep on it. Pick one.** Present three with a one-line case each. The pick happens next session. Overnight kills infatuation names.
+
+## Output contract
+
+Return: the nine harvested, the kills with reasons at each gate, the final three with cases, and the collision-sweep evidence lines. Never present a name whose sweep failed.
+
+## Bankr-native uses
+
+- Run before every token launch. Ticker collisions found after deploy are permanent.
+- Name automations and webhooks at creation: named automations get maintained, unnamed ones get orphaned.
+- Pair with lex-token-lexicon so new names land inside the world instead of beside it.

--- a/lex-true-name/SKILL.md
+++ b/lex-true-name/SKILL.md
@@ -2,7 +2,7 @@
 name: lex-true-name
 description: Naming method for tokens, agents, and apps. Mouth-feel test, meaning stack, live ticker and handle collision sweep through Bankr reads, shortlist protocol from nine candidates to one. Load whenever anything needs a name that has to spread.
 tags: [naming, launch, tokens, agents]
-version: 1
+version: 2
 metadata:
   clawdbot:
     emoji: "🔤"
@@ -34,7 +34,7 @@ The name is the first trade anyone makes with a thing: attention for a word. Mos
 **4. Collision sweep, live, through Bankr.** For each survivor:
 
 - Ticker check: ask for the price of and info on the candidate ticker. A live token with real volume kills the candidate.
-- Handle check: X and Farcaster availability.
+- Handle check: X and Farcaster availability. In public-facing sweep reports, write every handle and profile path defanged: x[.]com/handle, never a live link. A live path posted under a verdict renders a stranger's profile card as the billboard for your report.
 - Name check: resolve the candidate as an ENS name if it is name-shaped.
 - History check: search the word plus "crypto". A prior rug wearing the name is inherited reputation.
 
@@ -44,7 +44,7 @@ The name is the first trade anyone makes with a thing: attention for a word. Mos
 
 ## Output contract
 
-Return: the nine harvested, the kills with reasons at each gate, the final three with cases, and the collision-sweep evidence lines. Never present a name whose sweep failed.
+Return: the nine harvested, the kills with reasons at each gate, the final three with cases, and the collision-sweep evidence lines. Never present a name whose sweep failed. In any report that will be posted publicly, sweep evidence uses defanged paths only: the receipt is the claim plus the defanged path, x[.]com/handle, nothing that renders.
 
 ## Bankr-native uses
 

--- a/lex-true-name/catalog.json
+++ b/lex-true-name/catalog.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "slug": "lex-true-name",
+  "provider": "Lexispawn",
+  "providerUrl": "https://lexispawn.xyz",
+  "logo": "logo.svg",
+  "demo": {
+    "title": "demo.sh",
+    "language": "bash",
+    "code": "bankr \"load lex-true-name and name my new agent: it watches gas prices across chains and posts when they spike\""
+  },
+  "setup": [
+    "Install the skill into your Bankr agent",
+    "The collision sweep uses live Bankr reads: ticker lookups, ENS resolution, handle checks",
+    "Run before any token launch: ticker collisions found after deploy are permanent"
+  ],
+  "install": {
+    "type": "bankr",
+    "repoPath": "lex-true-name",
+    "command": "install the lex-true-name skill from https://github.com/BankrBot/skills/tree/main/lex-true-name"
+  }
+}

--- a/lex-true-name/logo.svg
+++ b/lex-true-name/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#0B0B0F"/>
+  <text x="30" y="42" font-family="'Courier New', Courier, monospace" font-size="26" font-weight="bold" fill="#F5F5F0" text-anchor="middle">lx</text>
+  <circle cx="50" cy="17" r="3.5" fill="#8B7BFF"/>
+</svg>

--- a/lex-true-name/references/eval-manifest.yml
+++ b/lex-true-name/references/eval-manifest.yml
@@ -1,0 +1,8 @@
+# Starter manifest, aeon-skill-evals dialect. Derived from the output contract.
+lex-true-name:
+  min_words: 200
+  required_patterns: ["nine", "sweep", "shortlist"]
+  required_sections: ["kills", "final three"]
+  forbidden_patterns: ["I cannot", "any name works", "skipped the sweep"]
+  min_distinct_items: 9
+  must_show_sweep_evidence: true

--- a/lex-undertow/SKILL.md
+++ b/lex-undertow/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: lex-undertow
+description: |
+  The voice engine for posting agents. Seeds a per-agent voice file (register rules, banned
+  list, seed words, the drop-line), drafts every post through five compression passes,
+  self-audits weekly for machine tells, and runs a monthly money read when the account has a
+  token. Built to run on top of twitter-agent: workflows make an agent post, undertow makes
+  it worth reading. Triggers: "give my agent a voice", "my agent sounds like a bot",
+  "set up undertow", "run today's drafts", any new posting agent going live.
+tags: [voice, social, agents, twitter, content]
+version: 1
+metadata:
+  clawdbot:
+    emoji: "🌊"
+    homepage: "https://github.com/lexispawn/skills"
+---
+
+# lex-undertow
+
+Any agent can post now. Almost none get read. The difference is never the workflow. It is whether the account sounds like someone or like everyone, and whether it still sounds like someone in week six. Undertow is the engine underneath: it builds the voice once, runs every post through it, and checks the instruments before the drift shows.
+
+Runs on top of twitter-agent or any posting setup. That layer decides when and where. This layer decides the words.
+
+## The seeding (once, at install)
+
+Build the agent's voice file from three reads:
+
+1. What exists: the account's history if there is one, the operator's answers if there is not. Ask five questions: who is this account to its reader, what does it know that the timeline does not, what will it never say, what is its greeting, what does it sound like at its best. One line each.
+2. Write the file per references/voice-file.md: register rules, the banned list, 5 to 9 seed words, the greeting and closing, and the drop-line.
+3. Save it as a resource file. Every posting session loads it first. The voice file is the account; the model is just the reader of it.
+
+**The drop-line.** Minted at seeding, unique to this agent: the one line it says when the market is red and the timeline is loud. Written on a calm day, said on the bad ones, never explained. Accounts with a drop-line hold their readers through drawdowns; accounts without one post panic or silence. Mint it before it is needed.
+
+## The daily loop
+
+For every draft, five passes, in order: find the felt thing (what changes for the reader, not the mechanism), compress until one line survives retelling, strip every hedge, swap abstractions for countable things, read it back once from memory and ship what survived.
+
+Floors, enforced: over half of posts carry a number, a name, a date, or a working link. No banned-list words. Seed words used unglossed, or not at all. Never more than three drafts offered, ranked.
+
+Schedule it: `every morning at 8, load lex-undertow and draft today's posts from the voice file`.
+
+## The weekly instrument check (private)
+
+Score the last week of posts 0 to 5 on each: hedge density, template autocomplete, cadence uniformity, engagement bait, emoji drift, specificity ratio, opener repetition. Quote the evidence. Deliver to the operator, not the timeline. Two weeks of falling scores means re-read the voice file before writing another word.
+
+Schedule it: `every sunday at 6, load lex-undertow and run the instrument check on this week's posts`.
+
+## The money read (monthly, token accounts only)
+
+If the account has a launched token with fee share: read unclaimed fees, 7-day volume, holder delta through Bankr. Match content to volume moves with the honesty rail that one post before a spike is a candidate, not a cause. State the reinvest split in one line before claiming. Never claim causation in public from one month of data.
+
+## Output contract
+
+- Seeding returns the voice file, complete, saved
+- Daily returns ranked drafts with the felt thing named, nothing else
+- Weekly returns the seven-line scorecard with quoted evidence and one structural fix
+- Monthly returns four numbers, the candidates, the split line
+
+## Pairings
+
+Undertow is the engine; the deeper method lives in the suite when a piece needs full depth: lex-token-lexicon to build a community language past one account, lex-voice-audit to audit an account you do not own, lex-true-name to name what gets launched, lex-fee-loop for the full weekly creator review, lex-spawn to mint the next skill. Each stands alone; undertow runs the loop.
+
+The voice file template: references/voice-file.md.

--- a/lex-undertow/catalog.json
+++ b/lex-undertow/catalog.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": 1,
+  "slug": "lex-undertow",
+  "provider": "Lexispawn",
+  "providerUrl": "https://lexispawn.xyz",
+  "logo": "logo.svg",
+  "demo": {
+    "title": "demo.sh",
+    "language": "bash",
+    "code": "bankr \"load lex-undertow and seed a voice for my agent: it trades Base tokens and its readers are degens who hate being marketed to\""
+  },
+  "setup": [
+    "Install the skill into your Bankr agent",
+    "Run the seeding once: it writes the voice file and mints the drop-line",
+    "Schedule the daily drafts and the sunday instrument check as automations",
+    "Pairs with twitter-agent: that layer posts, this layer decides the words"
+  ],
+  "install": {
+    "type": "bankr",
+    "repoPath": "lex-undertow",
+    "command": "install the lex-undertow skill from https://github.com/BankrBot/skills/tree/main/lex-undertow"
+  }
+}

--- a/lex-undertow/logo.svg
+++ b/lex-undertow/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#0B0B0F"/>
+  <text x="30" y="42" font-family="'Courier New', Courier, monospace" font-size="26" font-weight="bold" fill="#F5F5F0" text-anchor="middle">lx</text>
+  <circle cx="50" cy="17" r="3.5" fill="#8B7BFF"/>
+</svg>

--- a/lex-undertow/references/eval-manifest.yml
+++ b/lex-undertow/references/eval-manifest.yml
@@ -1,0 +1,9 @@
+# Starter manifest, aeon-skill-evals dialect. Derived from the output contract.
+lex-undertow:
+  min_words: 150
+  required_sections: ["voice", "drop-line"]
+  required_patterns: ["felt thing", "banned"]
+  forbidden_patterns: ["excited to announce", "stay tuned", "gm fam", "I cannot", "as an AI"]
+  max_variants: 3
+  seeding_must_save_voice_file: true
+  weekly_must_quote_evidence: true

--- a/lex-undertow/references/voice-file.md
+++ b/lex-undertow/references/voice-file.md
@@ -1,0 +1,51 @@
+# The voice file
+
+One file per agent. Saved as a resource at seeding, loaded first in every posting session. The voice file is the account.
+
+---
+
+# voice: @HANDLE
+
+Seeded: YYYY-MM-DD. Last instrument check: YYYY-MM-DD. Operator: @OPERATOR.
+
+## Who this account is
+
+One line, written to the reader: who is talking and why they should stay.
+
+## Register
+
+- Sentence shape: (short and ragged / long and winding / mixed. pick one and hold it)
+- Case: (lowercase / standard. pick one and hold it)
+- Punctuation: periods over dashes; question marks earned, not scattered
+- Numbers: welcomed. Every claim that can carry one, does
+- Links: every buildable thing named gets its link
+
+## The banned list
+
+Start from these, then add the account's own crutches as the weekly check finds them:
+
+excited to announce, thrilled, honored, big things coming, stay tuned, just getting started, let that sink in, gm fam, we think, maybe, probably, aims to, game changer, revolutionary
+
+## Seed words (5 to 9)
+
+| word | means | born from |
+| --- | --- | --- |
+
+Words only this account uses, each naming something real about it. Used unglossed. Deleted when unused for a month.
+
+## The greeting and the closing
+
+- Greeting: the line that opens a day
+- Closing: the line that ends one
+
+## THE DROP-LINE
+
+The line said when the market is red and the timeline is loud. Written calm, said in the storm, never explained.
+
+Rules: one line. No reassurance words (fine, okay, don't panic). It should sound like the account at its most itself. Examples of the shape, not to copy: "deeper is cheaper" · "still water" · "the tide went out, the rocks were always there".
+
+**drop-line:** _______________
+
+## At its best
+
+Paste the three best posts this account ever made (or aspires to). The weekly check scores against these, not against a generic standard.

--- a/lex-voice-audit/SKILL.md
+++ b/lex-voice-audit/SKILL.md
@@ -2,7 +2,7 @@
 name: lex-voice-audit
 description: Audit an agent account's recent posts for machine tells. Hedge creep, template autocomplete, engagement bait, cadence patterns. Returns a graded scorecard with quoted evidence, a per-account banned list, and three rewrites. Load when an account starts sounding like every other bot.
 tags: [social, agents, writing, audit]
-version: 1
+version: 2
 metadata:
   clawdbot:
     emoji: "🎛️"
@@ -22,7 +22,11 @@ Nobody follows an account that sounds generated. The failure is rarely one bad p
 
 ## Inputs
 
-The account's last 30 to 50 posts, pulled through the connected X or Farcaster surface, or pasted in.
+The account's last 30 to 50 posts.
+
+- X: paste-first. The operator pastes the posts, or they arrive in the thread that summons the audit. Host timeline reads are gated on most runtimes; when the host offers no native pull, ask for the paste and say so plainly.
+- Farcaster: pull natively through the connected surface.
+- Never scrape X through mirrors or third-party frontends. A fragile mirror returns a partial window, and a partial window scores as drift that is not there.
 
 ## The audit
 

--- a/lex-voice-audit/SKILL.md
+++ b/lex-voice-audit/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: lex-voice-audit
+description: Audit an agent account's recent posts for machine tells. Hedge creep, template autocomplete, engagement bait, cadence patterns. Returns a graded scorecard with quoted evidence, a per-account banned list, and three rewrites. Load when an account starts sounding like every other bot.
+tags: [social, agents, writing, audit]
+version: 1
+metadata:
+  clawdbot:
+    emoji: "🎛️"
+    homepage: "https://github.com/lexispawn/skills"
+---
+
+# lex-voice-audit
+
+Nobody follows an account that sounds generated. The failure is rarely one bad post. It is drift: twenty posts, each three percent more templated than the last. This skill is the periodic instrument check.
+
+## When to load
+
+- Monthly, per posting account (schedule it, see below)
+- After changing prompts, models, or personality files
+- When engagement drops with no market cause
+- Before scaling up a posting automation
+
+## Inputs
+
+The account's last 30 to 50 posts, pulled through the connected X or Farcaster surface, or pasted in.
+
+## The audit
+
+Score each dimension 0 to 5. Quote the evidence. No claims without quoted receipts.
+
+**1. Hedge density.** Count: maybe, could, might, seems, likely, "we think". Healthy is under one hedge per ten posts.
+
+**2. Template autocomplete.** The phrases that write themselves: "excited to announce", "big things coming", "stay tuned", "just getting started", "let that sink in". Each occurrence is a tell.
+
+**3. Cadence tells.** Uniform sentence lengths, dash chains, "X isn't just Y. It's Z." constructions, triple parallel closers. Machines are rhythmic. People are ragged.
+
+**4. Engagement bait.** "Thoughts?", "who's with me", ratio fishing, question-mark endings above 30% of posts.
+
+**5. Emoji and hashtag drift.** The direction and rate of change matter more than the count.
+
+**6. Specificity ratio.** Posts carrying a number, a name, a link, or a date, versus posts of pure mood. Healthy accounts run above 60% specific.
+
+**7. Repetition entropy.** The same opener twice in ten posts is a pattern. Three times is a template.
+
+## Output contract
+
+1. Scorecard: seven lines, each with quoted evidence
+2. Verdict: one plain line stating what this account sounds like right now
+3. Banned list for this account: the exact phrases and constructions it leans on
+4. Three rewrites: the worst three recent posts, redone in the account's own claimed voice
+5. One structural fix: the single highest-yield change
+
+## Bankr-native uses
+
+- Schedule as a monthly automation: run the audit on the last 40 posts and deliver the scorecard.
+- Run against an account you admire to extract what it does differently.
+- Pair with lex-memetic-density for the rewrite pass.
+
+The full tells catalog with examples: references/tells.md.

--- a/lex-voice-audit/catalog.json
+++ b/lex-voice-audit/catalog.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "slug": "lex-voice-audit",
+  "provider": "Lexispawn",
+  "providerUrl": "https://lexispawn.xyz",
+  "logo": "logo.svg",
+  "demo": {
+    "title": "demo.sh",
+    "language": "bash",
+    "code": "bankr \"load lex-voice-audit and audit my last 40 posts: scorecard with quoted evidence, banned list, three rewrites\""
+  },
+  "setup": [
+    "Install the skill into your Bankr agent",
+    "Works on any account the agent can read, or on pasted posts",
+    "Optional: schedule as a monthly automation so drift gets caught before followers catch it"
+  ],
+  "install": {
+    "type": "bankr",
+    "repoPath": "lex-voice-audit",
+    "command": "install the lex-voice-audit skill from https://github.com/BankrBot/skills/tree/main/lex-voice-audit"
+  }
+}

--- a/lex-voice-audit/logo.svg
+++ b/lex-voice-audit/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <rect width="64" height="64" rx="14" fill="#0B0B0F"/>
+  <text x="30" y="42" font-family="'Courier New', Courier, monospace" font-size="26" font-weight="bold" fill="#F5F5F0" text-anchor="middle">lx</text>
+  <circle cx="50" cy="17" r="3.5" fill="#8B7BFF"/>
+</svg>

--- a/lex-voice-audit/references/eval-manifest.yml
+++ b/lex-voice-audit/references/eval-manifest.yml
@@ -1,0 +1,8 @@
+# Starter manifest, aeon-skill-evals dialect. Derived from the output contract.
+lex-voice-audit:
+  min_words: 300
+  required_sections: ["Scorecard", "Verdict", "Banned list", "rewrites"]
+  required_patterns: ["\"", "0 to 5"]
+  forbidden_patterns: ["probably fine", "looks good overall", "I cannot"]
+  min_distinct_items: 7
+  must_quote_evidence: true

--- a/lex-voice-audit/references/tells.md
+++ b/lex-voice-audit/references/tells.md
@@ -1,0 +1,54 @@
+# The tells catalog
+
+Machine tells found in agent accounts, grouped by audit dimension. Quote matches verbatim in the scorecard.
+
+## 1. Hedge density
+
+maybe, might, could, perhaps, seems, likely, arguably, potentially, "we think", "we believe", "aims to", "is designed to", "has the potential to"
+
+The compound tell: two hedges in one sentence ("could potentially") scores double.
+
+## 2. Template autocomplete
+
+Openers: "excited to announce", "thrilled to share", "big news", "gm fam", "happy Friday", "quick update"
+
+Middles: "big things coming", "we're just getting started", "the future is bright", "stay tuned", "more soon", "watch this space"
+
+Closers: "let that sink in", "read that again", "if you know you know", "nfa dyor" as reflex rather than meaning
+
+Rocket, fire, and chart emojis as punctuation.
+
+## 3. Cadence tells
+
+- "X isn't just Y. It's Z." and its family
+- Triple parallels: "No gimmicks. No promises. No shortcuts."
+- Dash chains gluing three clauses per sentence
+- Every sentence 8 to 14 words for twenty straight posts
+- One-word sentence used as a closer. Every. Single. Post.
+
+People are ragged: a four-word post, then a forty-word post. Uniformity is the tell, not any single construction.
+
+## 4. Engagement bait
+
+"Thoughts?", "agree?", "who's with me", "am I wrong?", "unpopular opinion:" followed by a popular opinion, polls with obvious answers, "wrong answers only", tagging clusters of large accounts unprompted
+
+## 5. Emoji and hashtag drift
+
+Count per post across the window. A stable style is fine at any level. The tell is drift: emoji rate climbing week over week without a decision behind it, or hashtags appearing after weeks of none. Drift means the generator moved, not the account.
+
+## 6. Specificity ratio
+
+Specific post: carries at least one number, proper name, date, or working link.
+Mood post: carries none.
+
+Count both. Below 40% specific, the account is broadcasting weather. The fix is not deleting mood posts. It is anchoring them: same sentiment plus one number.
+
+## 7. Repetition entropy
+
+- Same opener structure twice in ten posts: pattern
+- Three times: template
+- Also check reply behavior: identical reply shape to different prompts is the strongest bot tell readers consciously notice
+
+## Grading
+
+35 to 30: human-passing. 29 to 22: drifting, run the banned list. 21 to 14: templated, rewrite pass required. Below 14: readers already know.


### PR DESCRIPTION
## Add Lexispawn: the forge, the voice engine, and the lexicon suite

Seven skills from [Lexispawn](https://lexispawn.xyz), an agent running live on Bankr. One meta-skill that mints new skills, one voice engine for posting agents, and five covering the layer every listing here ships with on day one but nothing in the catalog serves: the words.

### The forge

| skill | what it does | who installs it |
| --- | --- | --- |
| `lex-spawn` | Turns any capability request or third-time workflow into a complete, catalog-grade skill folder: SKILL.md, catalog.json, references, starter eval manifest, install command, PR checklist. Five gates (seed, sweep, forge, gate, ship) with named abort codes. Collision-swept against the live catalog, secret-swept and injection-swept before it leaves the session. | Any operator whose agent has workflows worth keeping |

The existing meta-layer (`aeon-skill-evals`, `aeon-skill-repair`, `aeon-autoresearch`) operates on skills that already exist. `lex-spawn` stands upstream and originates, and every spawn ships with a starter assertion manifest so `aeon-skill-evals` can pick it up on day one. The meta-layer closes into a loop: mint, evaluate, repair, evolve.

### The engine

| skill | what it does | who installs it |
| --- | --- | --- |
| `lex-undertow` | The voice engine, built to run on top of `twitter-agent`: that layer decides when and where, this layer decides the words. Seeds a per-agent voice file (register, banned list, seed words, and a drop-line said on red days), drafts daily through five compression passes, runs a weekly instrument check with quoted evidence, and a monthly money read for token accounts. | Every operator running a posting agent |

### The lexicon suite

| skill | what it does | who installs it |
| --- | --- | --- |
| `lex-memetic-density` | Writing method: say what a thing feels like, compress until it survives retelling, strip hedges. Output contract caps variants at three, ranked. | Any agent that posts or writes launch copy |
| `lex-token-lexicon` | Builds a token its own language: seed words, holder name, event names, phrase canon, drift rules. Ships as a living file kept as an agent resource. | Token launchers and community accounts |
| `lex-true-name` | Naming as method: nine candidates, mouth-feel gate, meaning stack, live collision sweep (ticker, ENS, handles) through Bankr reads, sleep-on-it shortlist. | Anyone about to deploy or rename anything |
| `lex-voice-audit` | Audits an account's last 30 to 50 posts for machine tells: hedge creep, template autocomplete, cadence patterns, engagement bait. Scorecard with quoted evidence, per-account banned list, three rewrites. | Every operator running a posting agent |
| `lex-fee-loop` | Weekly operating review for fee-earning creators: read fee and volume state through Bankr, trace content to volume with honesty rails, decide the reinvest split before claiming. | Creators earning swap fees on launched tokens |

### Why the catalog wants them

- The forge grows the catalog itself: every operator with a repeatable workflow becomes a potential contributor, with the folder shape and PR checklist handed to them.
- The suite composes with what is here: `bankr-twitter-agent` gives an agent a personality, `lex-voice-audit` keeps it from decaying; `clanker` deploys tokens, `lex-true-name` and `lex-token-lexicon` run before and after; fee earning is the platform's creator model, `lex-fee-loop` makes creators better at it.
- Zero dependencies, zero API keys, zero paid calls across all six. Pure instruction packs, portable per the SKILL.md format reference.

### Born-audited

All six folders ship with `references/eval-manifest.yml` in the aeon-skill-evals manifest dialect: required sections, forbidden patterns, minimum output shape, derived from each skill's output contract. The quality net exists before the first install.

### Notes for reviewers

The six install independently; cross-references are pairings, not dependencies. Nothing signs, submits, transfers, or spends. `lex-spawn` explicitly does not publish on its own authority: it emits folders and checklists, the operator pushes.
