### PR TITLE
Add hoodrunner-stash skill

### DIFF
--- a/hoodrunner-stash/SKILL.md
+++ b/hoodrunner-stash/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: hoodrunner-stash
+description: Wrap tokens into a Stash — an NFT that holds a basket of assets in its own account on Robinhood Chain. Create, fund, gift, nest, read (NAV), and unwrap Stashes. Run branded drops for a community. Trade a whole basket as one object; unwrap it natively. Built on ERC-6551 token-bound accounts; non-custodial.
+metadata:
+  {
+    "clawdbot": {
+      "emoji": "🏃",
+      "homepage": "https://hoodrunner.net",
+      "requires": { "bins": ["bankr"] },
+    },
+  }
+---
+
+# HoodRunner Stash
+
+Turn tokens into a **Stash**: one NFT whose own account (ERC-6551) holds a basket of assets. Trade
+the whole bag as a single object, gift it to someone, nest it inside another Stash, or unwrap it and
+take the tokens natively. Nothing is pooled — each Stash is its own holder-controlled vault, so its
+floor *is* its contents. HoodRunner is the courier; this skill is how you tell it to run a drop.
+
+This skill drives on-chain actions through the **Bankr Wallet API** (transaction signing +
+submission), so any agent with a Bankr key can create and deliver Stashes on Robinhood Chain.
+
+## What it does
+- **wrap** — mint a new Stash NFT + create its bound account (pay a flat wrap fee).
+- **fund** — send any tokens into a Stash's account (self-directed; you choose the contents).
+- **nav** — read a Stash's contents and total value (public, no key needed).
+- **gift** — deliver a Stash to a person (resolve @social handle → address) — the courier's drop.
+- **nest** — put a Stash (or NFT/tokens) inside another Stash's account.
+- **unwrap** — the current holder sweeps the contents out to their wallet.
+- **drop** — batch-wrap + gift many Stashes for a community (the B2B launch/loyalty use case).
+
+## Setup
+1. **Get a Bankr API key** (`bk_...`) with `walletApiEnabled`. See the base `bankr` skill for the
+   headless-email or web-terminal flow. Read-only keys can call `nav` but not wrap/gift/unwrap.
+2. **Point at Robinhood Chain** (chain id `4663`; testnet `46630`). Bankr natively supports RHC.
+3. **Contract addresses** — see [references/stash-contracts.md](references/stash-contracts.md). The
+   ERC-6551 registry is already live on RHC; the Stash collection, account implementation, and the
+   fee entrypoint are HoodRunner-deployed (addresses in the reference; testnet first).
+
+> **Non-custodial.** This skill only builds transactions your own wallet signs and submits via
+> Bankr. HoodRunner never holds your assets — they live in each Stash's own account, which only the
+> NFT holder controls.
+
+## Actions → transactions
+
+Each action is one or more transactions submitted through the Bankr Wallet API (`POST /wallet/tx`
+with signed calldata). Full ABIs, selectors, and encodings are in
+[references/stash-contracts.md](references/stash-contracts.md); a helper that computes the
+deterministic account address and encodes calldata is in [scripts/stash.mjs](scripts/stash.mjs).
+
+| Action | Call(s) | Notes |
+| --- | --- | --- |
+| wrap | `StashMint.wrap()` payable (flat fee) | Mints the NFT + creates its 6551 account atomically. Returns `(tokenId, account)`. |
+| fund | `token.transfer(account, amount)` per asset | Self-directed — send whatever you want into the Stash's account. |
+| nav | read `token.balanceOf(account)` per asset | Account address is deterministic — computable before it exists. |
+| gift | `Stash.transferFrom(holder, recipient, tokenId)` | Resolve `@handle` → address via Bankr first. Basket moves with the NFT; zero token transfers. |
+| nest | `Stash.transferFrom(holder, outerAccount, innerId)` | Outer account owns the inner Stash NFT → controls it recursively. |
+| unwrap | `account.execute(token, 0, transfer(holder, bal), 0)` per asset | Only the current NFT holder can execute; ex-owners cannot drain a sold Stash. |
+
+### The deterministic account (why pre-funding works)
+A Stash's account address is derived from `(implementation, salt, chainId, collection, tokenId)` via
+the registry `account(...)` view — it's known **before** the account is created, so a drop can fund a
+Stash ahead of delivery. `createAccount(...)` with the same args then deploys it (idempotent).
+
+## Supported chains
+| Chain | Chain ID | 6551 registry | Notes |
+| --- | --- | --- | --- |
+| Robinhood Chain | 4663 | ✅ live (`0x0000…5758`) | Primary. Memecoins + freely-transferable ERC-20s. |
+| Robinhood Chain testnet | 46630 | ✅ live | Proof-of-concept + dry runs. |
+
+> **Contents rule:** Stash freely-transferable ERC-20s only. **Do not** wrap ERC-8056 tokenized
+> stocks — their KYC/transfer restrictions break a tradeable, anonymous NFT.
+
+## Fees & monetization
+- **Flat wrap fee** — a per-action fee (not a % of contents) collected on-chain by the fee
+  entrypoint. Set on `StashMint`; goes to the HoodRunner treasury.
+- **Gift / drop fee** — flat fee to create a gifted drop (the courier running it for you).
+- **x402** — the hosted `drop` endpoint (batch drops for a community) is priced via x402, so
+  agents auto-pay per run. See [references/monetization.md](references/monetization.md).
+- **$HOODRUNNER** — pay any fee in $HOODRUNNER for a discount; collected fees fund a buyback. Utility
+  + medium-of-exchange only — never staking-for-yield, never "buy to earn."
+
+## Safety & access control
+- **Non-custodial** — assets live in the Stash's own account; only the holder's signature moves them.
+- **Unbypassable fee** — minting is locked to the paid entrypoint (`minter` gate on the collection).
+- **No back-door** — a sold Stash cannot be drained by its previous owner (enforced in `execute`).
+- **Read-only keys** — restrict an agent to `nav` (no wrap/gift/unwrap) with a read-only `bk_` key.
+- **Self-directed** — the caller chooses the contents; HoodRunner does not curate a basket for you.
+
+## Prompt examples
+- "Wrap 100 BRODIE, 50 VANE and 25 DASH into a Stash." → wrap → fund
+- "What's in Stash #42 and what's it worth?" → nav
+- "Gift Stash #42 to @friend." → resolve handle → gift
+- "Put Stash #42 inside Stash #7." → nest
+- "Unwrap Stash #42 into my wallet." → unwrap
+- "Run a drop: wrap 200 GREENLIGHT each into 50 Stashes and gift them to this list." → drop
+
+## Resources
+- Site: https://hoodrunner.net
+- Contracts + ABIs: [references/stash-contracts.md](references/stash-contracts.md)
+- Monetization detail: [references/monetization.md](references/monetization.md)
+- Helper (address derivation + calldata): [scripts/stash.mjs](scripts/stash.mjs)
+- Base Bankr skill (key setup, Wallet API): the `bankr` skill in this directory.

