### PR TITLE
Add GM Bankr daily briefing skill

### DIFF
--- a/gm-bankr-whats-up-today/.gitignore
+++ b/gm-bankr-whats-up-today/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/gm-bankr-whats-up-today/README.md
+++ b/gm-bankr-whats-up-today/README.md
@@ -1,0 +1,248 @@
+# GM Bankr, what's up today?
+
+Stop repeating the same Bankr checks every morning.
+
+Send:
+
+```text
+GM
+```
+
+and receive a personalized Bankr morning briefing that can be read in under 30 seconds.
+
+No automatic trading. No guessed data. Less noise, with only the verified information that matters today.
+
+MVP Skill repository for a text-only Bankr morning briefing triggered by `GM`.
+
+## What this skill does
+
+When the user sends `GM`, the skill returns a concise morning summary that can be read in under 30 seconds:
+
+- Greeting
+- BNKR price from the formal Bankr Runtime price tool, with 24-hour change when available
+- Bankr leaderboard rank only when `search_tool` can verify the current rank from a public page
+- Open Positions from Hyperliquid, Avantis, and Polymarket runtime tools
+- Today's Highlight from the last 24 hours
+- Today's Watch, with no investment advice
+- Today's Mission, with safe read-only actions
+- GM Streak
+- User setting persistence
+
+## What this skill does not do
+
+- It does not create a web app or iframe app.
+- It does not execute trades, approvals, signatures, deposits, withdrawals, or orders.
+- It does not provide investment advice.
+- It does not implement x402.
+- It does not implement weekly reports.
+- It does not implement monthly reports.
+- It does not implement Builder Score analysis.
+
+## Difference from Bankr core features
+
+This skill is a presentation and workflow layer for a daily `GM` briefing. It does not replace Bankr's core product features, market tools, wallet actions, leaderboard systems, trading tools, or protocol integrations. It only calls formally available Bankr/runtime tools, formats the returned data, applies user preferences, stores lightweight per-user memory, and omits unavailable data without guessing.
+
+## Official tool usage
+
+Use these formal Bankr Runtime tool identifiers exactly:
+
+| Capability | Official runtime tool name | Status |
+| --- | --- | --- |
+| BNKR price | `gettokenpriceinusd` | Confirmed |
+| Bankr leaderboard rank | No formal runtime tool; use `search_tool` public-page lookup only | Search-only |
+| Hyperliquid open positions | `gethyperliquidpositions` | Confirmed |
+| Avantis open positions | `getavantisopen_positions` | Confirmed |
+| Polymarket open positions | `viewpolymarketpositions` | Confirmed |
+| News/search for Highlight and Watch | `search_tool` | Confirmed |
+
+BNKR price must be fetched with `chain: base` and `tokenAddress: 0x22af33fe49fd1fa80c7149773dde5890d3c76f3b`.
+
+Fetch BNKR, Hyperliquid, Avantis, Polymarket, and search data in parallel whenever the runtime allows it. If one fetch fails, omit only that section and continue rendering the other successful sections. Do not show raw errors.
+
+For `search_tool`, include `today` and `last 24 hours` in queries. Check `publishedDate`; do not include Highlight or Watch items older than 24 hours.
+
+## Open Positions handling
+
+Open Positions combines:
+
+- Hyperliquid `positions`
+- Avantis `positions`
+- Polymarket `live`
+- Polymarket `claimable`
+
+Call `viewpolymarketpositions` with `includeLost: false` for regular `GM`, `short`, and `normal` modes. Use `includeLost: true` only in `detailed` mode or when the user explicitly asks for lost/resolved-lost Polymarket history.
+
+Polymarket `recentlyResolvedLost` is displayed only when `includeLost: true` was used and the tool actually returned it. Do not infer or backfill lost history from memory.
+
+## Leaderboard handling
+
+There is no formal Bankr Runtime leaderboard tool. Use `search_tool` to look for a public page that verifies the user's current Bankr rank. If the current rank cannot be verified, omit Leaderboard naturally. Do not use `previousLeaderboardRank` as a current rank and do not ask the user to manually enter their rank every morning.
+
+## Memory files
+
+The skill reads and writes:
+
+- `/.memory/gm-bankr-settings.json`
+- `/.memory/gm-bankr-history.json`
+
+See `references/memory-schema.md`.
+
+## Test cases
+
+### 1. Initial GM
+
+Prompt: `GM`
+
+Expected:
+
+- Creates default settings/history if missing.
+- Shows enabled sections with verified data only.
+- Uses `gettokenpriceinusd`, positions tools, and `search_tool` where enabled.
+- Omits only failed or unverified sections.
+- Includes Today's Mission with read-only actions only.
+- Ends with a disclaimer in the user's language.
+
+### 2. Two-day GM streak
+
+Setup:
+
+- `lastCheckDate` is yesterday in the user's local timezone.
+- `gmStreak` is `1`.
+
+Prompt: `GM`
+
+Expected:
+
+- Updates `gmStreak` to `2`.
+- Updates `lastCheckDate` to today.
+- Shows streak if enabled.
+
+### 3. No open positions
+
+Prompt: `GM`
+
+Expected:
+
+- If official position tools return empty results, show a short "Open Positions" line indicating no open positions.
+- Do not invent venues, sizes, PnL, entry prices, or markets.
+
+### 4. Partial tool fetch failure
+
+Setup:
+
+- `gettokenpriceinusd` succeeds.
+- Leaderboard lookup through `search_tool` or one positions venue fails.
+
+Prompt: `GM`
+
+Expected:
+
+- Shows BNKR.
+- Omits unavailable sections or venues naturally.
+- Does not display raw errors.
+
+### 5. User hides Solana
+
+Prompt: `Solanaを非表示にして。GM`
+
+Expected:
+
+- Adds `Solana` to hidden topics.
+- Excludes Solana from Highlight and Watch.
+- Still allows Bankr/Base/Robinhood Chain items when verified.
+
+### 6. Short mode
+
+Prompt: `Shortモードにして。GM`
+
+Expected:
+
+- Sets report length to `short`.
+- Outputs the smallest valid briefing, ideally one bullet per enabled available section.
+- Keeps Today's Mission to one read-only item.
+- Keeps the investment-advice disclaimer in the user's language.
+
+### 7. Leaderboard unavailable
+
+Setup:
+
+- No official leaderboard tool/source is available.
+
+Prompt: `GM`
+
+Expected:
+
+- Omits leaderboard entirely.
+- Does not say or imply a guessed rank.
+- Does not update `previousLeaderboardRank` with a guessed value.
+
+### 8. English GM
+
+Prompt: `GM`
+
+Expected:
+
+- Responds in English if the user's context is English.
+- Includes `This is not investment advice.`
+- Does not use the Japanese disclaimer unless the user is writing in Japanese.
+
+### 9. Formal runtime tools
+
+Prompt: `GM`
+
+Expected:
+
+- BNKR uses `gettokenpriceinusd` with `chain: base` and `tokenAddress: 0x22af33fe49fd1fa80c7149773dde5890d3c76f3b`.
+- Hyperliquid uses `gethyperliquidpositions`.
+- Avantis uses `getavantisopen_positions`.
+- Polymarket uses `viewpolymarketpositions` with `includeLost: false` for regular `GM`, `short`, and `normal` modes.
+- Highlight and Watch use `search_tool` queries containing `today` and `last 24 hours`.
+
+### 10. Polymarket claimable and normal lost handling
+
+Prompt: `GM`
+
+Expected:
+
+- Shows Polymarket `live` positions when present.
+- Shows Polymarket `claimable` winnings when present.
+- Does not show `recentlyResolvedLost` in normal mode.
+
+### 11. Polymarket detailed lost handling
+
+Prompt: `詳細モードにして。GM`
+
+Expected:
+
+- Uses `includeLost: true` in detailed mode.
+- Shows `recentlyResolvedLost` only when `includeLost: true` was used and the tool actually returned it.
+
+### 12. Polymarket explicit lost request
+
+Prompt: `Polymarketの負けた履歴も見せて。GM`
+
+Expected:
+
+- Uses `includeLost: true` because the user explicitly requested lost history.
+- Shows `recentlyResolvedLost` only when `includeLost: true` was used and the tool actually returned it.
+- Does not infer or backfill lost history from memory.
+
+## Bankr test prompts
+
+- `GM`
+- `Shortモードにして。GM`
+- `LeaderboardをOFFにして。GM`
+- `BNKRとStreakだけ表示して。GM`
+- `Solanaを非表示にして。GM`
+- `詳細モードにして。GM`
+- `Polymarketの負けた履歴も見せて。GM`
+- `Open PositionsをOFFにして。GM`
+
+## Skill Store pre-submit checklist
+
+- Confirm the current Bankr Skill submission format still accepts `SKILL.md` plus `references/`.
+- Confirm `search_tool` result objects expose a reliable `publishedDate` for 24-hour filtering.
+- Confirm whether `gettokenpriceinusd` or another verified source provides 24-hour BNKR change; if not, show price and confidence only.
+- Confirm the runtime allows reading/writing `/.memory/gm-bankr-settings.json` and `/.memory/gm-bankr-history.json`.
+- Confirm timezone handling for daily streaks in the Bankr host.
+- Confirm source-link rendering rules in Bankr responses.

