### PR TITLE
docs(bankr): weekly skill refresh — Claude Code launcher alias, latest gateway models, wallet-API swap coverage

### DIFF
--- a/bankr/SKILL.md
+++ b/bankr/SKILL.md
@@ -421,6 +421,12 @@ Environment variables override config file values. Config file values override d
 | `bankr llm setup claude` | Show Claude Code environment setup |
 | `bankr llm setup cursor` | Show Cursor IDE setup instructions |
 | `bankr llm claude [args...]` | Launch Claude Code via the Bankr LLM Gateway |
+| `bankr claude [args...]` | Top-level alias for `bankr llm claude` |
+| `bankr llm opencode [args...]` | Launch OpenCode via the Bankr LLM Gateway |
+
+On the launcher commands (`bankr claude`, `bankr llm claude`, `bankr llm opencode`) all arguments — including `-h` / `--help` — are forwarded to the spawned tool, and a help run doesn't require authentication. Use `bankr --help` / `bankr llm --help` for the Bankr CLI's own help. Named commands also take precedence over the prompt fallthrough, so `bankr claude ...` launches Claude Code instead of prompting the agent; use `bankr agent "..."` when a prompt starts with a command name.
+
+The `bankr claude` alias and the `--help` passthrough require **@bankr/cli 0.3.18+**; on older versions use `bankr llm claude`.
 
 ## Core Usage
 