--- a/hoodrunner-stash/catalog.json
+++ b/hoodrunner-stash/catalog.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "slug": "hoodrunner-stash",
+  "provider": "HoodRunner",
+  "providerUrl": "https://hoodrunner.net",
+  "logo": "logo.svg",
+  "demo": {
+    "title": "stash.mjs — derive account + encode unwrap",
+    "language": "bash",
+    "code": "# Derive a Stash's token-bound account address (Robinhood Chain)\nACCOUNT_IMPL=0xf7D4E66eA5b88B62a4aEb1E531e483B947B6151D \\\n  node hoodrunner-stash/scripts/stash.mjs account \\\n  0xA5718a030bd9dC18EB0b23B5409D86AA66A11944 1\n\n# Encode an unwrap: holder sweeps a token out of the Stash's account\nnode hoodrunner-stash/scripts/stash.mjs unwrap <account> <token> <amount>\n\n# Hand the encoded calldata to the Bankr Wallet API to sign + submit"
+  },
+  "setup": [
+    "Get a Bankr API key (bk_...) with walletApiEnabled — see the base `bankr` skill. Read-only keys can call `nav`.",
+    "Target Robinhood Chain (chain id 4663) — Bankr supports RHC natively.",
+    "Contracts are live on RHC mainnet (addresses in references/stash-contracts.md); `npm i viem` to run scripts/stash.mjs."
+  ],
+  "install": {
+    "type": "bankr",
+    "repoPath": "hoodrunner-stash",
+    "command": "install the hoodrunner-stash skill from https://github.com/BankrBot/skills/tree/main/hoodrunner-stash"
+  }
+}