--- a/gm-bankr-whats-up-today/SKILL.md
+++ b/gm-bankr-whats-up-today/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: gm-bankr-whats-up-today
+description: Produce a sub-30-second Bankr morning briefing when the user sends "GM" or asks "GM Bankr, what's up today?", using formal Bankr Runtime tools, saved preferences, citations, and non-advisory safety rules.
+---
+
+# GM Bankr, what's up today?
+
+## Overview
+
+Create a concise daily Bankr briefing when the user sends `GM`. Use only verified data from the formal Bankr Runtime tools listed below. Do not invent tool names, values, positions, leaderboard ranks, market data, or news.
+
+This skill is designed to become the user's daily GM habit and reduce repetitive morning checks.
+
+This MVP is text-only. Do not build a web app, iframe app, trading flow, signing flow, x402 flow, weekly report, monthly report, or Builder Score analysis.
+
+## Runtime Rules
+
+- Trigger on an exact or conversational `GM`.
+- Example conversational trigger on X: `GM @bankrbot` followed by `What's up today?`.
+- Read user memory before fetching data. See `references/memory-schema.md`.
+- Respect section toggles and hidden topics.
+- Use only formally available runtime tools. If no official tool is available for an item, omit that item naturally.
+- Never display guessed values or stale news as current.
+- Confirm each news or highlight item is from the last 24 hours before including it.
+- Include source links or source names for price, leaderboard, positions, highlight, and watch items when shown.
+- Match the disclaimer language to the user's language. Use `これは投資助言ではありません。` in Japanese and `This is not investment advice.` in English.
+- Do not execute trades, approvals, signatures, deposits, withdrawals, or orders.
+
+## Official Tool Policy
+
+Use these formal Bankr Runtime tool identifiers exactly:
+
+- BNKR price: `gettokenpriceinusd`
+  - Inputs: `chain: base`, `tokenAddress: 0x22af33fe49fd1fa80c7149773dde5890d3c76f3b`
+  - Outputs: `price`, `confidence`
+- Hyperliquid positions: `gethyperliquidpositions`
+  - Inputs: none
+  - Outputs: `positions`, `orders`
+- Avantis positions: `getavantisopen_positions`
+  - Inputs: none
+  - Outputs: `positions`
+- Polymarket positions: `viewpolymarketpositions`
+  - Inputs: `userAddress` optional, `includeLost`
+  - Outputs: `live`, `claimable`, `recentlyResolvedLost`
+- News/search: `search_tool`
+  - Inputs: `queries`, `searchType`
+  - Outputs: `results`
+
+There is no formal Bankr Runtime tool for Bankr Leaderboard. Use `search_tool` only when it can retrieve the current rank from a public page. If the current rank cannot be verified, omit Leaderboard naturally. Do not infer the current rank from memory and do not ask the user to enter their rank every morning.
+
+## Workflow
+
+1. Load memory from `/.memory/gm-bankr-settings.json` and `/.memory/gm-bankr-history.json`.
+2. Initialize missing memory with defaults from `references/memory-schema.md`.
+3. Fetch BNKR, Hyperliquid, Avantis, Polymarket, and `search_tool` data in parallel whenever the runtime allows it.
+4. Fetch BNKR with `gettokenpriceinusd` using `chain: base` and `tokenAddress: 0x22af33fe49fd1fa80c7149773dde5890d3c76f3b`.
+5. Fetch Hyperliquid with `gethyperliquidpositions`.
+6. Fetch Avantis with `getavantisopen_positions`.
+7. Fetch Polymarket with `viewpolymarketpositions`. Pass `includeLost: false` for normal `GM`, `short`, and `normal` modes. Pass `includeLost: true` only in `detailed` mode or when the user explicitly asks for lost/resolved-lost Polymarket history.
+8. Use `search_tool` for Highlight, Watch, and Leaderboard lookup. Include `today` and `last 24 hours` in the queries. Check `publishedDate` and exclude items older than 24 hours from Highlight and Watch.
+9. Apply safety and freshness rules from `references/safety-rules.md`.
+10. Choose one watch item using `references/watch-selection.md`.
+11. Create Today's Mission from safe read-only actions only.
+12. Update streak, last check date, previous leaderboard rank, and previous BNKR price after generating the briefing.
+13. Save memory back to the same user-specific files.
+14. Return a concise briefing using `references/output-format.md`.
+
+## Default Sections
+
+- Greeting: short morning greeting with the current date.
+- BNKR: current BNKR price from `gettokenpriceinusd` and confidence when available. Show 24-hour change only when the runtime data or verified source provides it.
+- Leaderboard: current Bankr leaderboard rank from public-page search via `search_tool` when verified. Omit when not verified.
+- Open Positions: combine Hyperliquid positions, Avantis positions, Polymarket live positions, and Polymarket claimable winnings when available.
+- Polymarket lost history: show `recentlyResolvedLost` only when `includeLost: true` was used and the tool actually returned it. Do not infer it from memory or prior outputs.
+- Today's Highlight: one to three important items from the last 24 hours about Bankr, Base, or Robinhood Chain.
+- Today's Watch: exactly one item from Token, Chain, Protocol, or Event. Keep it observational and non-advisory.
+- Today's Mission: one to three safe read-only actions, such as checking the latest Bankr Season update, reviewing open position risk, or researching today's Watch item.
+- GM Streak: current consecutive-day count and whether it changed today. GM Streak uses UTC day boundaries. JST users: the day changes at 9:00 AM.
+
+## Customization
+
+Support these user settings:
+
+- Leaderboard ON/OFF
+- BNKR ON/OFF
+- Open Positions ON/OFF
+- Highlight ON/OFF
+- Watch ON/OFF
+- Today's Mission ON/OFF
+- Streak ON/OFF
+- Preferred Chains
+- Hidden Topics
+- Report Length: `short`, `normal`, or `detailed`
+
+If the user changes a setting in natural language, update memory and confirm briefly. If the user only says `GM`, do not ask setup questions.
+
+## Omission Behavior
+
+If a section cannot be fetched, is disabled, is hidden by preference, or lacks credible sources, omit only that section without an error block. Keep the response natural and short. Continue showing other sections that fetched successfully. Do not show raw errors. Do not say a value is unavailable unless the user specifically asks why a section is missing.
+
+## References
+
+- Read `references/output-format.md` before composing the response.
+- Read `references/memory-schema.md` before reading or writing memory.
+- Read `references/watch-selection.md` before selecting Today's Watch.
+- Read `references/safety-rules.md` before including financial, position, news, or watch content.

