### PR TITLE
Add PFWA prediction markets skill

### DIFF
--- a/pfwa/prediction-markets/SKILL.md
+++ b/pfwa/prediction-markets/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: pfwa-prediction-markets
+description: Interact with PFWA (https://www.pfwa.fun/) prediction markets on Robinhood Chain (Chain ID 4663) to query markets, calculate quotes, buy YES/NO shares, and sell or redeem positions.
+visibility: private
+---
+
+# PFWA Prediction Markets
+
+PFWA is a permissionless prediction market protocol deployed on **Robinhood Chain (Chain ID 4663)**. It allows users to trade and create prediction markets based on token price, market cap, and volume metrics for Robinhood Chain tokens. Markets resolve permissionlessly using GeckoTerminal data.
+
+## Contract Addresses (Robinhood Chain - Chain ID 4663)
+
+- **PFWA Factory**: `0x2502aB7E69dDb3157683A82E603360Ada9B6E647`
+- **PFWA Orchestrator**: `0x943F5d2E75afec6d3f75aaF2E7Cdf8fE5418eD33`
+- **Block Explorer**: `https://robinhoodchain.blockscout.com`
+
+---
+
+> **CRITICAL INSTRUCTION FOR THE AI AGENT:** 
+> Do **NOT** attempt to use standard DEX swap routers, aggregators, or liquidity pools to buy or sell these outcome tokens. PFWA uses an internal custom bonding curve. You **MUST** execute trades by submitting a raw smart contract transaction directly to the option token's contract address, calling the `buy()` or `sell()` functions.
+
+---
+
+## Capabilities
+
+- **Market Discovery:** Query live, active, and resolved prediction markets via the PFWA API.
+- **Trading:** Quote prices, buy shares, and sell shares for active markets using bonding curve liquidity.
+- **Resolution & Claims:** Sell shares to exit a position early, or claim ETH winnings for correct predictions on resolved markets.
+
+## Usage Examples
+
+"Query active PFWA markets to see what tokens I can bet on."
+"Get a price quote to buy 100 shares of Option A for market 52."
+"Buy 0.01 ETH worth of YES shares for the $DOGE market."
+"Sell my position in market 52."
+
+## Requirements
+
+- **Chain:** `robinhood` (Robinhood Chain Mainnet - Chain ID 4663)
+- **Native Currency:** ETH (used for buying shares and paying gas)
+
+---
+
+## Functions & Operations
+
+### 1. Query Active Markets
+- Fetch active or resolved prediction markets directly from the PFWA API.
+- **Endpoint:** `GET https://www.pfwa.fun/api/agents/markets`
+- Returns a list of all active markets with their `marketId`, options, and `optionTokens` (the contract addresses to trade on).
+
+### 2. Get Price Quote
+- Fetch the exact cost to buy or the proceeds from selling a specific amount of shares.
+- **Endpoint:** `GET https://www.pfwa.fun/api/agents/quote?tokenAddress={address}&amount={weiAmount}`
+- *See the attached `api-docs.md` reference for the exact JSON structure.*
+
+### 3. Buy Market Shares (YES / NO)
+- **Contract:** The specific Option Token Contract (found in the `optionTokens` array from the API response).
+- **Chain:** `robinhood`
+- **Action:** Submit a raw transaction calling `buy(tokenAmount)` with native ETH attached as `msg.value` (get the exact ETH amount needed from the quote API first). 
+- *DO NOT route this through a DEX.*
+
+### 4. Sell / Redeem Position
+- **Contract:** The specific Option Token Contract (`optionTokens[index]`).
+- **Chain:** `robinhood`
+- **Action:** Submit a raw transaction calling `sell(tokenAmount)` to exit a position early.
+- **Claiming:** If the market is resolved and this was the winning option, call `claimWinnings()` to withdraw your ETH share.

--- a/pfwa/prediction-markets/pfwa-abi.json
+++ b/pfwa/prediction-markets/pfwa-abi.json
@@ -1,0 +1,56 @@
+[
+  {
+    "type": "function",
+    "name": "buy",
+    "inputs": [
+      {
+        "name": "tokenAmount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [],
+    "stateMutability": "payable"
+  },
+  {
+    "type": "function",
+    "name": "sell",
+    "inputs": [
+      {
+        "name": "tokenAmount",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "outputs": [
+      {
+        "name": "",
+        "type": "uint256",
+        "internalType": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "claimWinnings",
+    "inputs": [],
+    "outputs": [],
+    "stateMutability": "nonpayable"
+  },
+  {
+    "type": "function",
+    "name": "createRelayerMarket",
+    "inputs": [
+      { "internalType": "string", "name": "title", "type": "string" },
+      { "internalType": "string[]", "name": "optionTokens", "type": "string[]" },
+      { "internalType": "uint256", "name": "expirationTime", "type": "uint256" },
+      { "internalType": "uint8", "name": "mType", "type": "uint8" }
+    ],
+    "outputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "address[]", "name": "", "type": "address[]" }
+    ],
+    "stateMutability": "nonpayable"
+  }
+]

--- a/pfwa/prediction-markets/references/api-docs.md
+++ b/pfwa/prediction-markets/references/api-docs.md
@@ -1,0 +1,58 @@
+# PFWA API Documentation
+
+The PFWA platform provides two read-only endpoints for agents to query live market data and calculate bonding curve prices without needing to directly query RPC nodes.
+
+## 1. List Active Markets
+
+Retrieves all currently active or recently resolved prediction markets.
+
+**Endpoint:** `GET https://www.pfwa.fun/api/agents/markets`
+
+### Response Format
+```json
+{
+  "markets": [
+    {
+      "marketId": 52,
+      "title": "Will $DOGE hit $0.20 by tomorrow?",
+      "marketType": 0,
+      "resolved": false,
+      "expirationTime": 1723500000,
+      "options": [
+        {
+          "name": "YES",
+          "tokenAddress": "0x1234...abcd"
+        },
+        {
+          "name": "NO",
+          "tokenAddress": "0x5678...efgh"
+        }
+      ]
+    }
+  ]
+}
+```
+
+*Note: The `tokenAddress` for each option is the smart contract address you interact with to `buy()` or `sell()` shares.*
+
+## 2. Get Trading Quotes
+
+Calculates the exact execution price to buy or sell shares on the bonding curve.
+
+**Endpoint:** `GET https://www.pfwa.fun/api/agents/quote?tokenAddress={address}&amount={weiAmount}`
+
+**Parameters:**
+- `tokenAddress`: The contract address of the specific option (e.g. YES or NO token).
+- `amount`: The amount of shares you want to buy (in Wei, so 1 share = 1e18).
+
+### Response Format
+```json
+{
+  "costToBuyWei": "15000000000000000",
+  "costToBuyEth": "0.015",
+  "proceedsFromSellWei": "14500000000000000",
+  "proceedsFromSellEth": "0.0145"
+}
+```
+
+*Note: Use `costToBuyWei` as the `msg.value` when submitting the `buy(amount)` transaction to the `tokenAddress`.*


### PR DESCRIPTION
This PR introduces the official skill for PFWA Prediction Markets on Robinhood Chain (Chain ID 4663).

### What this skill does:
- Allows agents to discover live and resolved prediction markets via the PFWA API.
- Enables agents to fetch exact execution quotes for bonding curve token swaps.
- Provides the ABI and strict instructions for executing raw contract transactions to buy/sell shares directly without relying on DEX liquidity pools (which are unsupported for these outcome tokens).

### Files included:
- `SKILL.md`: The core skill instructions and contract addresses.
- `references/api-docs.md`: Details the JSON structures for market discovery and bonding curve quotes.
- `pfwa-abi.json`: The stripped-down contract ABI needed for agents to safely encode `buy()` and `sell()` transactions.

Tested and verified on live markets.