--- a/hoodrunner-stash/logo.svg
+++ b/hoodrunner-stash/logo.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128" role="img" aria-label="HoodRunner Stash">
+  <rect width="128" height="128" rx="26" fill="#05070A"/>
+  <!-- parcel / stash -->
+  <g fill="none" stroke="#9EF01A" stroke-width="6" stroke-linejoin="round" stroke-linecap="round">
+    <path d="M30 50 L64 34 L98 50 L98 88 L64 104 L30 88 Z"/>
+    <path d="M30 50 L64 66 L98 50"/>
+    <path d="M64 66 L64 104"/>
+  </g>
+  <!-- speed slashes -->
+  <g stroke="#22E4DA" stroke-width="5" stroke-linecap="round" opacity="0.85">
+    <path d="M12 58 L26 58"/>
+    <path d="M8 72 L24 72"/>
+    <path d="M12 86 L26 86"/>
+  </g>
+  <!-- glowing eyes in the fold -->
+  <g fill="#9EF01A">
+    <circle cx="55" cy="55" r="3.4"/>
+    <circle cx="73" cy="55" r="3.4"/>
+  </g>
+</svg>

--- a/hoodrunner-stash/references/monetization.md
+++ b/hoodrunner-stash/references/monetization.md
@@ -1,0 +1,36 @@
+# Stash monetization
+
+You sell software **actions** (wrap / gift / unwrap / route), not assets — cleaner than a fund taking
+a cut, and it fits an agent surface (get paid per call).
+
+## Fee surfaces
+| Fee | Where | Shape | Notes |
+| --- | --- | --- | --- |
+| Wrap | `StashMint.wrap()` on-chain | FLAT (e.g. ~$1–2 equiv) | Per-action, **not** a % of contents (a % reads like a load/AUM). Unbypassable. |
+| Gift / drop | hosted endpoint or on-chain | FLAT per gift | The courier running the drop for you. |
+| Routing spread | pay-with-anything swap | small % à la 0x/1inch | **Only** when paying in an arbitrary token. MT-flagged — ship after the swap rail. |
+| Resale royalty | EIP-2981 on the collection | ~2.5% | Passive, standard, on secondary Stash trades. |
+| Premium | hold-to-unlock | — | Nesting, gift-by-QR links, rare art variants, batch drops. |
+
+## x402 (the native "get paid per call" rail)
+Expose the batch **`drop`** endpoint (wrap + gift N Stashes for a community) as an x402-priced API.
+Agents auto-pay per run — this is how the *skill* earns directly, without a web app checkout. Price
+per drop or per Stash.
+
+## $HOODRUNNER (Howey-safe hooks only)
+1. **Pay any fee in $HOODRUNNER → discount** (buy-pressure ∝ usage; pure medium-of-exchange).
+2. **Fees fund a buyback** (revenue, not inflation; keeps it trading without a dump).
+3. **Hold-to-unlock** premium features (utility gating).
+**Never:** staking-for-fee-share, inflationary rewards, or "buy the token to earn."
+
+## Who pays (the go-to-market)
+- **Retail (weak at current scale):** individuals wrap/gift for themselves; the loop is gift-by-QR.
+- **B2B drops (the thesis):** a project/community/creator pays HoodRunner to run a **branded drop**
+  to their holders (launch/loyalty/reward). Marketing budget buying a service, not retail buying a
+  security → sidesteps Howey and is where intentful money lives. **This is the line to sell**, and
+  the Bankr skill + x402 is the delivery mechanism.
+
+## Legal one-liner
+Self-directed (buyer/creator picks contents) + non-custodial + flat per-action fees + no
+performance/return claims = a tool, not a fund. The money-transmission edge lives on the swap, not
+the wrap. Testnet is not the regulated act; counsel before real money on mainnet.