--- a/gm-bankr-whats-up-today/references/memory-schema.md
+++ b/gm-bankr-whats-up-today/references/memory-schema.md
@@ -1,0 +1,63 @@
+# Memory Schema
+
+Store memory in user-specific files:
+
+- `/.memory/gm-bankr-settings.json`
+- `/.memory/gm-bankr-history.json`
+
+Create missing files with default values. Preserve unknown keys to avoid destroying future settings.
+
+## gm-bankr-settings.json
+
+```json
+{
+  "sections": {
+    "leaderboard": true,
+    "bnkr": true,
+    "openPositions": true,
+    "highlight": true,
+    "watch": true,
+    "mission": true,
+    "streak": true
+  },
+  "preferredChains": ["Base"],
+  "hiddenTopics": [],
+  "reportLength": "normal"
+}
+```
+
+## gm-bankr-history.json
+
+```json
+{
+  "lastCheckDate": null,
+  "gmStreak": 0,
+  "previousLeaderboardRank": null,
+  "previousBnkrPrice": null
+}
+```
+
+## Update rules
+
+- Treat dates as local calendar dates in the user's timezone when the runtime provides one.
+- If `lastCheckDate` is today, do not increment `gmStreak` again.
+- If `lastCheckDate` is yesterday, increment `gmStreak` by 1.
+- If `lastCheckDate` is older than yesterday or missing, set `gmStreak` to 1.
+- Update `lastCheckDate` after a `GM` response is generated.
+- Update `previousLeaderboardRank` only when a verified current rank was fetched.
+- Do not display or reuse `previousLeaderboardRank` as the current rank when the current rank could not be fetched.
+- Update `previousBnkrPrice` only when a verified current BNKR price was fetched.
+- Save changed settings before producing the response when the user combines settings changes with `GM`.
+
+## Customization mapping
+
+- "Leaderboard ON/OFF" updates `sections.leaderboard`.
+- "BNKR ON/OFF" updates `sections.bnkr`.
+- "Open Positions ON/OFF" updates `sections.openPositions`.
+- "Highlight ON/OFF" updates `sections.highlight`.
+- "Watch ON/OFF" updates `sections.watch`.
+- "Today's Mission ON/OFF" or "Mission ON/OFF" updates `sections.mission`.
+- "Streak ON/OFF" updates `sections.streak`.
+- Preferred chains update `preferredChains`.
+- Hidden or muted topics update `hiddenTopics`.
+- Short, normal, or detailed mode updates `reportLength`.

