### PR TITLE
bankr: weekly sync — privacy tiers, Max Mode, Base tokenized equities, file storage

### DIFF
--- a/bankr/SKILL.md
+++ b/bankr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bankr
-description: AI-powered crypto trading agent, wallet API, and LLM gateway via natural language. Use when the user wants to trade crypto, trade tokenized stocks and ETFs (spot or leveraged), check portfolio balances (with PnL and NFTs), view token prices, search tokens, transfer crypto, manage NFTs, use leverage (Hyperliquid or Avantis), bet on Polymarket, deploy tokens, set up automated trading, sign and submit raw transactions, call or deploy x402 paid API endpoints, browse the web, or access LLM models through the Bankr LLM gateway funded by your Bankr wallet. Supports Base, Ethereum, Polygon, Solana, Unichain, World Chain, Arbitrum, BNB Chain, and Robinhood Chain.
+description: AI-powered crypto trading agent, wallet API, and LLM gateway via natural language. Use when the user wants to trade crypto, trade tokenized stocks and ETFs (spot or leveraged), check portfolio balances (with PnL and NFTs), view token prices, search tokens, research token holders, transfer crypto, manage NFTs, use leverage (Hyperliquid or Avantis), bet on Polymarket, deploy tokens, set up automated trading, sign and submit raw transactions, call or deploy x402 paid API endpoints, browse the web, store and query files on their wallet's filesystem, or access LLM models through the Bankr LLM gateway funded by your Bankr wallet — including zero-data-retention and TEE-private inference tiers. Supports Base, Ethereum, Polygon, Solana, Unichain, World Chain, Arbitrum, BNB Chain, and Robinhood Chain.
 metadata:
   {
     "clawdbot":
@@ -301,6 +301,7 @@ For full API details (request/response schemas, job states, rich data, polling s
 | Command | Description |
 |---------|-------------|
 | `bankr agent prompt <text>` | Send a prompt to the Bankr AI agent |
+| `bankr agent prompt <text> --model <id>` | Max Mode — run this prompt on a specific gateway model, billed from LLM credits (`-m` also works) |
 | `bankr agent prompt --continue <text>` | Continue the most recent conversation thread |
 | `bankr agent prompt --thread <id> <text>` | Continue a specific conversation thread |
 | `bankr agent status <jobId>` | Check the status of a running job |
@@ -314,6 +315,21 @@ For full API details (request/response schemas, job states, rich data, polling s
 |---------|-------------|
 | `bankr tokens search <query>` | Search for tokens by name or symbol |
 | `bankr tokens info <symbol-or-address>` | Get detailed token information |
+
+### `bankr files` — File Storage
+
+| Command | Description |
+|---------|-------------|
+| `bankr files ls [--folder <path>]` | List files, optionally scoped to a folder |
+| `bankr files upload <file> [--folder <path>]` | Upload a local file |
+| `bankr files download <fileId>` | Get a download URL |
+| `bankr files cat <fileId>` | Print file contents to stdout (or save locally) |
+| `bankr files edit <fileId> --find <text> --replace <text>` | Find/replace in place (`--all` for every occurrence) |
+| `bankr files write <fileId> [--from <path>]` | Overwrite text content from a local file or stdin |
+| `bankr files search <query> [--folder <path>] [--limit <n>]` | Search by filename, extension, or description |
+| `bankr files mkdir <name> [--parent <path>]` | Create a folder |
+| `bankr files rm <fileId>` | Delete a file (soft — recoverable for 24h) |
+| `bankr files storage` | Show storage usage and quota |
 
 ### `bankr club` — Bankr Club Membership
 
@@ -330,6 +346,23 @@ Manage Bankr Club subscription from the CLI (status, signup, cancel). Pay with U
 | `bankr club cancel` | Cancel subscription (access continues until period ends) |
 
 Pricing is $20/mo or $198/yr USD-equivalent. Actual on-chain amount depends on the chosen token's price at quote time. The `--token` flag was added in CLI 0.3.4; older versions only support USDC.
+
+**What Club actually gates** (everything else works without it):
+
+| Perk | Standard | Bankr Club |
+|------|----------|------------|
+| Swap fee | 0.65% | **0.15%** |
+| Terminal messages | 5/day | Unlimited |
+| Agent API requests | 100/day | 1,000/day |
+| Concurrent recurring agent-command automations | — | Up to 20 |
+| Gas-sponsored token deploys | 3/day | 10/day |
+| Token deploys | 50/day | 100/day |
+| File storage | 1 GB (10 MB/file) | 10 GB (50 MB/file) |
+| Monthly file downloads | 10 GB | 100 GB |
+| Model routing | Standard | Top-tier models |
+| Browser sessions, advanced research (Bankr score, PnL & volume analytics, web search, social sentiment) | — | Included |
+
+**Max Mode is the alternative to a subscription** — pay per request from LLM credits for unlimited terminal messages, and it works with external/connected wallets, which Club checkout does not (Club requires an embedded Bankr wallet). On the Agent API, non-Club Max Mode is still capped at 100 requests/day. Holding a legacy Bankr Club NFT does **not** grant membership; it was a commemorative token for the first 1,000 subscribers.
 
 **Monthly → yearly upgrade**: active monthly members can upgrade to yearly by asking the agent (e.g. "upgrade me to yearly"). The full yearly price is charged and the new 365-day term stacks on top of any remaining monthly time, so no paid time is lost. Yearly → monthly downgrades and yearly resubscribes are not supported.
 
@@ -510,6 +543,57 @@ The [Bankr LLM Gateway](https://docs.bankr.bot/llm-gateway/overview) is a unifie
 - **Per-model discounts** available for Bankr Club members and partners — applied automatically at billing time
 - **Image generation**: generate images via the OpenAI-native `/v1/images/generations` endpoint (model `gpt-image-2`), billed from the same LLM credit balance — see the reference
 - **Expiring credit grants**: promotional or developer grants may carry an expiry date. Your spendable balance is your permanent (purchased) credits plus any unexpired grants — grants are spent first (soonest-expiring first) and drop off automatically at expiry
+- **Privacy tiers**: every request is served at `standard`, `zdr` (zero data retention), or `private` (TEE). Ask for a tier per request, per model, per base URL, or account-wide — see below
+
+### Privacy Tiers
+
+Three nesting levels of data-handling guarantee, requested the same way on every endpoint:
+
+| Tier | Guarantee | Coverage |
+|------|-----------|----------|
+| `standard` (default) | Never routed to a provider that trains on your prompts. Providers may still retain them. | Every model |
+| `zdr` | Only providers that retain nothing. | Subset — filter with `bankr llm models --zdr` |
+| `private` | Runs inside a hardware-secured enclave (TEE), attestation verified per request. Zero-retention by construction. | Open-weight models only |
+
+Four ways to ask, so any client can reach any tier:
+
+```bash
+# 1. The `privacy` request field
+curl -X POST https://llm.bankr.bot/v1/chat/completions -H "X-API-Key: $BANKR_LLM_KEY" \
+  -d '{"model":"glm-5.2","privacy":"zdr","messages":[{"role":"user","content":"Hello"}]}'
+
+# 2. A base-path prefix — for tools that only take a base URL, key, and model
+export OPENAI_BASE_URL=https://llm.bankr.bot/zdr/v1      # OpenAI-compatible clients
+export ANTHROPIC_BASE_URL=https://llm.bankr.bot/zdr      # Anthropic-compatible clients
+
+# 3. A model-ID suffix
+bankr llm models --zdr                                   # which models have a ZDR slot
+# → use `glm-5.2:zdr` or `glm-5.2:private` as the model ID
+
+# 4. Account-wide — Settings in the web terminal, applies to every request
+```
+
+- **Every tier fails closed.** If no provider can serve your model at the tier you asked for, the request is rejected (`422 zdr_unavailable`) — never quietly downgraded.
+- **Account setting and request combine, strongest wins.** A request can tighten past the account setting; nothing in a request can drop below it.
+- **A tier endpoint is authoritative.** Sending a request that names a *different* tier to `/zdr` or `/private` returns `400 privacy_conflict` rather than merging. An unparseable `privacy` value returns `400 invalid_privacy` rather than being ignored.
+- **`X-Privacy-Tier` response header** reports the tier the request was actually handled under, so the guarantee is verifiable rather than assumed.
+- Tier matching is case-insensitive, and only a *trailing* `:zdr` / `:private` token counts as the suffix opt-in.
+
+### Max Mode — Pick the Agent's Model
+
+Max Mode overrides the Bankr agent's default model with any model from the gateway, billed per token from your **LLM credit balance** (not your trading wallet):
+
+```bash
+bankr agent "analyze my portfolio" --model claude-opus-5     # or -m
+bankr agent "what are the top memecoins today?" -m gemini-3.1-pro
+bankr agent prompt "tell me more" --continue --model claude-sonnet-5
+```
+
+The setting is stored on your wallet and applies across every surface — CLI, web terminal, social platforms, and automations. In the web terminal, toggle the **Max** button and pick a model from the picker.
+
+- **Credits are enforced per LLM call, not after the fact.** Your spendable balance (minus anything already metered but not yet deducted) becomes the run's budget, re-checked before every call — the turn ends honestly when it's exhausted instead of overspending.
+- **Shortfalls survive.** If a batch can't be fully covered, the credit is left untouched and the usage stays owed, so a later top-up settles it rather than the overspend being written off.
+- Top up before enabling, or Max Mode messages will fail.
 
 ### Quick Commands
 
@@ -583,6 +667,7 @@ For full details — setup paths, model list, provider config, SDK examples, key
 - Price charts
 - Trending tokens
 - Token comparisons
+- **Holder snapshots** — largest-first holder lists with USD value and supply percentage, plus a concentration summary. Supports a minimum-USD floor, which makes it usable for airdrop targeting ("holders of X with $50+")
 
 **Reference**: [references/market-research.md](references/market-research.md)
 
@@ -601,7 +686,7 @@ For full details — setup paths, model list, provider config, SDK examples, key
 
 - Browse and search collections
 - View floor prices and listings
-- Purchase NFTs via OpenSea
+- Purchase NFTs via OpenSea — including listings priced in an **ERC-20** rather than the native token (e.g. USDG on Robinhood Chain). The token approval, the payment-currency balance check, and decimals-aware pricing are all handled for you
 - Accept offers on NFTs you own
 - View your NFT portfolio
 - Transfer NFTs
@@ -625,6 +710,7 @@ For full details — setup paths, model list, provider config, SDK examples, key
 - **Avantis** (secondary) — Perpetuals on Base for crypto, equities (NVDA, TSLA, AAPL, HOOD, and more), forex, and commodities. Equity, forex, and commodity pairs trade during their underlying market hours only.
 - Stop loss, take profit, and position management on both platforms
 - Funding Hyperliquid is a **venue** deposit/withdraw, not a bridge: a deposit only reaches Hyperliquid, a withdrawal only lands on Arbitrum. Name the venue ("deposit $500 to hyperliquid") rather than saying "bridge"; to move withdrawn funds onward, chain a cross-chain swap after the withdrawal
+- Hyperliquid charges a **1 USDC withdrawal fee, taken out of the requested amount** — so your full withdrawable balance is requestable (you receive amount − 1), and withdrawals under $1 are refused rather than netting to zero
 
 **Reference**: [references/leverage-trading.md](references/leverage-trading.md) | [references/hyperliquid.md](references/hyperliquid.md)
 
@@ -632,18 +718,22 @@ For full details — setup paths, model list, provider config, SDK examples, key
 
 Trade tokenized stocks and ETFs — real-world equities issued as on-chain tokens — with a plain prompt, the same way you trade any other asset. Bankr resolves the best venue automatically when you name a ticker, or you can specify a chain/venue:
 
-- **Robinhood Chain** — spot tokens issued by Robinhood (95+ stocks and ETFs: NVDA, AAPL, TSLA, SPY, QQQ, and more). Trades settle against USDG (Global Dollar); Bankr routes funding through it automatically. **Requires one-time location verification** — log in to the [Bankr console](https://bankr.bot) (verified automatically from your connection, renews on login, expires after 30 days). Not available in the US, UK, or sanctioned countries/regions.
+- **Robinhood Chain** — spot tokens issued by Robinhood (200 stocks and ETFs: NVDA, AAPL, TSLA, SPY, QQQ, and more). Trades settle against USDG (Global Dollar); Bankr routes funding through it automatically. **Requires one-time location verification.**
+- **Base (B20 tokenized equities)** — Coinbase-issued equity tokens on Base: AAPL, AMZN, COIN, CRCL, GOOGL, INTC, META, MSFT, MSTR, NVDA, SNDK, SPCX, TSLA. **Same location verification as Robinhood stocks.**
 - **Solana** — spot tokens from third-party issuers such as xStocks (AAPLx, TSLAx). No verification required; trade like any other token.
-- **Base** — spot tokens from third-party issuers. No verification required.
+- **Base (third-party issuers)** — other issuers' spot stock tokens on Base. No verification required.
 - **Leveraged (perps)** — for long/short exposure without owning the token, use Avantis (Base) or Hyperliquid.
 
-Spot stocks work with swaps, transfers, limit orders, and DCA. Only Robinhood stock trades are location-gated — memecoins on Robinhood Chain, bridging, and transfers work without verification.
+Location verification is a one-time step — log in to the [Bankr console](https://bankr.bot) (verified automatically from your connection, renews on login, expires after 30 days). Not available in the US, UK, or sanctioned countries/regions.
+
+Spot stocks work with swaps, transfers, limit orders, and DCA. Only issuer-tokenized stock trades (Robinhood Chain and Base B20) are location-gated — memecoins, bridging, and transfers work without verification. Tickers collide across chains (12 of the 13 B20 tickers also exist on Robinhood Chain), so name the chain when you mean a specific one.
 
 **Reference**: [references/tokenized-stocks.md](references/tokenized-stocks.md)
 
 ### Token Deployment
 
 - **EVM (Base default, or Robinhood Chain)**: Launch ERC20 tokens via Doppler on a Uniswap V4 pool with customizable metadata and social links. Fixed **100 billion** supply. Every trade pays a **0.7% swap fee on the pool and 95% of it goes to you** (0.665% of volume, claimable anytime); the hook adds the Bankr protocol fee + BNKR buyback and LP fee on top, for **1.75% all-in**. The **0.285% LP fee is creator-side too** — it compounds as locked liquidity in your own pool, strengthening your token's liquidity on every swap, so the creator side totals **0.95% of volume**. Tokens deploy to Base by default; pass a chain (`bankr launch --chain robinhood`) to launch on Robinhood Chain instead. Legacy Clanker tokens remain claimable (claims auto-detect Doppler vs Clanker).
+- **Stock-paired launches** (EVM, optional): pair the new token's pool with a registry tokenized stock instead of WETH, so the token trades against equity exposure. Available on Base (B20 equities) and Robinhood Chain — pass `pairedStockAddress` to the deploy API, or ask the agent to pair the launch with a ticker. Only stocks Bankr can price are offered, since launch-curve math needs a USD price.
 - **Quote-only fees** (EVM, optional): opt in at launch to collect all creator fees in the quote token (e.g. WETH) instead of a mix of the launched token and quote token — your total take is identical either way. Ask for "quote-only fees", pass `quoteOnlyFees: true` to the deploy API, or use `bankr launch --quote-only-fees`. Fixed at launch, like the fee schedule itself.
 - **Solana**: Launch SPL tokens via Raydium LaunchLab with bonding curve and auto-migration to CPMM
 - Creator fee claiming on both chains
@@ -674,7 +764,7 @@ The agent can discover, call, and deploy x402-protected API endpoints, automatic
 
 - **Discover** endpoints in the Bankr registry or via web search
 - **Inspect** endpoint pricing, methods, and input/output schemas
-- **Call** endpoints with automatic payment signing in the endpoint's required token — USDC or any supported ERC-20 (max $10/request)
+- **Call** endpoints with automatic payment signing in the endpoint's required token — USDC or any supported ERC-20 (max $10/request). From the CLI, `--max-payment <usd>` is your cap and is what gets sent: an endpoint's advertised price is display-only and can never raise it, and a call whose advertised price exceeds your cap fails closed rather than paying
 - **Deploy** new x402 endpoints directly through the agent (write handler code, set pricing, deploy)
 - **Price** your own endpoints in USDC or any supported ERC-20; revenue settles on-chain and is accounted in USD at settlement time
 - Works with any x402-compatible endpoint (Bankr-hosted or external)
@@ -693,6 +783,18 @@ The agent has a built-in headless browser for web interactions:
 
 **Reference**: [references/x402-cloud.md](references/x402-cloud.md)
 
+### File Storage
+
+Every Bankr wallet has a persistent filesystem, shared across the CLI, web terminal, API, and every social surface the agent runs on.
+
+- Create, read, edit, search, move, rename, and delete files by asking the agent — a path (`/research/notes.md`) works anywhere a file ID does
+- `bankr files ls|upload|download|cat|edit|write|search|mkdir|rm|storage` from the CLI; `/user/files/*` over REST
+- **Ask questions about a file without loading it** — the agent runs a read-only `jq`/`grep`/`awk`-style pipeline in a sandbox and returns only the answer, so a 4 MB CSV never enters the conversation. Available on every wallet, no Club subscription needed
+- Quotas: 1 GB / 10 MB per file / 10 GB monthly downloads on the free tier; 10 GB / 50 MB / 100 GB on Bankr Club. Checked at write time, resolved live from your current Club status
+- Deletion is soft — files are recoverable via support for 24 hours, then permanently gone
+
+**Reference**: [references/files.md](references/files.md)
+
 ### Ask About Bankr
 
 The agent can answer questions about Bankr itself — how features work, official domains and links, the official Telegram bot, and support channels — grounded in Bankr's own documentation. When it doesn't have a confident answer it abstains rather than guessing, so you won't get fabricated links or facts. Useful for onboarding questions and for verifying that a link or channel is genuinely official.
@@ -703,6 +805,7 @@ The agent can answer questions about Bankr itself — how features work, officia
 - Custom contract calls to any address
 - Execute pre-built calldata from other tools
 - Value transfers with data
+- Read an unknown contract's ABI and call it — struct (tuple) parameters are expanded into the parenthesized signature form the encoder accepts, so struct-taking functions like Uniswap V4 position mints encode on the first try instead of failing as `tuple`
 
 **Reference**: [references/arbitrary-transaction.md](references/arbitrary-transaction.md)
 
@@ -710,7 +813,7 @@ The agent can answer questions about Bankr itself — how features work, officia
 
 | Chain       | Native Token | Best For                      | Gas Cost |
 | ----------- | ------------ | ----------------------------- | -------- |
-| Base        | ETH          | Memecoins, general trading    | Very Low |
+| Base        | ETH          | Memecoins, general trading, B20 tokenized equities | Very Low |
 | Polygon     | POL          | Gaming, NFTs, frequent trades | Very Low |
 | Ethereum    | ETH          | Blue chips, high liquidity    | High     |
 | Solana      | SOL          | High-speed trading            | Minimal  |
@@ -720,7 +823,9 @@ The agent can answer questions about Bankr itself — how features work, officia
 | BNB Chain   | BNB          | BSC ecosystem trading         | Low      |
 | Robinhood Chain | ETH      | Tokenized stocks & ETFs (USDG), memecoins, token launches | Very Low |
 
-**Robinhood Chain** is an EVM L2 (chainId `4663`) whose native stablecoin is **USDG** (Global Dollar). It hosts 95+ Robinhood-issued tokenized stocks and ETFs alongside memecoins, and supports Bankr token launches (Doppler). Tokenized-stock trades require location verification (see [Tokenized Stock Trading](#tokenized-stock-trading)); memecoin swaps, token launches, bridging, and transfers do not.
+**Robinhood Chain** is an EVM L2 (chainId `4663`) whose native stablecoin is **USDG** (Global Dollar). It hosts 200 Robinhood-issued tokenized stocks and ETFs alongside memecoins, and supports Bankr token launches (Doppler). Tokenized-stock trades require location verification (see [Tokenized Stock Trading](#tokenized-stock-trading)); memecoin swaps, token launches, bridging, and transfers do not.
+
+**Base** additionally hosts the **B20 tokenized equities** — Coinbase-issued, 8-decimal equity tokens whose redemption ratio to the underlying share is an on-chain multiplier that moves on corporate actions. Trading them is gated by the same location verification as Robinhood stocks; everything else on Base is not.
 
 ## Safety & Access Control
 
@@ -963,6 +1068,8 @@ See [references/safety.md](references/safety.md) for comprehensive safety guidan
 - "Buy $100 of NVDA on robinhood" (spot, location verification required)
 - "Swap $50 of ETH to SPY on robinhood"
 - "Sell half my AAPL on robinhood"
+- "Buy $100 of NVDA on base" (B20 equity, location verification required)
+- "Swap $50 of USDC to GOOGL on base"
 - "Buy $50 of AAPLx on solana" (xStocks, no verification)
 - "DCA $50 into SPY every friday"
 - "Long TSLA with 5x leverage on avantis" (leveraged perp)
@@ -986,6 +1093,15 @@ See [references/safety.md](references/safety.md) for comprehensive safety guidan
 - "Analyze ETH price"
 - "Trending tokens on Base"
 - "Compare UNI vs SUSHI"
+- "Who are the top holders of 0x... on base?"
+- "List holders of 0x... on solana with at least $50" (airdrop targeting)
+
+### Files
+
+- "Save this analysis as /research/base-vs-solana.md"
+- "Search my files for hyperliquid"
+- "How many rows in /exports/portfolio.csv have a negative pnl?"
+- "What's the highest score in /data/candidates.json?"
 
 ### Transfers
 
@@ -1097,7 +1213,7 @@ Venue selection is automatic and the Wallet API now covers the same edge cases t
 
 - **Same-chain EVM** goes through the DEX aggregator, with a direct-pool venue preferred on thin-liquidity chains; **cross-chain and any Solana leg** goes through the bridge/swap aggregator
 - **Brand-new Solana tokens** still on their Raydium LaunchLab bonding curve fall back to the curve when no aggregator route exists yet, instead of failing with "no route". The fallback is narrow: both legs on Solana, a SOL ↔ token pair with an un-migrated curve, a genuine no-route from the aggregator, and **no price-impact limit set on the wallet** — the curve exposes no impact figure to check, so Bankr fails closed rather than fill an unguardable venue. With price-impact protection on, these swaps are rejected by design (the `minBuyAmount` floor still applies inside the fill)
-- **Polygon `pUSD` → `USDC.e`** uses the 1:1 on-chain Offramp unwrap rather than a DEX quote: no fee, no slippage, no price impact. The reverse direction (`USDC.e` → `pUSD`) is quoted like any ordinary pair
+- **Polygon `pUSD` → `USDC.e`** uses the 1:1 on-chain Offramp unwrap rather than a DEX quote: no fee, no slippage, no price impact. The reverse direction (`USDC.e` → `pUSD`) is quoted like any ordinary pair. The unwrap settles to your own wallet, so a **swap-and-send** naming a different recipient routes through the normal venues instead — it never silently settles to you
 - **Robinhood Chain tokenized stocks** are quoted and filled through the aggregator's RFQ makers, settling against USDG, while ordinary Robinhood Chain pairs keep their thin-pool protection
 
 ```bash

--- a/bankr/references/arbitrary-transaction.md
+++ b/bankr/references/arbitrary-transaction.md
@@ -93,6 +93,11 @@ Submit this ERC-20 transfer:
 | Invalid calldata | Ensure proper hex encoding with 0x prefix |
 | Transaction reverted | Check calldata encoding and contract state |
 | Insufficient funds | Ensure wallet has enough ETH/MATIC for gas + value |
+| Signature won't encode (`tuple`) | Struct parameters must be written in parenthesized form — `mint((address,uint256) params)`, not `mint(tuple params)`. Signatures Bankr reads off a contract's ABI already come back expanded; when you write one from memory and encoding fails, the error includes the corrected form |
+
+## Reading a Contract's ABI
+
+Ask Bankr for an unknown contract's ABI and it returns human-readable function signatures you can pass straight to a read or write call. Struct (tuple) parameters and return values are recursively expanded into the parenthesized form the encoder accepts, and every generated signature is round-tripped through the parser before being offered — so a struct-taking function like a Uniswap V4 position mint encodes on the first attempt rather than failing as the literal keyword `tuple`.
 
 ## Use Cases
 

--- a/bankr/references/files.md
+++ b/bankr/references/files.md
@@ -1,0 +1,101 @@
+# File Storage Reference
+
+Every Bankr wallet has a persistent filesystem. Documents the agent generates for you, files you upload, installed CLI skills, and the agent's memory all live there — browsable, editable, and shared across every surface the agent runs on. Because state lives on your wallet, the CLI, the web terminal, the API, and the social platforms all see exactly the same files.
+
+## Tiers
+
+| | Free | Bankr Club |
+|---|------|------------|
+| Total storage | 1 GB | 10 GB |
+| Max per-file size | 10 MB | 50 MB |
+| Monthly downloads | 10 GB / month | 100 GB / month |
+
+You don't need a Club subscription to use file storage — read, write, edit, and organize all work on the free tier. Club buys headroom, bigger single files, and roughly 10× the monthly download budget.
+
+Quotas are checked at the moment of write and resolved from your current Club status, so subscribing raises your cap immediately with no migration. The per-file cap is separate from the total: a single file over the cap is rejected even with plenty of free space.
+
+## Layout
+
+```
+/                    ← your root
+├─ .memory/          ← auto-managed agent memory
+├─ cli/              ← installed CLI skills and manifests
+└─ (your folders)
+```
+
+## Using Files From Chat
+
+Just ask — the agent has tools for creating, reading, updating, searching, moving, renaming, and deleting.
+
+```
+save this analysis as /research/unichain-vs-base.md
+open my DCA plan
+rename /portfolio-report to /reports/2026-q1
+search my files for "hyperliquid"
+delete the draft from yesterday
+```
+
+A **path** (`/research/notes.md`) works anywhere a file ID does, on every file tool. When the agent generates a document you get a clickable link in the chat that opens the built-in preview/editor.
+
+## Asking Questions About a File
+
+Some questions are about a file rather than its bytes — how many rows match, what the total is, which entries clear a threshold. Loading a 4 MB CSV into the conversation to count lines is slow and burns context, so the agent instead runs a small read-only pipeline against the file in a sandbox and returns only the answer. The file itself never enters the conversation.
+
+```
+how many rows in /exports/portfolio-2026-04.csv have a negative pnl?
+count the ERROR lines in /logs/run.log
+what's the highest score in /data/candidates.json?
+```
+
+Available on **every wallet** — no Club subscription needed — and you don't have to ask for it by name; the agent reaches for it when a question is an aggregation rather than a read.
+
+**What it can run:** `jq` for JSON and JSONL, plus `grep`, `egrep`, `fgrep`, `awk`, `cut`, `sort`, `uniq`, `wc`, `head`, `tail`, `cat`, `tr`, `nl`, `rev`, `paste`, `column`, `comm`, and pipes between them. No redirection, command chaining, command substitution, or network access. It is read-only and can never modify the file.
+
+**Limits:** text files only (not PDFs, images, or archives), up to roughly **5 MB** per query — above that the agent falls back to reading the file in ranges. Answers are capped at ~8,000 characters and the pipeline is cut off after **10 seconds**. If you hit either, narrow the question to a count or a top-N rather than a dump.
+
+## CLI Commands
+
+```bash
+bankr files ls                                  # List files
+bankr files ls --folder /research               # Scoped to one folder
+bankr files upload ./report.csv --folder /data  # Upload from your machine
+bankr files download <fileId>                   # Get a download URL
+bankr files cat <fileId>                        # Print contents to stdout
+bankr files edit <fileId> -f "old" -r "new"     # Find/replace (--all for every occurrence)
+bankr files write <fileId> --from ./new.md      # Overwrite from a local file or stdin
+bankr files search "hyperliquid" --limit 20     # Search names, extensions, descriptions
+bankr files mkdir reports --parent /            # Create a folder
+bankr files rm <fileId>                         # Delete (soft)
+bankr files storage                             # Usage and quota
+```
+
+Listings can be scoped to a folder, and results come back with full paths — so a name that appears in several folders is unambiguous.
+
+## REST API
+
+The same filesystem is available under `/user/files/*` for programmatic access.
+
+## Uploads and Downloads
+
+Upload from the web at [bankr.bot](https://bankr.bot) → **Files** panel (drag and drop, or the upload button). Text (`.md`, `.txt`, `.csv`, `.json`, code files), images, and PDFs are supported; executables (`.exe`, `.sh`, `.bat`, `.com`) are blocked.
+
+Each download counts against your monthly budget, which resets on the 1st of each month (UTC). The cap exists to stop Bankr storage becoming a free CDN — normal use never approaches it.
+
+## Deletion
+
+Deletion is **soft**: the file leaves listings immediately and is permanently deleted **24 hours later**. Within that window a support agent can restore it. After it, the file is unrecoverable.
+
+## Quota Errors
+
+A write that would push you over fails fast rather than half-succeeding:
+
+```
+Storage full (950MB of 1.0GB used, attempted 200MB). Join Bankr Club for 10.0GB.
+```
+
+The agent sees the same error and relays it, so you can delete files, pick a smaller write, or subscribe.
+
+## Notes
+
+- File ownership is per-wallet; files can't be shared with another wallet directly. Download and send it yourself.
+- Letting a Club subscription lapse is non-destructive: your tier reverts to Free, existing files are preserved and remain readable and downloadable, and only new uploads that would exceed 1 GB are blocked.

--- a/bankr/references/hyperliquid.md
+++ b/bankr/references/hyperliquid.md
@@ -87,6 +87,11 @@ Perps trading requires USDC in the perps account. Bankr auto-transfers from spot
 
 Hyperliquid is a trading **venue**, not a chain, so moving USDC in and out of it is venue funding rather than bridging — and deposit and withdraw are separate operations with fixed destinations. A deposit only ever reaches Hyperliquid; a withdrawal only ever lands on **Arbitrum**. To get withdrawn funds somewhere else, follow it with an ordinary cross-chain swap ("withdraw $500 from hyperliquid, then move it to Base") — it composes as two steps.
 
+**Withdrawal fee.** Hyperliquid charges a flat **1 USDC** withdrawal fee and takes it **out of the amount you request** — request 100, receive 99. Two consequences worth knowing:
+
+- Your **full withdrawable balance is requestable**. You don't need to leave a dollar behind to cover the fee, so "withdraw everything" works as stated.
+- **Withdrawals under $1 are refused** rather than netting to zero or a negative amount.
+
 **Name the venue when you mean the venue.** Say "hyperliquid" (or "hl") rather than a bare "bridge" or "withdraw"; a generic verb with a non-Hyperliquid destination is a request for that destination, and Bankr will treat it as one.
 
 **Market data:**

--- a/bankr/references/llm-gateway.md
+++ b/bankr/references/llm-gateway.md
@@ -50,9 +50,12 @@ bankr config get llmKey
 | `claude-sonnet-4.6` | Anthropic | Previous generation Sonnet (1M context) |
 | `claude-sonnet-4.5` | Anthropic | Earlier Sonnet (1M context) |
 | `claude-haiku-4.5` | Anthropic | Fast, cost-effective (200K context) |
-| `gemini-3.5-flash` | Google | Latest Flash, 1M context |
+| `gemini-3.6-flash` | Google | Latest Flash — the Bankr agent's default model (1M, image input) |
+| `gemini-3.5-flash` | Google | Fast general-purpose (1M) |
+| `gemini-3.5-flash-lite` | Google | Ultra-fast, lowest cost (1M) |
 | `gemini-3.1-pro` | Google | Long context, reasoning (1M) |
 | `gemini-3.1-flash-lite` | Google | Ultra-fast, lowest cost (1M) |
+| `gemini-3-pro` | Google | Previous-gen Pro, long context (1M) |
 | `gemini-3-flash` | Google | High throughput (1M) |
 | `gemini-2.5-pro` | Google | Long context, multimodal |
 | `gemini-2.5-flash` | Google | Speed, high throughput |
@@ -72,11 +75,14 @@ bankr config get llmKey
 | `grok-4.20` | xAI | Deep reasoning, largest context (2M context) |
 | `grok-4.5` | xAI | Latest, balanced multimodal (500K context, image input) |
 | `grok-4.3` | xAI | Balanced performance (1M context) |
+| `grok-4.1-fast` | xAI | Fast, economical, largest context (2M) |
 | `deepseek-v4-pro` | DeepSeek | Long context reasoning (1M, 384K output) |
 | `deepseek-v4-flash` | DeepSeek | High throughput, cost-effective (1M) |
 | `deepseek-v3.2` | DeepSeek | Cost-effective (164K context) |
+| `qwen3.7-max` | Alibaba | Latest flagship (1M) |
 | `qwen3.7-plus` | Alibaba | Latest, long-context reasoning (1M) |
-| `qwen3.6-flash` | Alibaba | Latest fast, economical (1M) |
+| `qwen3.7-flash` | Alibaba | Latest fast tier, economical (1M, image input) |
+| `qwen3.6-flash` | Alibaba | Fast, economical (1M) |
 | `qwen3.5-plus` | Alibaba | Long-context reasoning (1M) |
 | `qwen3.5-flash` | Alibaba | Fast, economical (1M) |
 | `qwen3-coder` | Alibaba | Code generation, debugging (262K) |
@@ -100,27 +106,95 @@ bankr llm models
 
 The table above is a curated snapshot; the gateway adds and retires models over time. Run `bankr llm models` (or `GET /v1/models`) for the authoritative live list, current pricing, and per-model capability flags.
 
-### Private (Confidential) Inference
+### Privacy Tiers (standard / zdr / private)
 
-Some models can be routed to a confidential, TEE-backed provider for private inference. Opt in per request by appending `:private` to the model ID:
+Every request is served at one of three nesting data-handling tiers. Each contains the guarantees of the one below it.
+
+| Tier | What it guarantees | Coverage |
+|------|--------------------|----------|
+| `standard` (default) | Never routed to a provider that trains on your prompts. Providers may still **retain** them. Covers the routing hop only. | Every model |
+| `zdr` | Only providers whose verdict for that model's slot allows **zero retention**. | Subset — `bankr llm models --zdr` |
+| `private` | TEE (hardware enclave) compute, attestation verified per request. Zero-retention by construction. | Open-weight models only |
+
+```bash
+bankr llm models                  # full list; zdr- and private-capable models are flagged
+bankr llm models --zdr            # only models with a zero-retention slot
+bankr llm models --private        # only models that support TEE compute
+```
+
+**Every tier fails closed.** If no provider can serve your model at the tier you asked for, the request is rejected — never quietly downgraded to a weaker one.
+
+#### Four ways to request a tier
+
+**1. The `privacy` request field** — the documented form for anything that builds its own body. Works on `/v1/chat/completions`, `/v1/messages`, and `/v1/images/generations`:
 
 ```bash
 curl -X POST "https://llm.bankr.bot/v1/chat/completions" \
   -H "Authorization: Bearer $BANKR_LLM_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"model": "glm-5.2:private", "messages": [{"role": "user", "content": "Hello"}]}'
+  -d '{"model": "glm-5.2", "privacy": "zdr", "messages": [{"role": "user", "content": "Hello"}]}'
 ```
 
-List which models currently support private (TEE) compute:
+Accepted values: `"standard"`, `"zdr"`, `"private"`.
+
+**2. A base-path prefix** — for tools that only let you set a base URL, an API key, and a model. The prefix sits in front of the whole API, so it serves both SDK conventions from one setting:
 
 ```bash
-bankr llm models --private        # only models that support :private
-bankr llm models                  # full list; private-capable models are flagged
+# OpenAI-compatible clients (base URL ends in /v1)
+export OPENAI_BASE_URL=https://llm.bankr.bot/zdr/v1
+
+# Anthropic-compatible clients (Claude Code, OpenClaw — they append /v1/messages)
+export ANTHROPIC_BASE_URL=https://llm.bankr.bot/zdr
 ```
 
-- Confidentiality is a hard routing constraint — a `:private` request is only served by a private-capable provider, never silently downgraded to a standard one.
-- Only models that expose a private slot support it. `bankr llm models` flags which models are private-capable, and `bankr llm models --private` lists only those (driven live by the gateway's `private` flag on `GET /v1/models`). Sending `:private` to a model without one is rejected rather than falling back.
-- Only a trailing, lowercase `:private` is treated as the opt-in. Anything else in the model string is left untouched.
+`/private` works the same way. Every request through that base URL is served at the tier with no per-request configuration.
+
+**3. A model-ID suffix** — per model rather than per base URL:
+
+```
+glm-5.2:zdr
+glm-5.2:private
+```
+
+Only a **trailing** tier token counts as the opt-in, so unrelated model IDs containing a colon are unaffected. Matching is case-insensitive (`:ZDR`, `:Private` both work). The suffix is stripped before model lookup — privacy is a routing constraint, not part of the model's identity.
+
+**4. Account-wide** — turn ZDR on under **Settings** in the web terminal and every request from the account is served at that tier or stronger.
+
+#### Rules that decide the effective tier
+
+- **Account setting + request: combine, strongest wins.** A request can tighten past the account setting, but nothing in a request — and no choice of base URL — can drop below it.
+- **A tier endpoint is authoritative.** A request naming a *different* tier than the `/zdr` or `/private` endpoint it was sent to is rejected, in either direction, so an integration pinned to a tier endpoint stays usable as an audit point. Sending no privacy option, or one that matches, is fine. To mix tiers, use the `privacy` field against the default endpoint.
+- **`X-Privacy-Tier` response header** reports the tier the request was actually handled under. It's set as soon as the tier is known, so it describes the policy even on a request that then fails. (`private` additionally sets `X-Confidential-Verified` and the attested-identity headers.)
+
+#### Privacy error responses
+
+| Status | Code | Meaning |
+|--------|------|---------|
+| `422` | `zdr_unavailable` | No provider can serve that model with zero retention. Pick a model from `bankr llm models --zdr`. |
+| `422` / `503` | — | A `:private` request where no confidential provider serves the model (422), or its attestation couldn't be verified (503). Never a silent downgrade. |
+| `400` | `privacy_conflict` | The request named a different tier than the tier endpoint it was sent to. Remove the privacy option, or send it to the matching endpoint. |
+| `400` | `invalid_privacy` | The `privacy` field (or a legacy `zdr`/`private` boolean flag) had an uninterpretable value. Rejected rather than ignored — the unset state is the weak one, so a typo like `"zdrr"` must not silently serve at standard tier. |
+
+### Max Mode — Choose the Agent's Model
+
+Max Mode replaces the Bankr agent's default model (`gemini-3.6-flash`) with any gateway model, billed per token from your **LLM credit balance**. It's the pay-per-use alternative to a Bankr Club subscription for unlimited terminal messages, and unlike Club checkout it works with external/connected wallets.
+
+```bash
+bankr agent "analyze my portfolio" --model claude-opus-5
+bankr agent "what are the top memecoins today?" -m gemini-3.1-pro
+bankr agent prompt "tell me more" --continue --model claude-sonnet-5
+```
+
+The selection is stored on your wallet and applies across every surface — CLI, web terminal, Farcaster, X, Telegram, XMTP, and automations. In the web terminal, toggle the **Max** button and pick a model from the picker; a usage badge under each response shows model, tokens, and cost.
+
+**How credits are enforced:**
+
+- Your **effective balance** (spendable credits minus usage already metered but not yet deducted) becomes the run's budget, and it is re-checked **before every LLM call** — alongside the existing step and wall-clock budgets. The turn ends honestly when the budget is reached rather than running up an unbounded bill.
+- **Deduction is all-or-nothing.** A batch your balance can't fully cover leaves the credit untouched and the usage still owed, so the debt survives intact and a later top-up settles it — it is never written off.
+- App-invoked and x402-gated runs count undeducted usage against the balance too, so a pending bill can't be spent twice.
+- On the Agent API, non-Club Max Mode is capped at 100 requests/day.
+
+Top up before enabling (`bankr llm credits add 25`), or Max Mode messages will fail.
 
 ### Per-Model Discounts
 

--- a/bankr/references/market-research.md
+++ b/bankr/references/market-research.md
@@ -11,6 +11,21 @@ Research tokens and analyze market data using Bankr's AI-powered analysis.
 - Price charts
 - Trending tokens
 - Token comparisons
+- Holder snapshots and supply concentration
+
+## Token Holders
+
+Ask for a token's holders and Bankr returns them largest-first with **USD value** and **percentage of supply**, plus a concentration summary. It needs a contract address and a chain.
+
+```
+"who are the top holders of 0x... on base?"
+"show holder concentration for BNKR"
+"list holders of 0x... on solana with at least $50"
+```
+
+- Set a **minimum USD value** to bound the snapshot by value rather than by count — this is the shape you want for airdrop targeting ("holders with $50+").
+- The list is the **raw on-chain holder set**. It includes liquidity pools, the token contract itself, and treasuries — often the largest entries. Exclude those before paying anyone out.
+- Snapshots are capped per read, and the response tells you when it was truncated with more holders still qualifying.
 
 ## Prompt Examples
 

--- a/bankr/references/nft-operations.md
+++ b/bankr/references/nft-operations.md
@@ -34,6 +34,8 @@ Browse, purchase, and manage NFTs across chains via OpenSea integration.
 - "Buy Pudgy Penguin #1234"
 - "Get the floor Azuki"
 
+Listings priced in an **ERC-20** rather than the chain's native token — for example USDG listings on Robinhood Chain — are buyable the same way. Bankr submits the token approval the marketplace conduit needs, checks your balance of the payment currency before signing, and prices the listing using that token's decimals, so the quoted amount is the amount you pay. If a listing turns out to be stale, it moves on to the next one instead of failing the whole request.
+
 **Accept offers:**
 - "Accept the best offer on my Pudgy Penguin #1234"
 - "What's the highest offer on my Bored Ape?"

--- a/bankr/references/portfolio.md
+++ b/bankr/references/portfolio.md
@@ -69,6 +69,7 @@ All chains: Base, Polygon, Ethereum, Unichain, Solana, World Chain, Arbitrum, BN
 - **Real-Time Prices**: Values reflect current market prices
 - **Comprehensive View**: Shows all tokens with meaningful balances
 - **Wrap/Unwrap Aware**: Wrapping and unwrapping the native token (ETH ↔ WETH and equivalents) updates both balances, so a portfolio read straight after an unwrap reflects it
+- **Exact Balances**: token `balance` is the exact decimal amount in plain notation, carried as a string — never rounded, and never in scientific notation for very small or very large holdings. If you do arithmetic on it, parse it with a decimal-safe library rather than relying on a float
 
 ## Common Tokens Tracked
 

--- a/bankr/references/safety.md
+++ b/bankr/references/safety.md
@@ -285,8 +285,11 @@ The `/agent/prompt` endpoint enforces daily message limits per account:
 | Tier | Daily Limit |
 |------|-------------|
 | Standard | 100 messages/day |
+| Standard + Max Mode | 100 messages/day (Max Mode does not raise the API cap) |
 | Bankr Club | 1,000 messages/day |
 | Custom | Set per API key |
+
+These are Agent API limits. The web terminal is capped separately at 5 messages/day without a subscription, and unlimited with Bankr Club or Max Mode.
 
 **429 response when limit exceeded:**
 ```json

--- a/bankr/references/token-deployment.md
+++ b/bankr/references/token-deployment.md
@@ -269,12 +269,34 @@ Like the fee schedule, this option cannot be changed after launch.
 
 ### Rate Limits
 
-| User Type | Daily Limit | Gas |
-|-----------|-------------|-----|
-| Standard Users | 50 tokens/day | Sponsored within limit |
-| Bankr Club Members | 100 tokens/day | Sponsored within limit |
+| User Type | Deploys per day | Gas-sponsored deploys per day |
+|-----------|-----------------|-------------------------------|
+| Standard Users | 50 | 3 |
+| Bankr Club Members | 100 | 10 |
+
+The two limits are separate: the daily cap is how many tokens you may deploy, the sponsorship cap is how many of those Bankr pays gas for. Past the sponsorship cap you can keep deploying up to the daily cap by paying gas yourself. A deploy that fails before broadcast because of gas doesn't consume sponsorship quota, though it still counts against the daily cap.
+
+A separate cross-account limit applies to fee recipients: an address may be named fee recipient on at most **20 deploys per 24 hours** across all accounts.
 
 High-volume or bot-like deploy patterns can trigger automated spam protections and temporary or permanent restrictions. For legitimate programmatic deploy use cases, open a support ticket before scaling up.
+
+### Stock-Paired Launches
+
+Instead of pairing your token's pool with WETH, you can pair it with a registry **tokenized stock**, so the token trades against equity exposure rather than against ETH. Available on **Base** (B20 equities) and **Robinhood Chain**.
+
+```bash
+bankr agent prompt "Launch a token called Semis paired with NVDA on base"
+```
+
+```json
+POST /token/deploy
+{ "name": "Semis", "symbol": "SEMIS", "chain": "base", "pairedStockAddress": "0x..." }
+```
+
+- Only stocks Bankr can price are offered — the launch curve's tick math needs a USD price, so an unpriceable stock would fail late rather than early.
+- The same rule set validates the pairing in the launch wizard, the deploy API, and the agent, so what's offered is what's accepted.
+- Pairing is fixed at launch, like the fee schedule.
+- The pool's quote asset is the stock, so a swap leg that touches it is subject to that stock's location verification like any other stock trade.
 
 ### Fee Structure
 

--- a/bankr/references/tokenized-stocks.md
+++ b/bankr/references/tokenized-stocks.md
@@ -4,27 +4,31 @@ Trade tokenized stocks and ETFs — real-world equities issued as on-chain token
 
 ## Venues
 
-Bankr supports tokenized stocks across four venues. When you ask for a stock by ticker, Bankr resolves the best venue automatically; name the chain or venue to force a specific one.
+Bankr supports tokenized stocks across five venues. When you ask for a stock by ticker, Bankr resolves the best venue automatically; name the chain or venue to force a specific one.
 
 | Venue | What you get | Examples | Location verification |
 |-------|--------------|----------|-----------------------|
 | Robinhood Chain | Spot tokens issued by Robinhood (stocks + ETFs) | NVDA, AAPL, TSLA, SPY, QQQ | **Required** |
+| Base — B20 equities | Spot equity tokens issued by Coinbase | NVDA, AAPL, GOOGL, META, COIN | **Required** |
 | Solana | Spot tokens from third-party issuers (e.g. xStocks) | AAPLx, TSLAx | Not required |
-| Base | Spot tokens from third-party issuers | varies by listing | Not required |
+| Base — third-party issuers | Spot tokens from other issuers | varies by listing | Not required |
 | Avantis (Base) | Leveraged equity perpetuals (long/short) | NVDA, TSLA, HOOD, META | Not required |
 
 Stock **perpetuals** (leveraged long/short exposure rather than spot ownership) are also available on Hyperliquid via HIP-3. See [leverage-trading.md](leverage-trading.md) and [hyperliquid.md](hyperliquid.md).
 
 ```
 "buy $100 of NVDA on robinhood"
+"buy $100 of NVDA on base"
 "buy $50 of AAPLx on solana"
 "long TSLA with 5x leverage on avantis"
 "short HOOD on hyperliquid"
 ```
 
+**Tickers collide across chains.** Twelve of the thirteen Base B20 tickers also exist on Robinhood Chain, so name the chain when you mean a specific one — a bare ticker leaves the choice to Bankr's venue resolution.
+
 ## Robinhood Chain (spot)
 
-Robinhood Chain hosts 95+ tokenized stocks and ETFs issued by Robinhood — large caps (NVDA, AAPL, MSFT, AMZN), ETFs (SPY, QQQ, SOXX), and pre-IPO names.
+Robinhood Chain hosts 200 tokenized stocks and ETFs issued by Robinhood — large caps (NVDA, AAPL, MSFT, AMZN), ETFs (SPY, QQQ, SOXX), and pre-IPO names.
 
 ```
 "buy $100 of NVDA on robinhood"
@@ -46,17 +50,33 @@ Robinhood Chain supports the full set of advanced orders — **limit, stop (incl
 "set a trailing stop on my TSLA on robinhood"
 ```
 
+## Base B20 tokenized equities (spot)
+
+Base hosts the **B20 tokenized equities** — Coinbase-issued equity tokens trading as ordinary ERC-20s on Base:
+
+**AAPL, AMZN, COIN, CRCL, GOOGL, INTC, META, MSFT, MSTR, NVDA, SNDK, SPCX, TSLA**
+
+```
+"buy $100 of NVDA on base"
+"swap $50 of USDC to GOOGL on base"
+"sell half my META on base"
+```
+
+B20 is an ERC-20 extension: transfers and approvals behave normally, but the redemption ratio to the underlying share is an **on-chain multiplier** that moves on corporate actions (splits, dividends), and issuer policy can block transfers. Token price = the underlying equity's price × that multiplier, so Bankr prices these off the equity rather than off pool liquidity — a B20 is quotable before any Base liquidity exists. They are 8-decimal tokens (Robinhood stocks are 18-decimal), which matters if you're reading raw amounts from the API rather than the formatted figures.
+
+**Base B20 trades are behind the same location verification as Robinhood stocks** — same site-visit verdict, same blocked-country list, same 30-day expiry, and the same fail-closed behaviour. Everything else on Base is ungated.
+
 ### Location verification
 
-Robinhood tokenized stocks are **not available in the US, UK, sanctioned countries or regions, or any jurisdiction where they are prohibited by local law**. This is the only Bankr feature that requires location verification.
+Issuer-tokenized stocks — Robinhood Chain and Base B20 alike — are **not available in the US, UK, sanctioned countries or regions, or any jurisdiction where they are prohibited by local law**. This is the only Bankr feature that requires location verification.
 
 1. Log in to the [Bankr console](https://bankr.bot). Your location is verified automatically from your connection — there are no forms and nothing to upload.
-2. Once verified, you can trade Robinhood stocks from any platform — X, Telegram, the console, or the API.
+2. Once verified, you can trade issuer-tokenized stocks from any platform — X, Telegram, the console, or the API.
 3. Verification expires after 30 days. Logging in to the console again renews it.
 
-If you attempt a stock trade before verifying (or after your verification lapses), the trade is blocked and Bankr asks you to log in to the console first. Only Robinhood stock trades are gated — memecoins on Robinhood Chain, bridging, and transfers work without verification. Over the Wallet API, a swap involving a Robinhood tokenized stock without a passed location check returns `403` with instructions to verify.
+If you attempt a stock trade before verifying (or after your verification lapses), the trade is blocked and Bankr asks you to log in to the console first. Only issuer-tokenized stock trades are gated — memecoins on Robinhood Chain, everything else on Base, bridging, and transfers work without verification. Over the Wallet API, a swap involving a gated tokenized stock without a passed location check returns `403` with instructions to verify.
 
-## Solana and Base (spot)
+## Solana and third-party issuers on Base (spot)
 
 Tokenized stocks from third-party issuers — such as xStocks (AAPLx, TSLAx, and others) on Solana — trade like any other token on those chains. No location verification is required; standard swap, limit order, and DCA commands all work:
 
@@ -81,10 +101,11 @@ No location verification is required for perps. Equity perpetuals only trade dur
 
 ## Which venue should I use?
 
-- **Own the asset on an EVM chain with deep coverage** → Robinhood Chain (verification required)
+- **Own the asset on an EVM chain with the widest coverage** → Robinhood Chain, 200 names (verification required)
+- **Own a large-cap on Base, alongside the rest of your Base portfolio** → B20 equities, 13 names (verification required)
 - **Own the asset on Solana without verification** → xStocks
 - **Leveraged or short exposure, no ownership** → Avantis (Base) or Hyperliquid perps
 
 ## Regional availability & risk
 
-Robinhood tokenized stocks are unavailable in the US, UK, and sanctioned countries and regions. Availability of third-party issuer tokens on Solana and Base is subject to the issuer's own terms. Nothing here is investment advice; tokenized equities carry issuer and market risks in addition to normal on-chain risks.
+Robinhood Chain and Base B20 tokenized stocks are unavailable in the US, UK, and sanctioned countries and regions. Availability of third-party issuer tokens on Solana and Base is subject to the issuer's own terms. Nothing here is investment advice; tokenized equities carry issuer and market risks in addition to normal on-chain risks.

--- a/bankr/references/x402-cloud.md
+++ b/bankr/references/x402-cloud.md
@@ -184,6 +184,21 @@ bankr agent prompt "What does the x402 weather endpoint cost?"
 
 The agent pays in the token each endpoint requires (USDC or any supported ERC-20) on Base. Maximum payment per request is $10. The agent will always confirm the payment amount and token before calling.
 
+### Via the CLI
+
+```bash
+bankr x402 schema <url>                           # Inspect pricing and input/output schema
+bankr x402 call <url>                             # Call with automatic payment (GET)
+bankr x402 call <url> -X POST -d '{"text":"hi"}'  # With a method and JSON body
+bankr x402 call <url> --max-payment 0.50          # Your cap in USD (default 1, ceiling 10)
+bankr x402 call <url> -i                          # Fetch the schema and prompt for input values
+bankr x402 call <url> -y                          # Skip the payment confirmation
+```
+
+**`--max-payment` is your cap, and your cap is what gets sent.** The price an endpoint advertises is display-only — it can never raise your cap, and a call whose advertised price exceeds the cap fails closed instead of paying. In non-interactive mode the price probe is skipped entirely, so `--ni` behaves the same as `-y`.
+
+**Smart-contract wallets can pay.** Payment signatures are verified through an ERC-1271/6492-aware path as well as plain ECDSA recovery, so gas-sponsored and 7702-delegated wallets settle x402 payments normally rather than failing verification.
+
 ### With x402-fetch (for developers)
 
 ```typescript


### PR DESCRIPTION
Weekly refresh of the `bankr` skill against capabilities that are now live on the platform. Four new areas are documented, and several existing sections had drifted from actual behaviour.

## New

**LLM gateway privacy tiers.** The gateway serves every request at one of three nesting tiers — `standard`, `zdr` (zero data retention), `private` (TEE). Documents all four ways to request one (the `privacy` body field, a `/zdr` or `/private` base-path prefix, a `:zdr` / `:private` model suffix, and the account-wide setting), the fail-closed contract, how the account setting and a per-request ask combine, the `X-Privacy-Tier` response header, and the privacy error codes (`zdr_unavailable`, `privacy_conflict`, `invalid_privacy`). Replaces the narrower "Private (Confidential) Inference" section, which covered only the `:private` suffix.

**Max Mode.** Running the agent on a chosen gateway model via `--model` / `-m`, billed per token from LLM credits. Covers how credits are enforced — the effective balance becomes the run's budget and is re-checked before every LLM call, and an uncovered batch leaves the credit untouched so the usage stays owed until a top-up settles it — plus the CLI and web-terminal surfaces and the Agent API cap.

**Base B20 tokenized equities.** Base is now a tokenized-stock venue alongside Robinhood Chain, with 13 Coinbase-issued equity tokens. Documents the ticker list, the on-chain multiplier pricing model, the 8-decimal difference from Robinhood stocks, the ticker collision across chains, and that these trades sit behind the same location verification as Robinhood stocks.

**Wallet file storage** (new `references/files.md`). The per-wallet filesystem: the `bankr files` CLI surface, `/user/files/*` over REST, free/Club quotas and how they're checked, soft deletion, and asking questions about a file without loading it into the conversation — including what that sandbox can run and its size/time/output limits.

**Stock-paired token launches.** Pairing a launch pool with a registry tokenized stock instead of WETH, on Base and Robinhood Chain, via `pairedStockAddress`.

## Corrected

- **Bankr Club perks** — the list had drifted in both directions. Rebuilt from what the platform actually gates, with the swap-fee tiers (0.15% vs 0.65%), the terminal and Agent API message caps, storage tiers, and automation limits. Notes Max Mode as the alternative for anyone who can't or doesn't want to subscribe, including external-wallet users.
- **Token deploy limits** — the daily deploy cap and the gas-sponsorship cap were conflated into one number; they're separate, and the sponsorship figures were stale.
- **Robinhood Chain listing count** — 95+ → 200.

## Smaller updates

- Market research: token holder snapshots with USD value, supply percentage, and a concentration summary, plus the minimum-USD floor and the caveat that the raw holder set includes pools and treasuries
- Hyperliquid: the 1 USDC withdrawal fee comes out of the requested amount, so the full balance is requestable and sub-$1 withdrawals are refused
- x402: `--max-payment` is the cap that gets sent and an advertised price can't raise it; smart-contract wallets can now settle payments
- NFTs: ERC-20-priced listings are buyable, with approval, balance preflight, and decimals-aware pricing handled
- Arbitrary transactions: struct parameters use the parenthesized signature form, and ABI reads return them already expanded
- Portfolio: token balances are exact plain-notation decimal strings
- Gateway model snapshot refreshed with newly available models

---
_Generated by [Claude Code](https://claude.ai/code/session_01T2ceMWyWPJeh2s2YvafkwX)_