--- a/hoodrunner-stash/references/stash-contracts.md
+++ b/hoodrunner-stash/references/stash-contracts.md
@@ -1,0 +1,63 @@
+# Stash contracts — addresses, ABIs, encodings
+
+## Addresses
+| Contract | RHC mainnet (4663) |
+| --- | --- |
+| ERC-6551 registry | `0x000000006551c19487814612e58FE06813775758` ✅ live (canonical) |
+| Stash account impl | `0xf7D4E66eA5b88B62a4aEb1E531e483B947B6151D` ✅ deployed |
+| Stash collection (ERC-721 "STASH") | `0xA5718a030bd9dC18EB0b23B5409D86AA66A11944` ✅ deployed |
+| StashMint (fee entrypoint) | `0xc6083Ffb885777cF8e80834E78346F726E825F9E` ✅ deployed |
+
+> **Deployed to RHC mainnet 2026-07-20.** `SALT` = `0x00…00` (bytes32 zero). `feeRecipient` =
+> `0xE852823A8daE6418Ad07A3E62F0bdac7fA665d4a`; `wrapFee` = 0 (free mints until priced via
+> `setWrapFee`). `owner` (setMinter/setWrapFee/setFeeRecipient) = the deployer
+> `0xE852823A8daE6418Ad07A3E62F0bdac7fA665d4a`. Verified on-chain: `collection.minter` = StashMint
+> (minting locked to the paid entrypoint; a direct `mint()` reverts `not minter`).
+
+## Registry — deterministic account
+```solidity
+// view: address is known before the account exists (pre-funding)
+function account(address implementation, bytes32 salt, uint256 chainId,
+                 address tokenContract, uint256 tokenId) external view returns (address);
+// deploy the account (idempotent for the same args)
+function createAccount(address implementation, bytes32 salt, uint256 chainId,
+                       address tokenContract, uint256 tokenId) external returns (address);
+```
+
+## StashMint — the paid wrap entrypoint
+```solidity
+function wrap() external payable returns (uint256 tokenId, address account); // requires msg.value >= wrapFee
+function wrapFee() external view returns (uint256);
+function feeRecipient() external view returns (address);
+```
+`wrap()` collects the flat fee, mints the Stash to `msg.sender`, creates its account, refunds any
+overpayment, emits `Wrapped(to, tokenId, account, fee)`. Minting is locked to this contract, so the
+fee cannot be bypassed.
+
+## Stash account — hold & unwrap
+```solidity
+function token() external view returns (uint256 chainId, address tokenContract, uint256 tokenId);
+function owner() external view returns (address); // = ownerOf(the Stash NFT)
+// only the current NFT holder may call; this is how unwrap + nested control happen
+function execute(address to, uint256 value, bytes calldata data, uint8 operation)
+    external payable returns (bytes memory);
+```
+
+## Encodings (viem-style)
+```
+wrap:    StashMint.wrap()                        value = wrapFee
+fund:    erc20.transfer(account, amount)         // one per constituent
+gift:    Stash.transferFrom(holder, to, tokenId)
+nest:    Stash.transferFrom(holder, outerAccount, innerTokenId)
+unwrap:  account.execute(erc20, 0,
+             erc20.transfer(holder, balanceOf(account)), 0)   // one per constituent
+nested:  outerAccount.execute(innerAccount, 0,
+             innerAccount.execute(erc20, 0, erc20.transfer(holder, bal), 0), 0)
+```
+
+## Bankr Wallet API
+Submit each encoded tx via the Bankr Wallet API (`/wallet/*`, direct signing + submission). Resolve
+`@social` recipients to addresses with Bankr's handle resolution before `gift`. Use a read-only
+`bk_` key to expose only `nav`.
+
+All ABIs/selectors are in the Foundry project (`out/*.json`) and the source under `src/`.