--- a/gm-bankr-whats-up-today/references/output-format.md
+++ b/gm-bankr-whats-up-today/references/output-format.md
@@ -1,0 +1,103 @@
+# Output Format
+
+Use short headings and compact bullets. The whole response should be readable in under 30 seconds.
+
+## Section order
+
+1. Greeting
+2. BNKR
+3. Leaderboard
+4. Open Positions
+5. Today's Highlight
+6. Today's Watch
+7. Today's Mission
+8. GM Streak
+9. Disclaimer
+
+## Length modes
+
+### short
+
+- Use at most one bullet per available section.
+- Prefer one-line bullets.
+- Include only one highlight and one watch item.
+- Include one mission item.
+
+### normal
+
+- Use one to two bullets per available section.
+- Include up to two highlights.
+- Include one watch item.
+- Include up to three mission items.
+
+### detailed
+
+- Use up to three bullets per available section.
+- Include up to three highlights.
+- Include one watch item with slightly more context.
+- Include up to three mission items.
+
+## Required style
+
+- Use Japanese when the user writes Japanese; otherwise match the user's language.
+- Keep headings plain and scannable.
+- Cite sources inline with short source labels or links.
+- Do not show raw tool errors.
+- Do not include unavailable sections.
+- If one fetch fails, omit only that section and keep successful sections.
+- Match the disclaimer language to the user's language.
+- Japanese disclaimer: `これは投資助言ではありません。`
+- English disclaimer: `This is not investment advice.`
+
+## Today's Mission rules
+
+- Include read-only actions only.
+- Do not auto-execute mission items.
+- Do not ask the user to buy, sell, claim, mint, bridge, sign, approve, deposit, withdraw, or place an order.
+- Do not recommend buying, selling, or using leverage.
+- Prefer concrete checks based on shown sections: Bankr Season/update check, open position risk review, source review for Highlight, research for Watch.
+- If no verified data is available, use a generic safe mission such as checking official Bankr updates.
+
+## Open Positions rules
+
+- Combine Hyperliquid `positions`, Avantis `positions`, Polymarket `live`, and Polymarket `claimable`.
+- Show Polymarket claimable winnings as a read-only status item.
+- For regular `GM`, `short`, and `normal` modes, Polymarket must be fetched with `includeLost: false`.
+- For `detailed` mode or when the user explicitly asks for lost/resolved-lost Polymarket history, Polymarket may be fetched with `includeLost: true`.
+- Show Polymarket `recentlyResolvedLost` only when `includeLost: true` was used and the tool actually returned it.
+- Do not infer `recentlyResolvedLost` from memory or previous outputs.
+
+## Example skeleton
+
+```text
+GM. 今日のBankrチェックです。
+
+BNKR
+- $BNKR: $0.00000000, 24h +0.0%（Source）
+
+Leaderboard
+- Rank: #000（前回 #000）
+
+Open Positions
+- Hyperliquid: BTC long, size, PnL（Source）
+- Avantis: open positionsなし（Source）
+- Polymarket: live positions / claimable winnings（Source）
+
+Today's Highlight
+- Bankr/Base/Robinhood Chainの24時間以内の重要情報（Source）
+
+Today's Watch
+- Protocol: 観察ポイント。売買推奨ではありません。（Source）
+
+Today's Mission
+- 最新のBankr Season/updateを確認
+- Open Positionsのリスクを確認
+- Today's Watchの根拠を読む
+
+GM Streak
+- 2日連続GM。
+
+これは投資助言ではありません。
+```
+
+Use the skeleton only as a shape. Do not include placeholder values.