@@ -500,6 +506,7 @@ The [Bankr LLM Gateway](https://docs.bankr.bot/llm-gateway/overview) is a unifie
 - **New accounts start with $0 LLM credits** — top up via `bankr llm credits add 25` or at [bankr.bot/llm?tab=credits](https://bankr.bot/llm?tab=credits) before making any LLM calls, or you will get a 402 error
 - Check credits: `bankr llm credits` | Top up: `bankr llm credits add <amount>` | Auto top-up: `bankr llm credits auto --enable --amount 25 --tokens USDC`
 - In OpenClaw config, prefix model IDs with `bankr/` (e.g. `bankr/claude-sonnet-5`). In direct API calls, use bare IDs (e.g. `claude-sonnet-5`). Run `bankr llm models` for the current model list
+- **Claude Code's `[1m]` context-tier suffix is optional through the gateway** — it's stripped before model lookup and the 1M window comes from the model's own context window, so `claude-opus-5` and `claude-opus-5[1m]` behave identically. If you do use it, quote it (`--model "claude-opus-5[1m]"`) — in zsh it's a glob character class and the command aborts before the CLI runs
 - **Per-model discounts** available for Bankr Club members and partners — applied automatically at billing time
 - **Image generation**: generate images via the OpenAI-native `/v1/images/generations` endpoint (model `gpt-image-2`), billed from the same LLM credit balance — see the reference
 - **Expiring credit grants**: promotional or developer grants may carry an expiry date. Your spendable balance is your permanent (purchased) credits plus any unexpired grants — grants are spent first (soonest-expiring first) and drop off automatically at expiry
@@ -515,7 +522,9 @@ bankr llm credits add 25 --token ETH       # Native token; auto-swapped on its c
 bankr llm credits auto --enable --amount 25 --tokens USDC,USDT  # Multi-chain auto top-up
 bankr llm setup openclaw --install         # Install Bankr provider into OpenClaw
 bankr llm setup claude                     # Print Claude Code env vars
-bankr llm claude                           # Launch Claude Code through gateway
+bankr claude                               # Launch Claude Code through gateway
+bankr claude --model claude-opus-5         # Any tool flags are forwarded
+bankr llm opencode                         # Launch OpenCode through gateway
 ```
 
 ### Agent Credit Top-Up
@@ -561,6 +570,7 @@ For full details — setup paths, model list, provider config, SDK examples, key
 - Track holdings by token or chain
 - Real-time price updates
 - Multi-chain aggregation
+- Wrapping/unwrapping the native token (ETH ↔ WETH and equivalents) is reflected in both balances right away
 - Filter by chain: `bankr wallet portfolio --chain base,solana` or `GET /wallet/portfolio?chains=base,solana`
 
 **Reference**: [references/portfolio.md](references/portfolio.md)
@@ -1072,6 +1082,12 @@ curl -X POST "https://api.bankr.bot/wallet/transfer" \
 
 Swap tokens via CLI or Wallet API without AI processing. The **CLI** (`bankr wallet swap`) executes **same-chain EVM** swaps only. The **Wallet API** (`/wallet/swap`, `/wallet/swap-quote`) also handles **cross-chain and Solana** legs: same-chain EVM stays on the fast direct path, while cross-chain or any Solana leg routes through Relay behind the same endpoints. The CLI resolves token symbols to contracts and uses the quote's `minBuyAmount` as slippage protection when executing.
 
+Venue selection is automatic and the Wallet API now covers the same edge cases the agent does — you don't pick a route:
+
+- **Brand-new Solana tokens** still on their Raydium LaunchLab bonding curve fall back to the curve when no aggregator route exists yet, instead of failing with "no route"
+- **Polygon `pUSD` ↔ `USDC.e`** uses the 1:1 on-chain unwrap rather than a DEX quote (`pUSD` isn't reliably DEX-routable)
+- **Robinhood Chain tokenized stocks** are routed to a venue that quotes them, while ordinary Robinhood Chain pairs keep their thin-pool protection
+
 ```bash
 # CLI — quote only (no execution)
 bankr wallet swap --from ETH --to USDC --amount 0.1 --chain base --quote-only
@@ -1195,7 +1211,7 @@ See [references/error-handling.md](references/error-handling.md) for comprehensi
 
 ---
 
-**Pro Tip**: The most common issue is not specifying the chain for tokens. When in doubt, always include "on Base" or "on Ethereum" in your prompt.
+**Pro Tip**: The most common issue is not specifying the chain for tokens. When in doubt, always include "on Base" or "on Ethereum" in your prompt — or paste the contract address, which Bankr verifies against the chain that actually hosts it.
 
 **Security**: Keep your API key private. Never commit your config file to version control. Only trade amounts you can afford to lose.
 

--- a/bankr/references/llm-gateway.md
+++ b/bankr/references/llm-gateway.md
@@ -41,12 +41,14 @@ bankr config get llmKey
 | Model | Provider | Best For |
 |-------|----------|----------|
 | `claude-fable-5` | Anthropic | Latest generation, agentic + multimodal (1M context, image input) |
-| `claude-opus-4.8` | Anthropic | Latest, most capable reasoning (1M context) |
+| `claude-opus-5` | Anthropic | Latest Opus, most capable reasoning (1M context, image input) |
+| `claude-opus-4.8` | Anthropic | Previous flagship Opus (1M context) |
 | `claude-opus-4.7` | Anthropic | Advanced reasoning (1M context) |
 | `claude-opus-4.6` | Anthropic | Advanced reasoning (1M context) |
 | `claude-opus-4.5` | Anthropic | Complex reasoning (200K context) |
-| `claude-sonnet-4.6` | Anthropic | Balanced speed and quality (1M context) |
-| `claude-sonnet-4.5` | Anthropic | Previous generation Sonnet (1M context) |
+| `claude-sonnet-5` | Anthropic | Latest Sonnet, balanced speed and quality (1M context, image input) |
+| `claude-sonnet-4.6` | Anthropic | Previous generation Sonnet (1M context) |
+| `claude-sonnet-4.5` | Anthropic | Earlier Sonnet (1M context) |
 | `claude-haiku-4.5` | Anthropic | Fast, cost-effective (200K context) |
 | `gemini-3.5-flash` | Google | Latest Flash, 1M context |
 | `gemini-3.1-pro` | Google | Long context, reasoning (1M) |
@@ -296,15 +298,29 @@ Two ways to use Claude Code with the gateway:
 
 ```bash
 # Launch Claude Code through the gateway
-bankr llm claude
+bankr claude              # top-level alias
+bankr llm claude          # equivalent, explicit form
 
 # Pass any Claude Code flags through
-bankr llm claude --model claude-sonnet-4.6
-bankr llm claude --allowedTools Edit,Write,Bash
-bankr llm claude --resume
+bankr claude --model claude-sonnet-5
+bankr claude --allowedTools Edit,Write,Bash
+bankr claude --resume
 ```
 
 All arguments after `claude` are forwarded to the `claude` binary. The CLI sets `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` automatically from your config (using `llmKey` if set, otherwise `apiKey`).
+
+`bankr claude` is a top-level alias for `bankr llm claude` (requires **@bankr/cli 0.3.18+**; `bankr llm claude` works on every version). Named commands win over the prompt fallthrough, so `bankr claude ...` launches Claude Code rather than sending "claude ..." to the agent — use `bankr agent "..."` when a prompt starts with a command name.
+
+`-h` / `--help` on the launchers (`bankr claude`, `bankr llm claude`, `bankr llm opencode`) is forwarded to the spawned tool and prints *its* help, without requiring authentication. For the Bankr CLI's own help use `bankr --help` or `bankr llm --help`.
+
+**1M-token context tier:** Claude Code exposes it as a `[1m]` model suffix (`claude-opus-5[1m]`). Through the gateway the suffix is **optional** — it is stripped before model lookup and the 1M window is enabled from the model's own context window, so `claude-opus-5` and `claude-opus-5[1m]` send an identical request. Omitting it is simplest. If you do pass it, **quote it**: in zsh (the macOS default) `[1m]` is a glob character class and the command aborts with `zsh: no matches found` before the CLI runs, while bash passes it through literally — so the same command can work on one machine and fail on another.
+
+```bash
+bankr claude --model claude-opus-5          # full 1M window, nothing to quote
+bankr claude --model "claude-opus-5[1m]"    # explicit suffix — quotes required
+```
+
+Inside `~/.claude/settings.json` it's already a JSON string, so no extra escaping is needed: `{ "model": "claude-opus-5[1m]" }`.
 
 **Option B: Set environment variables**
 
@@ -324,6 +340,9 @@ Add these to `~/.zshrc` or `~/.bashrc` so all Claude Code sessions use the gatew
 ### OpenCode
 
 ```bash
+# Launch OpenCode through the gateway (args forwarded to the tool)
+bankr llm opencode
+
 # Auto-install Bankr provider into ~/.config/opencode/opencode.json
 bankr llm setup opencode --install
 

--- a/bankr/references/portfolio.md
+++ b/bankr/references/portfolio.md
@@ -36,7 +36,7 @@ The `/wallet/portfolio` endpoint is a read endpoint — any valid API key with a
 
 ## Supported Chains
 
-All chains: Base, Polygon, Ethereum, Unichain, Solana, World Chain, Arbitrum, BNB Chain
+All chains: Base, Polygon, Ethereum, Unichain, Solana, World Chain, Arbitrum, BNB Chain, Robinhood Chain
 
 ## Prompt Examples
 
@@ -68,6 +68,7 @@ All chains: Base, Polygon, Ethereum, Unichain, Solana, World Chain, Arbitrum, BN
 - **Multi-Chain Aggregation**: See the same token across all chains
 - **Real-Time Prices**: Values reflect current market prices
 - **Comprehensive View**: Shows all tokens with meaningful balances
+- **Wrap/Unwrap Aware**: Wrapping and unwrapping the native token (ETH ↔ WETH and equivalents) updates both balances, so a portfolio read straight after an unwrap reflects it
 
 ## Common Tokens Tracked
 

--- a/bankr/references/token-trading.md
+++ b/bankr/references/token-trading.md
@@ -7,9 +7,12 @@ Execute token trades and swaps across multiple blockchains.
 | Chain | Native Token | Characteristics |
 |-------|--------------|-----------------|
 | Base | ETH | Low fees, ideal for memecoins |
-| Polygon | MATIC | Fast, cheap transactions |
+| Polygon | POL | Fast, cheap transactions |
 | Ethereum | ETH | Highest liquidity, expensive gas |
 | Unichain | ETH | Newer L2 option |
+| World Chain | ETH | Uniswap V3/V4 swaps |
+| Arbitrum | ETH | DeFi, low-cost transactions |
+| BNB Chain | BNB | BSC ecosystem trading |
 | Robinhood Chain | ETH | Tokenized stocks & ETFs (USDG stablecoin), memecoins |
 | Solana | SOL | High speed, minimal fees |
 
@@ -39,12 +42,15 @@ Execute token trades and swaps across multiple blockchains.
 - "Convert 0.1 ETH to WETH"
 - "Unwrap 0.5 WETH to ETH"
 
+Both balances update after a wrap or unwrap, so you can check your portfolio immediately afterwards and see the result.
+
 ## Chain Selection
 
 - If no chain specified, Bankr selects the most appropriate chain
 - Base is preferred for most operations due to low fees
 - Cross-chain routes are automatically optimized
 - Include chain name in prompt to specify: "Buy ETH on Polygon"
+- **Pasting a raw contract address is safe**: Bankr verifies which chain actually hosts that contract before quoting, so a token on a less common chain (e.g. Robinhood Chain) is found even if the chain isn't named or is guessed wrong
 
 ## Slippage
 

--- a/bankr/references/tokenized-stocks.md
+++ b/bankr/references/tokenized-stocks.md
@@ -35,6 +35,8 @@ Robinhood Chain hosts 95+ tokenized stocks and ETFs issued by Robinhood — larg
 
 Prices track the underlying equity. Trades settle on-chain against **USDG (Global Dollar)**, Robinhood Chain's native stablecoin — Bankr routes through it automatically, so you can fund a purchase from ETH, USDG, or any token on the chain in a single command.
 
+Stock legs are routed differently from the chain's memecoin pools: tokenized stocks have no AMM pool of their own, so Bankr sends them to a venue that quotes them directly (with a tighter slippage tolerance), while ordinary Robinhood Chain pairs keep the thin-pool protection they've always had. This is automatic — the same prompt works for both.
+
 Robinhood Chain supports the full set of advanced orders — **limit, stop (including trailing), DCA, and TWAP** — alongside spot swaps and transfers:
 
 ```


### PR DESCRIPTION
Weekly refresh of the `bankr` skill to match current Bankr capabilities.

## LLM Gateway

- Added `claude-opus-5` and `claude-sonnet-5` to the model snapshot in `references/llm-gateway.md`, and re-labelled the previous Opus/Sonnet flagships so "latest" points at the right rows. The table still carries its "curated snapshot — run `bankr llm models` for the live list" caveat.
- Documented the `bankr claude` top-level alias for `bankr llm claude`, plus the `bankr llm opencode` launcher, which was already available but undocumented.
- Documented that `-h` / `--help` on the launcher commands is forwarded to the spawned tool (and doesn't require authentication), while `bankr --help` / `bankr llm --help` still print the CLI's own help.
- Noted that named commands take precedence over the prompt fallthrough, so a prompt beginning with a command name should go through `bankr agent "..."`.
- New section on Claude Code's `[1m]` context-tier suffix: through the gateway it's **optional** (the window comes from the model's own context size), and if used it must be quoted — in zsh it's a glob character class, so an unquoted id fails before the CLI runs while bash passes it through.

## Wallet API swaps

Added a short "venue selection is automatic" block to the Swap (Direct) section covering cases the Wallet API now handles the same way the agent does:

- brand-new Solana tokens still on their bonding curve fall back to the curve instead of returning "no route"
- Polygon `pUSD` ↔ `USDC.e` uses the 1:1 on-chain unwrap rather than a DEX quote
- Robinhood Chain tokenized stocks route to a venue that quotes them, while ordinary pairs on that chain keep their thin-pool protection (also reflected in `references/tokenized-stocks.md`)

## Portfolio & token trading

- Native wrap/unwrap (ETH ↔ WETH and equivalents) is reflected in both balances, so a portfolio read straight afterwards shows the result — noted in `SKILL.md`, `references/portfolio.md`, and `references/token-trading.md`.
- Added Robinhood Chain to the supported-chain list in `references/portfolio.md`.
- Pasting a raw contract address is safe: the hosting chain is verified before quoting, so tokens on less common chains resolve even when the chain isn't named. Also softened the closing "always name the chain" pro tip accordingly.
- Refreshed the chain table in `references/token-trading.md` — `MATIC` → `POL`, and added World Chain, Arbitrum, and BNB Chain to match `SKILL.md`.

## Notes for reviewers

- The CLI-side additions (`bankr claude` alias, `--help` passthrough) are marked as requiring **@bankr/cli 0.3.18+**, which is not on npm yet (latest published is 0.3.13). The version note keeps the docs accurate either way, but worth confirming the version number lands as expected at publish time.
- `claude-opus-5` is documented from the gateway model catalogue; please confirm it's live before merging if the gateway hasn't been redeployed since the model was added.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GEwQnv1c5aEzpxbyFoaNVY)_