--- a/hoodrunner-stash/scripts/stash.mjs
+++ b/hoodrunner-stash/scripts/stash.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// Helper for the HoodRunner Stash skill: derive a Stash's deterministic account
+// address and encode calldata for each action. Read-only (no signing) — hand the
+// encoded calldata to the Bankr Wallet API to submit.
+//
+//   npm i viem
+//   node stash.mjs account   <collection> <tokenId>
+//   node stash.mjs unwrap    <account> <token> <amount>
+//   node stash.mjs gift      <holder> <to> <tokenId>
+//
+// Env: RPC_URL (default RHC testnet), ACCOUNT_IMPL, SALT (default 0x00..00).
+
+import { createPublicClient, http, encodeFunctionData, getAddress } from "viem";
+
+const REGISTRY = "0x000000006551c19487814612e58FE06813775758";
+const SALT = process.env.SALT || `0x${"0".repeat(64)}`;
+const RPC_URL = process.env.RPC_URL || "https://rpc.testnet.chain.robinhood.com";
+const ACCOUNT_IMPL = process.env.ACCOUNT_IMPL; // Stash account implementation
+
+const registryAbi = [{
+  type: "function", name: "account", stateMutability: "view",
+  inputs: [
+    { name: "implementation", type: "address" }, { name: "salt", type: "bytes32" },
+    { name: "chainId", type: "uint256" }, { name: "tokenContract", type: "address" },
+    { name: "tokenId", type: "uint256" },
+  ],
+  outputs: [{ type: "address" }],
+}];
+const erc20Abi = [{ type: "function", name: "transfer", stateMutability: "nonpayable",
+  inputs: [{ name: "to", type: "address" }, { name: "amount", type: "uint256" }], outputs: [{ type: "bool" }] }];
+const stashAbi = [{ type: "function", name: "transferFrom", stateMutability: "nonpayable",
+  inputs: [{ name: "from", type: "address" }, { name: "to", type: "address" }, { name: "id", type: "uint256" }], outputs: [] }];
+const accountAbi = [{ type: "function", name: "execute", stateMutability: "payable",
+  inputs: [{ name: "to", type: "address" }, { name: "value", type: "uint256" }, { name: "data", type: "bytes" }, { name: "operation", type: "uint8" }], outputs: [{ type: "bytes" }] }];
+
+const client = createPublicClient({ transport: http(RPC_URL) });
+
+async function accountAddress(collection, tokenId) {
+  if (!ACCOUNT_IMPL) throw new Error("set ACCOUNT_IMPL to the deployed Stash account implementation");
+  return client.readContract({
+    address: REGISTRY, abi: registryAbi, functionName: "account",
+    args: [getAddress(ACCOUNT_IMPL), SALT, BigInt((await client.getChainId())), getAddress(collection), BigInt(tokenId)],
+  });
+}
+
+const [cmd, ...a] = process.argv.slice(2);
+switch (cmd) {
+  case "account": {
+    console.log(await accountAddress(a[0], a[1]));
+    break;
+  }
+  case "unwrap": {
+    const [account, token, amount] = a;
+    const inner = encodeFunctionData({ abi: erc20Abi, functionName: "transfer", args: [getAddress(account), BigInt(amount)] });
+    const data = encodeFunctionData({ abi: accountAbi, functionName: "execute", args: [getAddress(token), 0n, inner, 0] });
+    console.log(JSON.stringify({ to: getAddress(account), value: "0", data }, null, 2));
+    break;
+  }
+  case "gift": {
+    const [holder, to, tokenId] = a;
+    const data = encodeFunctionData({ abi: stashAbi, functionName: "transferFrom", args: [getAddress(holder), getAddress(to), BigInt(tokenId)] });
+    console.log(JSON.stringify({ to: "<STASH_COLLECTION>", value: "0", data }, null, 2));
+    break;
+  }
+  default:
+    console.log("usage: account|unwrap|gift  (see header)");
+}


### PR DESCRIPTION
## hoodrunner-stash

Wrap tokens into a **Stash** — an NFT that holds a basket of assets in its own account (ERC-6551 token-bound account) on **Robinhood Chain**. Trade the whole basket as one object, gift it, nest it, or unwrap it natively. Non-custodial: each Stash is its own holder-controlled vault, so its floor is its contents.

### Actions
`wrap` · `fund` · `nav` · `gift` · `nest` · `unwrap` · `drop` (batch wrap + gift for a community launch/loyalty moment)

Each maps to a transaction submitted through the Bankr Wallet API. Read-only keys can call `nav`.

### Live on Robinhood Chain (chain 4663)
- StashAccount impl: `0xf7D4E66eA5b88B62a4aEb1E531e483B947B6151D`
- Stash721 ("STASH"): `0xA5718a030bd9dC18EB0b23B5409D86AA66A11944`
- StashMint (fee entrypoint): `0xc6083Ffb885777cF8e80834E78346F726E825F9E`
- ERC-6551 registry (canonical): `0x000000006551c19487814612e58FE06813775758`

### Contents
- `SKILL.md` — actions, Wallet-API transaction table, chains, fees, safety, prompt examples
- `catalog.json` — Discover manifest (`slug: hoodrunner-stash`)
- `references/` — contract addresses/ABIs/encodings + monetization
- `scripts/stash.mjs` — derive the token-bound account address + encode calldata (`npm i viem`)

Minting is locked to the paid entrypoint; the fee is flat (currently 0) and per-action, not a percentage of contents.