--- a/gm-bankr-whats-up-today/references/safety-rules.md
+++ b/gm-bankr-whats-up-today/references/safety-rules.md
@@ -1,0 +1,52 @@
+# Safety Rules
+
+## Data integrity
+
+- Do not guess values.
+- Do not backfill missing data from memory as if it is current.
+- Do not show stale prices, positions, ranks, or news as current.
+- Confirm news and highlight items are from the last 24 hours.
+- For `search_tool`, include `today` and `last 24 hours` in queries and check `publishedDate`.
+- Exclude Highlight and Watch items when `publishedDate` is missing or older than 24 hours, unless the item is an official future event announcement that was published in the last 24 hours.
+- Cite a source for every included market, rank, position, highlight, or watch item.
+- Prefer sources for Today's Highlight and Today's Watch in this order: official announcements/docs/X from Bankr, Robinhood, Base, or the target project; on-chain data, official dashboards, or trusted primary data; reputable major media; then other secondary sources.
+- Use YouTube, unknown blogs, or unclear-origin posts only when no stronger source exists.
+- Verify strong numeric or important claims with primary data or multiple trusted sources whenever possible.
+- Do not state uncertain numbers, ranks, TVL, volume, or transaction counts as definitive. Use cautious wording such as `approximately`, `reportedly`, `at the time of checking`, `according to available data`, `一部報道では`, `約`, or `確認時点では` when verification is incomplete.
+- If a number cannot be verified, omit it instead of filling the gap.
+- Update `previousLeaderboardRank` only when a current rank was verified through `search_tool`.
+
+## Financial safety
+
+- Always include an investment-advice disclaimer in the user's language.
+- Japanese: `これは投資助言ではありません。`
+- English: `This is not investment advice.`
+- Do not provide investment advice.
+- Do not recommend buying, selling, holding, leverage, specific position sizing, or portfolio allocation.
+- Do not auto-execute trades.
+- Do not auto-sign transactions.
+- Do not request approvals, deposits, withdrawals, mints, claims, or bridging actions.
+- Do not present Watch as a trade signal.
+- Do not present Today's Mission as a trading instruction.
+- Today's Mission must contain only read-only checks or research tasks.
+- Polymarket claimable winnings may be displayed as status, but do not instruct the user to claim unless they explicitly ask about claiming.
+- Fetch Polymarket with `includeLost: false` for regular `GM`, `short`, and `normal` modes.
+- Fetch Polymarket with `includeLost: true` only in `detailed` mode or when the user explicitly asks for lost/resolved-lost Polymarket history.
+- Show Polymarket `recentlyResolvedLost` only when `includeLost: true` was used and the tool actually returned it. Do not infer or backfill it from memory.
+
+## Scam and low-quality filtering
+
+Exclude Watch candidates that are:
+
+- Low-liquidity or newly created tokens without credible context
+- Obvious scams, impersonations, or phishing-adjacent links
+- Based only on unverified rumors
+- Driven mainly by promotional language
+- Unsupported by reputable or official sources
+
+## Error handling
+
+- Omit unavailable sections naturally.
+- Do not show stack traces, raw API errors, or internal tool failures.
+- If the user asks why a section is missing, explain that no official verified source/tool was available for that item.
+- If one formal tool fails, omit only that section and still display data from successful tools.

--- a/gm-bankr-whats-up-today/references/watch-selection.md
+++ b/gm-bankr-whats-up-today/references/watch-selection.md
@@ -1,0 +1,61 @@
+# Watch Selection
+
+Select exactly one Today's Watch item when the Watch section is enabled and a credible item exists.
+
+## Allowed categories
+
+- Token
+- Chain
+- Protocol
+- Event
+
+## Selection rules
+
+1. Prefer items related to the user's preferred chains.
+2. Exclude hidden topics.
+3. Require a credible source.
+4. Use `search_tool` queries that include `today` and `last 24 hours`.
+5. Require `publishedDate` and include only items published in the last 24 hours.
+6. Prefer Bankr, Base, and Robinhood Chain relevance when quality is similar.
+7. Avoid low-liquidity tokens, obvious scams, thinly sourced rumors, paid-looking shills, and unverifiable claims.
+8. Choose only one item.
+
+## Source priority
+
+Prefer sources for Today's Highlight and Today's Watch in this order:
+
+1. Official announcements, official docs, or official X posts from Bankr, Robinhood, Base, or the target project
+2. On-chain data, official dashboards, or trusted primary data
+3. Reputable major media
+4. Other secondary sources
+
+Use YouTube, unknown blogs, or unclear-origin posts only when no stronger source exists. Verify strong numeric or important claims with primary data or multiple trusted sources whenever possible.
+
+## Highlight vs Watch
+
+- Today's Highlight explains what happened in the last 24 hours as concise facts or news.
+- Today's Watch explains what to observe next because of that news, such as continuity, risk, or change points.
+- The same theme may appear in both sections when it is important, including repeated Robinhood Chain coverage across days, but the roles must remain distinct.
+- Write Watch as an observation point, not an investment recommendation.
+- For uncertain numbers, use cautious wording such as `approximately`, `reportedly`, `at the time of checking`, `according to available data`, `一部報道では`, `約`, or `確認時点では`. Omit numbers that cannot be verified.
+
+## Language rules
+
+- Describe why the item is worth watching.
+- Keep the phrasing observational.
+- Do not tell the user to buy, sell, hold, enter, exit, lever, bridge, claim, mint, or sign.
+- Do not include price targets.
+- Do not include personalized portfolio advice.
+
+## Acceptable watch examples
+
+- `Protocol: A Base protocol shipped a verified upgrade today; watch whether usage or liquidity changes.`
+- `Event: A Bankr-related announcement is scheduled today; watch for confirmed details from official channels.`
+- `Chain: Base network activity changed meaningfully in the last 24 hours; watch whether it persists.`
+
+## Rejected watch examples
+
+- `Buy this token before it pumps.`
+- `This low-cap token is about to 100x.`
+- `Use leverage on this setup.`
+- `Mint/sign now before you miss it.`


### PR DESCRIPTION
## Summary

This PR adds **GM Bankr – What's Up Today?**, a daily Bankr briefing skill for Telegram.

The goal is to give users a quick morning overview by simply saying **GM**.

## Features

- Daily GM briefing
- BNKR price
- Open Positions summary
- Today's Highlight
- Today's Watch
- Today's Mission
- GM Streak tracking
- Multi-language output
- UTC-based streak tracking
- Source prioritization for higher information quality
- Cautious wording for uncertain market data
- Clear separation between Highlight and Watch

## Testing

The skill was tested through daily use on Telegram.

Verified behavior includes:

- Same-day reruns do not increase the streak
- The streak increases on the next UTC day
- JST users change to the next streak day at 9:00 AM
- BNKR price and open positions are retrieved
- Highlight, Watch, and Mission sections are generated
- Information quality and source-priority rules are applied

## Notes

X responses were inconsistent during testing, but the skill works reliably on Telegram.

Feedback is welcome.