### PR TITLE
docs(bankr): weekly skill sync — NFT bids and listings, contract deploy, holders endpoint, gateway daily budget

### DIFF
--- a/bankr/SKILL.md
+++ b/bankr/SKILL.md
@@ -626,7 +626,7 @@ bankr llm models --zdr                                   # which models have a Z
 
 ### Daily Spend Budget
 
-An optional per-UTC-day cap across **all metered LLM spend on the wallet** — every API key it owns, plus Max Mode and app-invoked agent runs. Gateway requests over budget are refused; an agent run ends early once the day's spend reaches the cap.
+An optional per-UTC-day cap across **all metered LLM spend on the wallet** — every API key it owns, plus Max Mode agent runs (wherever they're invoked from). Gateway requests over budget are refused; a Max Mode agent run ends early once the day's spend reaches the cap. Ordinary non-Max agent runs don't spend LLM credits, so they aren't affected.
 
 ```bash
 curl -s https://llm.bankr.bot/v1/credits -H "X-API-Key: $BANKR_LLM_KEY"
@@ -637,7 +637,7 @@ curl -s https://llm.bankr.bot/v1/credits -H "X-API-Key: $BANKR_LLM_KEY"
 
 - `dailyBudget` is **omitted entirely** when the wallet is uncapped, so its presence is the answer to "am I capped?" — no sentinel value to test for.
 - Over budget, spend requests return `402` with error `type: "daily_budget_exceeded"` — distinct from the `insufficient_credits` you get when the balance itself runs out. Read-only `GET` endpoints (`/v1/credits`, `/v1/usage`, `/v1/models`) keep working, so you can still read `remainingUsd` and `resetsAt` to find out when you'll be unblocked.
-- Budget changes reach the gateway within ~60s (it caches auth state), and each instance caches independently — so spend can overshoot slightly under a sustained burst. Treat it as a guardrail; your credit balance is still the hard limit on total spend.
+- Budget changes take effect within ~60s and enforcement is eventually consistent, so spend can overshoot the cap slightly under a sustained burst. Treat it as a guardrail; your credit balance is still the hard limit on total spend.
 
 ### Max Mode — Pick the Agent's Model
 
@@ -699,7 +699,7 @@ For full details — setup paths, model list, provider config, SDK examples, key
 ### Trading Operations
 
 - **Token Swaps**: Buy/sell/swap tokens across chains
-- **Exact-output orders**: pin the quantity you want to *receive* ("buy exactly 1,000 PEPE"), not just the amount to spend — supported on same-chain EVM and same-chain Solana
+- **Exact-output orders**: name the quantity you want to *receive* ("buy exactly 1,000 PEPE") and Bankr sizes the input — supported on same-chain EVM and same-chain Solana. The output is a target, not a guarantee: price impact means the delivered amount lands close to it, not exactly on it
 - **Cross-Chain**: Bridge tokens between chains
 - **Limit Orders**: Execute at target prices
 - **Stop Loss**: Automatic sell protection
@@ -749,13 +749,13 @@ For full details — setup paths, model list, provider config, SDK examples, key
 
 ### NFT Operations
 
-Buy, sell, bid, and manage NFTs through OpenSea on **every supported EVM chain** — Base, Ethereum, Polygon, Unichain, World Chain, Arbitrum, BNB Chain, and Robinhood Chain.
+Buy, sell, bid, and manage NFTs through OpenSea on **Base, Ethereum, Polygon, Unichain, Arbitrum, and Robinhood Chain**. World Chain and BNB Chain are supported for trading but not for NFTs — Bankr has no marketplace coverage there.
 
 - Browse and search collections
 - View floor prices and listings
 - Purchase NFTs via OpenSea — including listings priced in an **ERC-20** rather than the native token (e.g. USDG on Robinhood Chain). The token approval, the payment-currency balance check, and decimals-aware pricing are all handled for you
 - **List your NFTs for sale**, see your own live listings, and cancel them
-- **Check the best offer** on any NFT (a collection with no live offers is a normal "no offers" answer, not an error) and accept offers on NFTs you own
+- **Check the best offer** on any NFT (one with no live offers is a normal "no offers" answer, not an error) and accept offers on NFTs you own
 - **Make collection-wide bids** — an offer good for any token in a collection — see the bids you've made, and retract them
 - View your NFT portfolio
 - Transfer NFTs
@@ -778,7 +778,7 @@ Bids are always paid in an **ERC-20**, never native ETH — WETH on most chains,
 ### Leverage Trading
 
 - **Hyperliquid** (primary) — Perpetual futures on Hyperliquid L1 with on-chain order book. Crypto, stocks (TSLA, AAPL, NVDA via HIP-3), spot trading. Up to 50x leverage.
-- **Avantis** (secondary) — Perpetuals on Base for crypto, equities (NVDA, TSLA, AAPL, HOOD, and more), forex, and commodities, across ~118 pairs. Equity, forex, and commodity pairs trade during their underlying market hours only.
+- **Avantis** (secondary) — Perpetuals on Base for crypto, equities (NVDA, TSLA, AAPL, HOOD, and more), forex, and commodities, across 100+ pairs. Equity, forex, and commodity pairs trade during their underlying market hours only.
 - Stop loss, take profit, and position management on both platforms
 - On Avantis, a stop loss or take profit set on the wrong side of the trade — an SL past your liquidation price, or a TP the wrong side of entry — is **refused up front with the liquidation price in the message**, rather than accepted and silently dropped. Setting a level also waits until it is actually visible on the position before reporting success, so "set" means set. Avantis TP/SL is not available in wallet (connected-wallet) mode, which returns a clear unsupported error
 - Funding Hyperliquid is a **venue** deposit/withdraw, not a bridge: a deposit only reaches Hyperliquid, a withdrawal only lands on Arbitrum. Name the venue ("deposit $500 to hyperliquid") rather than saying "bridge"; to move withdrawn funds onward, chain a cross-chain swap after the withdrawal
@@ -1146,7 +1146,7 @@ See [references/safety.md](references/safety.md) for comprehensive safety guidan
 - "Swap 0.1 ETH for USDC"
 - "Sell 50% of my PEPE"
 - "Bridge 100 USDC from Polygon to Base"
-- "Buy exactly 1,000 PEPE on Base" (exact-output — pins what you receive)
+- "Buy exactly 1,000 PEPE on Base" (exact-output — targets what you receive)
 - "Buy exactly 500 BONK on Solana"
 
 ### Tokenized Stocks

--- a/bankr/SKILL.md
+++ b/bankr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bankr
-description: AI-powered crypto trading agent, wallet API, and LLM gateway via natural language. Use when the user wants to trade crypto, trade tokenized stocks and ETFs (spot or leveraged), check portfolio balances (with PnL and NFTs), view token prices, search tokens, research token holders, transfer crypto, manage NFTs, use leverage (Hyperliquid or Avantis), bet on Polymarket, deploy tokens, set up automated trading, sign and submit raw transactions, call or deploy x402 paid API endpoints, browse the web, store and query files on their wallet's filesystem, or access LLM models through the Bankr LLM gateway funded by your Bankr wallet — including zero-data-retention and TEE-private inference tiers. Supports Base, Ethereum, Polygon, Solana, Unichain, World Chain, Arbitrum, BNB Chain, and Robinhood Chain.
+description: AI-powered crypto trading agent, wallet API, and LLM gateway via natural language. Use when the user wants to trade crypto, trade tokenized stocks and ETFs (spot or leveraged), check portfolio balances (with PnL and NFTs), view token prices, search tokens, research token holders, transfer crypto, buy/sell/list/bid on NFTs, use leverage (Hyperliquid or Avantis), bet on Polymarket, deploy tokens, deploy and verify arbitrary EVM contracts, set up automated trading, sign and submit raw transactions, call or deploy x402 paid API endpoints, deploy webhooks that trigger the agent from external events, browse the web, store and query files on their wallet's filesystem, or access LLM models through the Bankr LLM gateway funded by your Bankr wallet — including zero-data-retention and TEE-private inference tiers. Supports Base, Ethereum, Polygon, Solana, Unichain, World Chain, Arbitrum, BNB Chain, and Robinhood Chain.
 metadata:
   {
     "clawdbot":
@@ -253,6 +253,25 @@ The legacy aliases `/public/resolve-recipient` and `/public/search-users` have b
 | `/agent/job/{jobId}` | GET | Check job status and results |
 | `/agent/job/{jobId}/cancel` | POST | Cancel a running job |
 
+#### Token data (`/tokens/*`)
+
+| Endpoint | Method | Auth | Description |
+|----------|--------|------|-------------|
+| `/tokens/search?query=<q>` | GET | None | Search tokens by name or symbol |
+| `/tokens/trending?chain=<chain>` | GET | None | Trending tokens for a chain |
+| `/tokens/balance` | GET | None | Single-token on-chain balance for an address (authoritative for fresh/thin tokens the portfolio read model hides) |
+| `/tokens/balances` | GET | None | Token balances for an address |
+| `/tokens/holders?tokenAddress=0x…&chain=<chain>` | GET | API key | Holders of an EVM token joined to Bankr wallet identity and X handle |
+
+`GET /tokens/holders` is the only authenticated route in this group — it maps addresses to real social identities. Query params: `tokenAddress` (0x, required), `chain` (required, any supported EVM chain), `filter` (`bankr` — default, Bankr wallets only, cheap and exact; or `all` — the full on-chain ranking annotated with Bankr identity where we recognise the address), `limit` (1–100, default 50), and `cursor`.
+
+```bash
+curl -s "https://api.bankr.bot/tokens/holders?tokenAddress=0x...&chain=base&filter=all&limit=50" \
+  -H "X-API-Key: $BANKR_API_KEY"
+```
+
+Each row carries `address`, `balance` (raw integer string — may exceed `Number` precision), `isBankrWallet`, and `xUsername` / `xProfileImageUrl` when known. Paginate by replaying `nextCursor` as `cursor` until it's absent; a cursor is only valid for the exact `tokenAddress` + `chain` + `filter` that minted it (`400` otherwise). Ranking is over live balances, so it is a feed, not a snapshot — a holder whose balance moves between pages can repeat or be missed.
+
 #### Public endpoints (no auth required)
 
 | Endpoint | Method | Description |
@@ -293,8 +312,9 @@ For full API details (request/response schemas, job states, rich data, polling s
 | `bankr wallet transfer --to vitalik.eth --token USDC --amount 50 --chain base` | ENS recipient with explicit chain |
 | `bankr wallet swap --from <symbol/addr> --to <symbol/addr> --amount <amount>` | Swap tokens on a single EVM chain (same-chain). Resolves symbols to contracts; `--from`/`--to`/`--amount` required; `--chain` defaults to `base`. Solana is not supported (use the Wallet API or agent for cross-chain and Solana swaps). |
 | `bankr wallet swap --from ETH --to USDC --amount 0.1 --chain base --quote-only` | Print the swap quote (you pay / you receive / min received) without executing |
-| `bankr wallet sign` | Sign messages/typed data/transactions |
-| `bankr wallet submit` | Submit raw transactions |
+| `bankr wallet sign -t <type> [-m <msg>\|--typed-data <json>\|--transaction <json>]` | Sign a message (`personal_sign`), EIP-712 typed data (`eth_signTypedData_v4`), or a transaction (`eth_signTransaction`) without broadcasting |
+| `bankr wallet submit tx --to <addr> --chain-id <id> [--value <wei>] [--data <hex>] [--no-wait]` | Submit a transaction from explicit parameters (also accepts gas/nonce/EIP-1559 overrides) |
+| `bankr wallet submit json '<json>'` | Submit a transaction from JSON: `{to, chainId, value?, data?}` |
 
 ### `bankr agent` — AI Agent Operations
 
@@ -328,8 +348,30 @@ For full API details (request/response schemas, job states, rich data, polling s
 | `bankr files write <fileId> [--from <path>]` | Overwrite text content from a local file or stdin |
 | `bankr files search <query> [--folder <path>] [--limit <n>]` | Search by filename, extension, or description |
 | `bankr files mkdir <name> [--parent <path>]` | Create a folder |
+| `bankr files mv <fileId> <folder>` | Move a file to a different folder |
+| `bankr files rename <fileId> <name>` | Rename a file or folder |
+| `bankr files info <fileId>` | Show file metadata |
 | `bankr files rm <fileId>` | Delete a file (soft — recoverable for 24h) |
 | `bankr files storage` | Show storage usage and quota |
+
+### `bankr webhooks` — Agent-Triggering Webhooks
+
+Deploy your own TypeScript handlers that turn an external event into a Bankr agent run. Each deployed webhook gets a public trigger URL — `https://webhooks.bankr.bot/u/<wallet>/<name>` — and the handler returns `{ prompt, threadId?, context? }`, which the agent then executes on your wallet.
+
+| Command | Description |
+|---------|-------------|
+| `bankr webhooks init` | Scaffold a `webhooks/` folder and `bankr.webhooks.json` |
+| `bankr webhooks add <name> [--provider slack\|github\|stripe\|generic]` | Add a handler, optionally from a provider template |
+| `bankr webhooks deploy [name]` | Bundle and deploy all handlers, or one |
+| `bankr webhooks list` | List deployed webhooks |
+| `bankr webhooks pause <name>` / `resume <name>` | Pause or resume a deployed webhook |
+| `bankr webhooks delete <name>` | Delete a deployed webhook (not undoable) |
+| `bankr webhooks logs <name>` | Recent invocations |
+| `bankr webhooks env set KEY=VALUE` / `list` / `unset KEY` | Manage encrypted env vars (e.g. signing secrets) |
+
+**The trigger URL is public — verify the signature in your handler.** The `slack`, `github`, and `stripe` templates ship with signature verification and return `401` without ever reaching the agent; the `generic` template does not, so anyone who guesses the URL can trigger agent runs on your wallet until you add a verifier.
+
+**Reference**: [references/webhooks.md](references/webhooks.md)
 
 ### `bankr club` — Bankr Club Membership
 
@@ -375,12 +417,14 @@ Pricing is $20/mo or $198/yr USD-equivalent. Actual on-chain amount depends on t
 | `bankr login email <address> --code <otp> [options]` | Verify OTP and complete setup (headless step 2) |
 | `bankr login --api-key <key>` | Login with an existing API key directly |
 | `bankr login --api-key <key> --llm-key <key>` | Login with separate LLM gateway key |
+| `bankr login siwe --private-key <key>` | Sign-in-with-Ethereum using a local key (headless) |
 | `bankr login --url` | Print Bankr Terminal URL for API key generation |
 | `bankr logout` | Clear stored credentials |
 | `bankr whoami` | Show current authentication info |
 | `bankr config get [key]` | Get config value(s) |
 | `bankr config set <key> <value>` | Set a config value |
 | `bankr --config <path> <command>` | Use a custom config file path |
+| `bankr update` | Update the CLI to the latest published version |
 
 Valid config keys: `apiKey`, `apiUrl`, `llmKey`, `llmUrl`
 
@@ -543,6 +587,7 @@ The [Bankr LLM Gateway](https://docs.bankr.bot/llm-gateway/overview) is a unifie
 - **Per-model discounts** available for Bankr Club members and partners — applied automatically at billing time
 - **Image generation**: generate images via the OpenAI-native `/v1/images/generations` endpoint (model `gpt-image-2`), billed from the same LLM credit balance — see the reference
 - **Expiring credit grants**: promotional or developer grants may carry an expiry date. Your spendable balance is your permanent (purchased) credits plus any unexpired grants — grants are spent first (soonest-expiring first) and drop off automatically at expiry
+- **Daily spend budget** (optional): a per-UTC-day cap on how much the wallet spends. The credit balance bounds *total* spend; this bounds *burn rate*, so a runaway loop or a leaked key can't drain a funded wallet in one day. Set it in the **Settings** tab at [bankr.bot/llm](https://bankr.bot/llm) — web auth only, so a key can never raise the cap it is bound by. See below
 - **Privacy tiers**: every request is served at `standard`, `zdr` (zero data retention), or `private` (TEE). Ask for a tier per request, per model, per base URL, or account-wide — see below
 
 ### Privacy Tiers
@@ -579,6 +624,21 @@ bankr llm models --zdr                                   # which models have a Z
 - **`X-Privacy-Tier` response header** reports the tier the request was actually handled under, so the guarantee is verifiable rather than assumed.
 - Tier matching is case-insensitive, and only a *trailing* `:zdr` / `:private` token counts as the suffix opt-in.
 
+### Daily Spend Budget
+
+An optional per-UTC-day cap across **all metered LLM spend on the wallet** — every API key it owns, plus Max Mode and app-invoked agent runs. Gateway requests over budget are refused; an agent run ends early once the day's spend reaches the cap.
+
+```bash
+curl -s https://llm.bankr.bot/v1/credits -H "X-API-Key: $BANKR_LLM_KEY"
+# → { "balanceUsd": …, "effectiveBalanceUsd": …, "undeductedCostUsd": …,
+#     "dailyBudget": { "limitUsd": 25, "spentUsd": 4.2, "remainingUsd": 20.8,
+#                      "exceeded": false, "resetsAt": "…T00:00:00.000Z" } }
+```
+
+- `dailyBudget` is **omitted entirely** when the wallet is uncapped, so its presence is the answer to "am I capped?" — no sentinel value to test for.
+- Over budget, spend requests return `402` with error `type: "daily_budget_exceeded"` — distinct from the `insufficient_credits` you get when the balance itself runs out. Read-only `GET` endpoints (`/v1/credits`, `/v1/usage`, `/v1/models`) keep working, so you can still read `remainingUsd` and `resetsAt` to find out when you'll be unblocked.
+- Budget changes reach the gateway within ~60s (it caches auth state), and each instance caches independently — so spend can overshoot slightly under a sustained burst. Treat it as a guardrail; your credit balance is still the hard limit on total spend.
+
 ### Max Mode — Pick the Agent's Model
 
 Max Mode overrides the Bankr agent's default model with any model from the gateway, billed per token from your **LLM credit balance** (not your trading wallet):
@@ -593,7 +653,8 @@ The setting is stored on your wallet and applies across every surface — CLI, w
 
 - **Credits are enforced per LLM call, not after the fact.** Your spendable balance (minus anything already metered but not yet deducted) becomes the run's budget, re-checked before every call — the turn ends honestly when it's exhausted instead of overspending.
 - **Shortfalls survive.** If a batch can't be fully covered, the credit is left untouched and the usage stays owed, so a later top-up settles it rather than the overspend being written off.
-- Top up before enabling, or Max Mode messages will fail.
+- **Out of credits is a reply, not a crash.** The agent asks you to top up rather than silently answering on the default model — except on X, where it quietly falls back to the standard model so a public thread never becomes a top-up nag. If credits run out *partway* through a turn, it stops there and saves its progress in the thread, so you can top up and ask it to continue.
+- Top up (or enable auto top-up) before enabling, so a run isn't interrupted mid-turn.
 
 ### Quick Commands
 
@@ -638,6 +699,7 @@ For full details — setup paths, model list, provider config, SDK examples, key
 ### Trading Operations
 
 - **Token Swaps**: Buy/sell/swap tokens across chains
+- **Exact-output orders**: pin the quantity you want to *receive* ("buy exactly 1,000 PEPE"), not just the amount to spend — supported on same-chain EVM and same-chain Solana
 - **Cross-Chain**: Bridge tokens between chains
 - **Limit Orders**: Execute at target prices
 - **Stop Loss**: Automatic sell protection
@@ -657,6 +719,8 @@ For full details — setup paths, model list, provider config, SDK examples, key
 - Wrapping/unwrapping the native token (ETH ↔ WETH and equivalents) is reflected in both balances right away
 - Filter by chain: `bankr wallet portfolio --chain base,solana` or `GET /wallet/portfolio?chains=base,solana`
 
+> **`token.balance` is a string, not a number.** It holds the exact decimal amount — parsing it as a float rounds high-decimal tokens up, and a max-size trade built from a rounded balance reverts on-chain. `nativeBalance`, `nativeUsd` and `total` are strings too; `balanceUSD` and `price` are numbers.
+
 **Reference**: [references/portfolio.md](references/portfolio.md)
 
 ### Market Research
@@ -668,6 +732,7 @@ For full details — setup paths, model list, provider config, SDK examples, key
 - Trending tokens
 - Token comparisons
 - **Holder snapshots** — largest-first holder lists with USD value and supply percentage, plus a concentration summary. Supports a minimum-USD floor, which makes it usable for airdrop targeting ("holders of X with $50+")
+- **Holders joined to Bankr identity** — `GET /tokens/holders` returns an EVM token's holders with their Bankr wallet and X handle, paginated. Use `filter=bankr` for just the Bankr users who hold it, `filter=all` for the full on-chain ranking annotated where we recognise the address
 
 **Reference**: [references/market-research.md](references/market-research.md)
 
@@ -684,13 +749,19 @@ For full details — setup paths, model list, provider config, SDK examples, key
 
 ### NFT Operations
 
+Buy, sell, bid, and manage NFTs through OpenSea on **every supported EVM chain** — Base, Ethereum, Polygon, Unichain, World Chain, Arbitrum, BNB Chain, and Robinhood Chain.
+
 - Browse and search collections
 - View floor prices and listings
 - Purchase NFTs via OpenSea — including listings priced in an **ERC-20** rather than the native token (e.g. USDG on Robinhood Chain). The token approval, the payment-currency balance check, and decimals-aware pricing are all handled for you
-- Accept offers on NFTs you own
+- **List your NFTs for sale**, see your own live listings, and cancel them
+- **Check the best offer** on any NFT (a collection with no live offers is a normal "no offers" answer, not an error) and accept offers on NFTs you own
+- **Make collection-wide bids** — an offer good for any token in a collection — see the bids you've made, and retract them
 - View your NFT portfolio
 - Transfer NFTs
 - Mint from supported platforms
+
+Bids are always paid in an **ERC-20**, never native ETH — WETH on most chains, or whatever currency the collection pins (USDG on some Robinhood Chain collections). If your balance is short and the currency is WETH, Bankr wraps the difference from ETH for you. Only collection-wide bids can be retracted through Bankr; a bid on a single token has to be cancelled on OpenSea directly.
 
 **Reference**: [references/nft-operations.md](references/nft-operations.md)
 
@@ -707,8 +778,9 @@ For full details — setup paths, model list, provider config, SDK examples, key
 ### Leverage Trading
 
 - **Hyperliquid** (primary) — Perpetual futures on Hyperliquid L1 with on-chain order book. Crypto, stocks (TSLA, AAPL, NVDA via HIP-3), spot trading. Up to 50x leverage.
-- **Avantis** (secondary) — Perpetuals on Base for crypto, equities (NVDA, TSLA, AAPL, HOOD, and more), forex, and commodities. Equity, forex, and commodity pairs trade during their underlying market hours only.
+- **Avantis** (secondary) — Perpetuals on Base for crypto, equities (NVDA, TSLA, AAPL, HOOD, and more), forex, and commodities, across ~118 pairs. Equity, forex, and commodity pairs trade during their underlying market hours only.
 - Stop loss, take profit, and position management on both platforms
+- On Avantis, a stop loss or take profit set on the wrong side of the trade — an SL past your liquidation price, or a TP the wrong side of entry — is **refused up front with the liquidation price in the message**, rather than accepted and silently dropped. Setting a level also waits until it is actually visible on the position before reporting success, so "set" means set. Avantis TP/SL is not available in wallet (connected-wallet) mode, which returns a clear unsupported error
 - Funding Hyperliquid is a **venue** deposit/withdraw, not a bridge: a deposit only reaches Hyperliquid, a withdrawal only lands on Arbitrum. Name the venue ("deposit $500 to hyperliquid") rather than saying "bridge"; to move withdrawn funds onward, chain a cross-chain swap after the withdrawal
 - Hyperliquid charges a **1 USDC withdrawal fee, taken out of the requested amount** — so your full withdrawable balance is requestable (you receive amount − 1), and withdrawals under $1 are refused rather than netting to zero
 
@@ -769,6 +841,11 @@ The agent can discover, call, and deploy x402-protected API endpoints, automatic
 - **Price** your own endpoints in USDC or any supported ERC-20; revenue settles on-chain and is accounted in USD at settlement time
 - Works with any x402-compatible endpoint (Bankr-hosted or external)
 
+Two things worth knowing when calling third-party endpoints:
+
+- **`$0` challenges are paid, not rejected.** Some services gate a free endpoint behind a `$0` 402 whose payment payload they verify but never settle. Bankr signs it (no allowance check, no gas burned on an approval) instead of bailing as unparseable
+- **A multi-rail 402 is priced on the rail Bankr can actually settle.** Sellers advertise rails in whatever order they like; Bankr prices and bounds the same entry it will sign, so a seller listing an unsupported rail first no longer makes a payable endpoint look unpriceable
+
 **Reference**: [references/x402-cloud.md](references/x402-cloud.md)
 
 ### Web Browsing
@@ -806,6 +883,11 @@ The agent can answer questions about Bankr itself — how features work, officia
 - Execute pre-built calldata from other tools
 - Value transfers with data
 - Read an unknown contract's ABI and call it — struct (tuple) parameters are expanded into the parenthesized signature form the encoder accepts, so struct-taking functions like Uniswap V4 position mints encode on the first try instead of failing as `tuple`
+- **Deploy a contract** from compiled creation bytecode, and **verify its source** on block explorers afterwards
+
+All of these work on every supported EVM chain (Base, Ethereum, Polygon, Unichain, World Chain, Arbitrum, BNB Chain, Robinhood Chain).
+
+> **Deploys go through a shared CREATE2 proxy**, so inside your constructor `msg.sender` is the proxy — **not** your wallet. A contract that assigns ownership or mints an initial supply to `msg.sender` will attribute those to the proxy. Prefer contracts that take the owner/recipient as an explicit constructor argument. The deployed address is deterministic and known before broadcasting, and deploys carry no native value. This is not for token launches — use the token deployment flow for those.
 
 **Reference**: [references/arbitrary-transaction.md](references/arbitrary-transaction.md)
 
@@ -869,6 +951,8 @@ Per-key settings configured at [bankr.bot/api-keys](https://bankr.bot/api-keys):
 **IP Whitelisting**: Set `allowedIps` on your API key to restrict usage to specific IPs or CIDR ranges (e.g., `10.0.0.0/24`). Requests from non-whitelisted IPs are rejected with 403 at the auth layer.
 
 **Recipient Allowlist**: Restrict which addresses the key can send funds to. Independent from the wallet-level permitted recipients — when both are configured, both must pass.
+
+**Active sessions**: [bankr.bot](https://bankr.bot) → Security lists every device signed in to the account. CLI email logins (`bankr login email`) appear there alongside browser sessions and can be logged out the same way — server-side, immediately. Sessions created by an older CLI predate this and won't be listed, so run `bankr update` and sign in again if a CLI session is missing.
 
 ### Incident Response
 
@@ -1062,6 +1146,8 @@ See [references/safety.md](references/safety.md) for comprehensive safety guidan
 - "Swap 0.1 ETH for USDC"
 - "Sell 50% of my PEPE"
 - "Bridge 100 USDC from Polygon to Base"
+- "Buy exactly 1,000 PEPE on Base" (exact-output — pins what you receive)
+- "Buy exactly 500 BONK on Solana"
 
 ### Tokenized Stocks
 
@@ -1115,6 +1201,12 @@ See [references/safety.md](references/safety.md) for comprehensive safety guidan
 - "Show Bored Ape floor price"
 - "Buy cheapest Pudgy Penguin"
 - "Show my NFTs"
+- "List my Pudgy Penguin #1234 for 5 ETH"
+- "Show my NFT listings" / "Cancel my listing on #1234"
+- "What's the best offer on my Bored Ape?"
+- "Bid 0.02 WETH on any okcomputers NFT" (collection-wide offer, paid in WETH)
+- "Offer 0.5 each for 3 Bored Apes, expiring in 2 days"
+- "Show the offers I've made" / "Cancel my okcomputers bids"
 
 ### Polymarket
 
@@ -1187,6 +1279,8 @@ See [references/safety.md](references/safety.md) for comprehensive safety guidan
 - "Submit this transaction: {to: 0x..., data: 0x..., value: 0, chainId: 8453}"
 - "Execute this calldata on Base: {...}"
 - "Send raw transaction with this JSON: {...}"
+- "Deploy this bytecode on Base: 0x60806040..." (constructor args already ABI-encoded and appended)
+- "Verify the contract I just deployed at 0x... on Base"
 
 ### Transfers (Direct)
 

--- a/bankr/references/arbitrary-transaction.md
+++ b/bankr/references/arbitrary-transaction.md
@@ -1,15 +1,19 @@
 # Arbitrary Transaction Reference
 
-Submit raw EVM transactions with explicit calldata to any supported chain.
+Submit raw EVM transactions with explicit calldata, call or read any contract, and deploy and verify contracts — on any supported EVM chain.
 
 ## Supported Chains
 
-| Chain | Chain ID |
-|-------|----------|
-| Ethereum | 1 |
-| Polygon | 137 |
-| Base | 8453 |
-| Unichain | 130 |
+| Chain | Chain ID | Slug |
+|-------|----------|------|
+| Ethereum | 1 | `mainnet` |
+| Unichain | 130 | `unichain` |
+| Polygon | 137 | `polygon` |
+| World Chain | 480 | `worldchain` |
+| BNB Chain | 56 | `bnb` |
+| Base | 8453 | `base` |
+| Arbitrum | 42161 | `arbitrum` |
+| Robinhood Chain | 4663 | `robinhood` |
 
 ## JSON Format
 
@@ -27,7 +31,7 @@ Submit raw EVM transactions with explicit calldata to any supported chain.
 | `to` | string | Yes | Target contract address (0x + 40 hex chars) |
 | `data` | string | Yes | Calldata to execute (0x + hex string, or "0x" for empty) |
 | `value` | string | Yes | Amount in wei (e.g., "0", "1000000000000000000" for 1 ETH) |
-| `chainId` | number | Yes | Target chain ID (1, 137, 8453, or 130) |
+| `chainId` | number | Yes | Target chain ID from the table above |
 
 ## Validation Rules
 
@@ -36,7 +40,7 @@ Submit raw EVM transactions with explicit calldata to any supported chain.
 | `to` | Must be 0x followed by exactly 40 hex characters |
 | `data` | Must start with 0x, can be "0x" for empty calldata |
 | `value` | Wei amount as string, use "0" for no value transfer |
-| `chainId` | Must be a supported chain ID |
+| `chainId` | Must be one of the supported chain IDs above |
 
 ## Prompt Examples
 
@@ -88,7 +92,7 @@ Submit this ERC-20 transfer:
 
 | Issue | Resolution |
 |-------|------------|
-| Unsupported chain | Use chainId 1, 137, 8453, or 130 |
+| Unsupported chain | Use one of the chain IDs in the table above |
 | Invalid address | Ensure 0x + 40 hex chars |
 | Invalid calldata | Ensure proper hex encoding with 0x prefix |
 | Transaction reverted | Check calldata encoding and contract state |
@@ -99,8 +103,44 @@ Submit this ERC-20 transfer:
 
 Ask Bankr for an unknown contract's ABI and it returns human-readable function signatures you can pass straight to a read or write call. Struct (tuple) parameters and return values are recursively expanded into the parenthesized form the encoder accepts, and every generated signature is round-tripped through the parser before being offered — so a struct-taking function like a Uniswap V4 position mint encodes on the first attempt rather than failing as the literal keyword `tuple`.
 
+## Deploying a Contract
+
+Bankr can deploy a contract from **compiled creation bytecode** and then verify its source on block explorers.
+
+**What you supply:** the creation bytecode (`initCode`) with any constructor arguments **already ABI-encoded and appended**, the chain, and optionally a 32-byte CREATE2 salt. Bankr does not compile Solidity and does not encode constructor arguments for you — bring ready-to-deploy bytecode.
+
+```
+Deploy this on Base: 0x60806040...
+Deploy this bytecode on Base with salt 0x00...2a
+```
+
+**How it deploys, and why that matters:**
+
+- Deployment goes through the canonical deterministic **CREATE2 proxy** (`0x4e59…4956c`, the same address on every chain). The deployed address is therefore **deterministic and known before broadcasting**.
+- Because the proxy is the deployer, **`msg.sender` inside your constructor is the proxy, not your wallet.** A constructor that assigns ownership or mints an initial supply to `msg.sender` gives those to the proxy. Prefer contracts that take the owner/recipient as an explicit constructor argument, and check this before deploying anything whose constructor may rely on `msg.sender`.
+- **Deploys carry no native value** — there is no `value` field, so a payable constructor needs a different flow.
+- A colliding salt (an address already taken) and a chain missing the CREATE2 proxy are both caught **before** broadcasting, so you don't pay for a failed transaction or get a "successful" deploy that deployed nothing.
+- This is **not** for token launches — use the token deployment flow (`deploy_erc20_token` / `bankr launch`) for those. See [token-deployment.md](token-deployment.md).
+- Bankr never sponsors gas for these deploys, and the same guards as every other arbitrary-transaction tool apply: the arbitrary-contract-calls kill switch, the Blockaid scan, wallet-safety preflight, and any recipient allowlist on your API key (which must include the CREATE2 proxy address for a recipient-scoped key to deploy).
+
+## Verifying a Contract
+
+Verify a deployed contract's source on **Etherscan v2 and Blockscout**. The explorer recompiles and matches against the on-chain bytecode, so it needs the exact inputs used at deploy time:
+
+- The exact source
+- The **long** compiler version (e.g. `v0.8.24+commit.e11b9ed9`)
+- Optimizer settings
+- ABI-encoded constructor arguments
+
+```
+Verify the contract I just deployed at 0x... on Base
+```
+
+A freshly deployed contract may need a few blocks to be indexed, so a `pending` or "unable to verify" result shortly after deployment is usually worth retrying rather than a real failure. Verification is an off-chain write — it broadcasts no transaction and needs no recipient allowlist, but it does require a read-write API key.
+
 ## Use Cases
 
+- **Contract deployment** - Deploy compiled bytecode and verify its source
 - **Custom contract interactions** - Call any function on any contract
 - **Pre-built calldata execution** - Execute calldata generated by other tools
 - **Advanced DeFi operations** - Complex multi-step transactions

--- a/bankr/references/files.md
+++ b/bankr/references/files.md
@@ -65,6 +65,9 @@ bankr files edit <fileId> -f "old" -r "new"     # Find/replace (--all for every 
 bankr files write <fileId> --from ./new.md      # Overwrite from a local file or stdin
 bankr files search "hyperliquid" --limit 20     # Search names, extensions, descriptions
 bankr files mkdir reports --parent /            # Create a folder
+bankr files mv <fileId> /archive                # Move a file to a different folder
+bankr files rename <fileId> notes-v2.md         # Rename a file or folder
+bankr files info <fileId>                       # Show file metadata
 bankr files rm <fileId>                         # Delete (soft)
 bankr files storage                             # Usage and quota
 ```

--- a/bankr/references/leverage-trading.md
+++ b/bankr/references/leverage-trading.md
@@ -14,7 +14,16 @@ Two leverage platforms are available:
 ### Avantis Details
 
 **Chain**: Base
-**Protocol**: [Avantis](https://docs.avantisfi.com/)
+**Protocol**: [Avantis](https://docs.avantisfi.com/) (v2)
+
+Bankr trades Avantis v2. The pair catalogue — roughly **118 named pairs** — is sourced from the Avantis data API rather than read pair-by-pair on chain, so lookups are fast and a transient refresh failure serves the last-known catalogue instead of breaking every symbol lookup.
+
+**Take profit and stop loss are signed intents, not transactions.** Setting a level signs an EIP-712 request that Avantis executes through its operator; there is no on-chain transaction to wait on. Two consequences worth knowing:
+
+- **An unreachable level is refused up front, not silently dropped.** A stop loss past your liquidation price can never fire, and a take profit on the wrong side of entry is meaningless — Avantis accepts both and then discards them. Bankr rejects them before submitting, and tells you the liquidation price so you can pick a level that works.
+- **"Set" means visible on the position.** A `2xx` from Avantis means accepted, not executed, so Bankr polls your position and only reports success once the levels actually show up. If it times out, it says the outcome is unconfirmed rather than claiming a rejection it can't know about.
+
+Avantis TP/SL is **not available in wallet (connected-wallet) mode** — it returns a clear unsupported error rather than a transaction that would revert.
 
 ### Leverage Limits
 
@@ -168,6 +177,9 @@ NVDA, TSLA, AAPL, AMZN, MSFT, META, COIN, HOOD, and more. Equity pairs trade **d
 | Insufficient collateral | Add more funds to wallet |
 | Asset not supported | Check available markets list |
 | Position liquidated | Reduce leverage or add more collateral |
+| Stop loss refused as unreachable (Avantis) | The level is past liquidation — the error carries your liquidation price; pick a level inside it, or reduce leverage first |
+| Take profit refused (Avantis) | The level is on the wrong side of your entry for the direction you're trading |
+| TP/SL unsupported (Avantis) | You're in wallet (connected-wallet) mode; Avantis TP/SL requires an embedded Bankr wallet |
 | High funding rate | Consider closing and reopening |
 | Slippage | Use smaller position size |
 | Cannot close | Market might be paused (rare) |

--- a/bankr/references/leverage-trading.md
+++ b/bankr/references/leverage-trading.md
@@ -16,7 +16,7 @@ Two leverage platforms are available:
 **Chain**: Base
 **Protocol**: [Avantis](https://docs.avantisfi.com/) (v2)
 
-Bankr trades Avantis v2. The pair catalogue — roughly **118 named pairs** — is sourced from the Avantis data API rather than read pair-by-pair on chain, so lookups are fast and a transient refresh failure serves the last-known catalogue instead of breaking every symbol lookup.
+Bankr trades Avantis v2. The pair catalogue — **100+ named pairs**, and it changes as Avantis lists and delists — is fetched live from the Avantis data API rather than read pair-by-pair on chain, so lookups are fast and a transient refresh failure serves the last-known catalogue instead of breaking every symbol lookup. Ask for the current list rather than assuming a pair exists.
 
 **Take profit and stop loss are signed intents, not transactions.** Setting a level signs an EIP-712 request that Avantis executes through its operator; there is no on-chain transaction to wait on. Two consequences worth knowing:
 

--- a/bankr/references/llm-gateway.md
+++ b/bankr/references/llm-gateway.md
@@ -241,7 +241,7 @@ Your credit balance caps **total** spend; the daily budget caps **burn rate**. I
 
 Set it in the **Settings** tab at [bankr.bot/llm](https://bankr.bot/llm). It is **web-auth only** — an API key cannot change the budget of the wallet it belongs to, so a compromised key can't raise the cap it's bound by.
 
-The budget spans **all metered LLM spend on the wallet**, not just gateway traffic: requests from every API key it owns, plus Max Mode and app-invoked Bankr agent runs. Both are enforced — gateway requests are refused, and an agent run ends early once the day's spend reaches the cap.
+The budget spans **all metered LLM spend on the wallet**, not just gateway traffic: requests from every API key it owns, plus Max Mode agent runs wherever they're invoked from. Both are enforced — gateway requests are refused, and a Max Mode run ends early once the day's spend reaches the cap. Ordinary non-Max agent runs don't draw on LLM credits, so the budget doesn't touch them.
 
 Read the current state from `/v1/credits`:
 
@@ -286,7 +286,7 @@ curl -s https://llm.bankr.bot/v1/credits -H "X-API-Key: $BANKR_LLM_KEY"
   ```
 
 - **Only requests that spend are blocked.** Every read-only `GET` — `/v1/credits`, `/v1/usage`, `/v1/models` — keeps working while you're over budget, so you can still read `remainingUsd` and `resetsAt` to find out when you'll be unblocked, and check what spent the budget.
-- Budget changes reach the gateway within ~60 seconds (it caches authentication state), and enforcement is evaluated against that cached view, so spend may overshoot slightly under a sustained burst. Each gateway instance caches independently, so the overshoot scales with instance count. **Treat it as a guardrail, not an accounting boundary** — your credit balance remains the hard limit on total spend.
+- Budget changes take effect within ~60 seconds, and enforcement is eventually consistent against that view — so spend may overshoot the cap slightly under a sustained burst. **Treat it as a guardrail, not an accounting boundary** — your credit balance remains the hard limit on total spend.
 
 ### Expiring Credit Grants
 
@@ -621,9 +621,16 @@ Two different causes — **read the error `type`**, they need different fixes:
 
 No provider slot is currently serving the model you asked for. This is an operational state, not a bad request — retry, or fall back to another model.
 
-### Error envelopes differ by surface
+### Error envelopes differ by layer, not just by surface
 
-The OpenAI-compatible routes return `{"error": {"message", "type", "code"}}`. On `/v1/messages`, errors use the **Anthropic** envelope instead — `{"type": "error", "error": {"type", "message"}}` — with the same status codes. Parse for the surface you're calling.
+The OpenAI-compatible routes return `{"error": {"message", "type", "code"}}` throughout. On `/v1/messages` it's split, and the split matters if you're branching on the error:
+
+| Error class | Envelope on `/v1/messages` |
+|-------------|----------------------------|
+| Request and streaming errors (validation, model, provider) | **Anthropic** — `{"type": "error", "error": {"type", "message"}}` |
+| Auth and billing (`401`, `402`, `403`) | **OpenAI** — `{"error": {"message", "type"}}`, same as everywhere else |
+
+So the `402` checks above — `insufficient_credits` vs `daily_budget_exceeded` — are read from `error.type` in the **OpenAI** shape on every surface, `/v1/messages` included. Don't reach for `error.error.type` there.
 
 ### OpenRouter routing controls are stripped on `/v1/messages`
 

--- a/bankr/references/llm-gateway.md
+++ b/bankr/references/llm-gateway.md
@@ -72,14 +72,16 @@ bankr config get llmKey
 | `gpt-5.2-codex` | OpenAI | Code generation (400K context) |
 | `gpt-5-mini` | OpenAI | Previous gen, economical (400K) |
 | `gpt-5-nano` | OpenAI | Previous gen, ultra-fast (400K) |
+| `grok-4.6` | xAI | Latest xAI reasoning (500K context, image input) |
 | `grok-4.20` | xAI | Deep reasoning, largest context (2M context) |
-| `grok-4.5` | xAI | Latest, balanced multimodal (500K context, image input) |
+| `grok-4.5` | xAI | Previous balanced multimodal (500K context, image input) |
 | `grok-4.3` | xAI | Balanced performance (1M context) |
 | `grok-4.1-fast` | xAI | Fast, economical, largest context (2M) |
 | `deepseek-v4-pro` | DeepSeek | Long context reasoning (1M, 384K output) |
 | `deepseek-v4-flash` | DeepSeek | High throughput, cost-effective (1M) |
 | `deepseek-v3.2` | DeepSeek | Cost-effective (164K context) |
-| `qwen3.7-max` | Alibaba | Latest flagship (1M) |
+| `qwen3.8-max` | Alibaba | Latest flagship, multimodal (1M context, image input) |
+| `qwen3.7-max` | Alibaba | Previous flagship (1M) |
 | `qwen3.7-plus` | Alibaba | Latest, long-context reasoning (1M) |
 | `qwen3.7-flash` | Alibaba | Latest fast tier, economical (1M, image input) |
 | `qwen3.6-flash` | Alibaba | Fast, economical (1M) |
@@ -232,6 +234,59 @@ bankr llm credits auto --disable
 ```
 
 When credits are exhausted, gateway requests will fail with HTTP 402.
+
+### Daily Spend Budget
+
+Your credit balance caps **total** spend; the daily budget caps **burn rate**. It's an optional per-UTC-day limit that exists so a runaway loop or a leaked key can't drain a funded wallet in a single day.
+
+Set it in the **Settings** tab at [bankr.bot/llm](https://bankr.bot/llm). It is **web-auth only** — an API key cannot change the budget of the wallet it belongs to, so a compromised key can't raise the cap it's bound by.
+
+The budget spans **all metered LLM spend on the wallet**, not just gateway traffic: requests from every API key it owns, plus Max Mode and app-invoked Bankr agent runs. Both are enforced — gateway requests are refused, and an agent run ends early once the day's spend reaches the cap.
+
+Read the current state from `/v1/credits`:
+
+```bash
+curl -s https://llm.bankr.bot/v1/credits -H "X-API-Key: $BANKR_LLM_KEY"
+```
+
+```json
+{
+  "object": "credit_balance",
+  "balanceUsd": 12.34,
+  "effectiveBalanceUsd": 11.2,
+  "undeductedCostUsd": 1.14,
+  "dailyBudget": {
+    "limitUsd": 25,
+    "spentUsd": 4.2,
+    "remainingUsd": 20.8,
+    "exceeded": false,
+    "resetsAt": "2026-08-16T00:00:00.000Z"
+  }
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `limitUsd` | number | The configured cap, in USD per UTC day |
+| `spentUsd` | number | Spend counted against the budget so far today, including usage not yet deducted |
+| `remainingUsd` | number | `limitUsd - spentUsd`, floored at `0` |
+| `exceeded` | boolean | Whether the budget is spent. While `true`, spend requests are rejected |
+| `resetsAt` | string | ISO 8601 timestamp of the next reset — always the next 00:00 UTC |
+
+- **`dailyBudget` is omitted entirely when the wallet is uncapped**, so its presence answers "am I capped?" without a sentinel value to test for.
+- Over budget, spend requests return **`402` with `type: "daily_budget_exceeded"`** — distinct from the `insufficient_credits` you get when the balance itself runs out:
+
+  ```json
+  {
+    "error": {
+      "message": "Daily LLM Gateway spend budget reached. It resets at 00:00 UTC, or you can raise it at bankr.bot/llm.",
+      "type": "daily_budget_exceeded"
+    }
+  }
+  ```
+
+- **Only requests that spend are blocked.** Every read-only `GET` — `/v1/credits`, `/v1/usage`, `/v1/models` — keeps working while you're over budget, so you can still read `remainingUsd` and `resetsAt` to find out when you'll be unblocked, and check what spent the budget.
+- Budget changes reach the gateway within ~60 seconds (it caches authentication state), and enforcement is evaluated against that cached view, so spend may overshoot slightly under a sustained burst. Each gateway instance caches independently, so the overshoot scales with instance count. **Treat it as a guardrail, not an accounting boundary** — your credit balance remains the hard limit on total spend.
 
 ### Expiring Credit Grants
 
@@ -548,15 +603,33 @@ Check `bankr llm models` for current model status and replacement mappings.
 - Ensure the key hasn't expired
 
 ### 402 Payment Required
-- Credits exhausted: `bankr llm credits` shows $0.00
-- Top up via CLI: `bankr llm credits add 25` or at [bankr.bot/llm?tab=credits](https://bankr.bot/llm?tab=credits) — this is the most common error for new users
-- Set up auto top-up to prevent this: `bankr llm credits auto --enable --amount 25 --threshold 5 --tokens USDC`
-- New wallets start with $0 — you must add credits before first use
-- LLM credits are separate from your trading wallet balance
+
+Two different causes — **read the error `type`**, they need different fixes:
+
+- `insufficient_credits` — the balance is spent. `bankr llm credits` shows $0.00. Top up via CLI (`bankr llm credits add 25`) or at [bankr.bot/llm?tab=credits](https://bankr.bot/llm?tab=credits) — this is the most common error for new users. Set up auto top-up to prevent it: `bankr llm credits auto --enable --amount 25 --threshold 5 --tokens USDC`. New wallets start with $0, and LLM credits are separate from your trading wallet balance.
+- `daily_budget_exceeded` — you still have credit, but the wallet's **daily spend budget** is spent for this UTC day. Topping up does nothing. Wait for `resetsAt` (visible on `GET /v1/credits`, which keeps working over budget) or raise the cap in the Settings tab at [bankr.bot/llm](https://bankr.bot/llm). See [Daily Spend Budget](#daily-spend-budget).
 
 ### Model not found
 - Use exact model IDs (e.g., `claude-sonnet-4.6`, not `claude-3-sonnet`)
 - Check available models: `bankr llm models`
+
+### 503 Model temporarily unavailable
+
+```json
+{ "error": { "message": "Model temporarily unavailable", "type": "api_error", "code": "provider_unavailable" } }
+```
+
+No provider slot is currently serving the model you asked for. This is an operational state, not a bad request — retry, or fall back to another model.
+
+### Error envelopes differ by surface
+
+The OpenAI-compatible routes return `{"error": {"message", "type", "code"}}`. On `/v1/messages`, errors use the **Anthropic** envelope instead — `{"type": "error", "error": {"type", "message"}}` — with the same status codes. Parse for the surface you're calling.
+
+### OpenRouter routing controls are stripped on `/v1/messages`
+
+When a request is served through OpenRouter's native `/messages`, the OpenRouter routing controls — `provider`, `models`, `fallbacks`, `route`, `transforms`, `plugins` — are removed rather than forwarded. The gateway picks the upstream provider itself, and usage is metered and priced against the model you named, so a routing override in the body can't move the request to a model you aren't being billed for.
+
+**Don't send them at all**, though: that route is the only one that strips them, and a provider that receives an unknown top-level field may reject the whole request.
 
 ### Claude Code not found
 - `bankr llm claude` requires Claude Code to be installed separately

--- a/bankr/references/market-research.md
+++ b/bankr/references/market-research.md
@@ -27,6 +27,30 @@ Ask for a token's holders and Bankr returns them largest-first with **USD value*
 - The list is the **raw on-chain holder set**. It includes liquidity pools, the token contract itself, and treasuries — often the largest entries. Exclude those before paying anyone out.
 - Snapshots are capped per read, and the response tells you when it was truncated with more holders still qualifying.
 
+### Holders joined to Bankr identity — `GET /tokens/holders`
+
+For EVM tokens there is also a direct REST endpoint that returns holders **with their Bankr wallet and X handle**, paginated. Unlike the rest of `/tokens/*` it requires an API key, because it maps addresses to real social identities.
+
+```bash
+curl -s "https://api.bankr.bot/tokens/holders?tokenAddress=0x...&chain=base&filter=all&limit=50" \
+  -H "X-API-Key: $BANKR_API_KEY"
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `tokenAddress` | Yes | 0x token address |
+| `chain` | Yes | Any supported EVM chain (`base`, `mainnet`, `polygon`, `unichain`, `worldchain`, `arbitrum`, `bnb`, `robinhood`) |
+| `filter` | No | `bankr` (default) — only holders who are Bankr users, answered straight from our index. `all` — the true on-chain ranking, annotated with Bankr identity where we recognise the address |
+| `limit` | No | 1–100, default 50 |
+| `cursor` | No | Opaque `nextCursor` from the previous page |
+
+Each holder row carries `address`, `balance`, `isBankrWallet`, and `xUsername` / `xProfileImageUrl` when known. The response also reports `source` (`index` for `filter=bankr`, `codex` for `filter=all`) and `nextCursor`.
+
+- **`balance` is a raw integer string** in the token's smallest unit — it can exceed `Number` precision, so don't parse it as a float.
+- **Paginate by replaying `nextCursor` as `cursor`** until it's absent. A cursor is only valid for the exact `tokenAddress` + `chain` + `filter` that minted it; anything else returns `400`.
+- **This is a feed, not a snapshot.** Ranking is over live balances, so a holder whose balance moves between pages can repeat or be missed. For a point-in-time list (airdrop targeting), prefer the agent's holder snapshot above.
+- `filter=bankr` is the cheap, exact answer to "which of our users hold this". `filter=all` costs an upstream call and returns mostly-anonymous rows.
+
 ## Prompt Examples
 
 **Price queries:**

--- a/bankr/references/nft-operations.md
+++ b/bankr/references/nft-operations.md
@@ -2,7 +2,9 @@
 
 Browse, purchase, sell, bid on, and manage NFTs across chains via OpenSea integration.
 
-**Supported Chains**: every supported EVM chain — Base, Ethereum, Polygon, Unichain, World Chain, Arbitrum, BNB Chain, and Robinhood Chain. (Solana NFTs are not covered by these tools.)
+**Supported Chains**: Base, Ethereum, Polygon, Unichain, Arbitrum, and Robinhood Chain.
+
+**World Chain and BNB Chain are not supported for NFTs** even though Bankr trades tokens on both — there's no marketplace coverage for them, so a collection on either chain is rejected rather than traded. (Solana NFTs are also outside these tools.)
 
 ## Operations
 
@@ -133,7 +135,7 @@ Bankr resolves common names and abbreviations:
 - Buying, listing, bidding, and accepting offers all work here — the ERC-20 payment currency is handled for you
 - Very low gas fees
 
-### Unichain, World Chain, Arbitrum, BNB Chain
+### Unichain, Arbitrum
 - Supported by the same tools; collection depth varies by chain
 
 ## OpenSea Integration
@@ -157,6 +159,7 @@ Bankr uses OpenSea's marketplace:
 | Bid rejected as too low | OpenSea enforces per-collection minimums and increments — raise the amount, don't retry the same price |
 | "You don't have enough WETH" on a bid | Bids are ERC-20; Bankr wraps ETH → WETH for you, but you still need the ETH to wrap |
 | Can't cancel a bid | Only collection-wide bids are cancellable through Bankr; single-token bids must be cancelled on OpenSea |
+| "Not supported by Bankr" on a collection | The collection is on World Chain or BNB Chain — no NFT marketplace coverage there, though token trading works |
 
 ## Safety Tips
 

--- a/bankr/references/nft-operations.md
+++ b/bankr/references/nft-operations.md
@@ -1,18 +1,47 @@
 # NFT Operations Reference
 
-Browse, purchase, and manage NFTs across chains via OpenSea integration.
+Browse, purchase, sell, bid on, and manage NFTs across chains via OpenSea integration.
 
-**Supported Chains**: Base, Ethereum, Polygon
+**Supported Chains**: every supported EVM chain — Base, Ethereum, Polygon, Unichain, World Chain, Arbitrum, BNB Chain, and Robinhood Chain. (Solana NFTs are not covered by these tools.)
 
 ## Operations
+
+**Buy side**
 
 - **Browse** - Search NFT collections
 - **View Listings** - Find best deals and floor prices
 - **Buy** - Purchase NFTs from marketplace listings
+- **Make a collection-wide bid** - An offer good for *any* token in a collection
+- **View your bids** - See the offers you've made
+- **Cancel your collection bids** - Retract every open collection offer you have on a collection, in one transaction
+
+**Sell side**
+
+- **List for sale** - Put an NFT you own on the market
+- **View your listings** - See your own live listings
+- **Cancel listings** - Take one or more listings down
+- **Check the best offer** - Ask what the highest live bid on an NFT is before selling
 - **Accept Offer** - Accept an offer on an NFT you own
+
+**Everything else**
+
 - **View Holdings** - Check your NFT portfolio
 - **Transfer** - Send NFTs to another wallet
 - **Mint** - Mint from supported platforms (Manifold, SeaDrop)
+
+## Offers and Bids
+
+**Offers are always paid in an ERC-20, never in the chain's native token.** Seaport can't pull native value from the offerer, so a bid falls back to wrapped native — WETH on most chains — or to whatever currency the collection pins (USDG on some Robinhood Chain collections). The currency is per-collection, not per-chain. If your balance of that currency is short and it's WETH, Bankr wraps the difference from ETH as part of the same flow.
+
+Other things to expect:
+
+- **Price per item, not total.** A bid on several NFTs takes a per-item price and a quantity; Bankr multiplies.
+- **OpenSea enforces per-collection minimums and bid increments**, so a very small offer can be rejected outright. Raise the amount rather than retrying the same price.
+- **A live collection offer holds an ERC-20 approval open** until it's accepted, expires, or is cancelled.
+- **Only collection-wide bids can be retracted through Bankr.** A bid on a single token has to be cancelled on OpenSea directly — Bankr will tell you so rather than promising a cancel it can't perform.
+- **"No offers" is a normal answer.** Asking for the best offer on an NFT that has none returns exactly that, not an error.
+
+Asking for offers has three distinct meanings, and they map to three different lookups: offers *you made* (your bids), the best offer *received* on an NFT you own, and your own *listings*. Say which you mean and Bankr picks the right one.
 
 ## Prompt Examples
 
@@ -36,9 +65,20 @@ Browse, purchase, and manage NFTs across chains via OpenSea integration.
 
 Listings priced in an **ERC-20** rather than the chain's native token — for example USDG listings on Robinhood Chain — are buyable the same way. Bankr submits the token approval the marketplace conduit needs, checks your balance of the payment currency before signing, and prices the listing using that token's decimals, so the quoted amount is the amount you pay. If a listing turns out to be stale, it moves on to the next one instead of failing the whole request.
 
-**Accept offers:**
+**Sell — list, cancel, and check offers:**
+- "List my Pudgy Penguin #1234 for 5 ETH"
+- "List my Bored Ape for 30 ETH, expiring in a week"
+- "Show my NFT listings"
+- "Cancel my listing on Pudgy Penguin #1234"
+- "What's the best offer on my Bored Ape?"
 - "Accept the best offer on my Pudgy Penguin #1234"
-- "What's the highest offer on my Bored Ape?"
+
+**Bid on a collection:**
+- "Bid 0.02 WETH on any okcomputers NFT"
+- "Make an offer of 0.5 each for 3 Bored Apes, expiring in 2 days"
+- "Show the offers I've made"
+- "Show my bids on okcomputers"
+- "Cancel my okcomputers bids"
 
 **View holdings:**
 - "Show my NFTs"
@@ -88,6 +128,14 @@ Bankr resolves common names and abbreviations:
 - Good for frequent trading
 - Strong gaming communities
 
+### Robinhood Chain
+- Listings and offers are commonly denominated in **USDG**, not the native token
+- Buying, listing, bidding, and accepting offers all work here — the ERC-20 payment currency is handled for you
+- Very low gas fees
+
+### Unichain, World Chain, Arbitrum, BNB Chain
+- Supported by the same tools; collection depth varies by chain
+
 ## OpenSea Integration
 
 Bankr uses OpenSea's marketplace:
@@ -106,6 +154,9 @@ Bankr uses OpenSea's marketplace:
 | Insufficient funds | Check balance including gas costs |
 | High gas | Wait for lower gas or try L2 (Base/Polygon) |
 | Unverified collection | Verify legitimacy before purchasing |
+| Bid rejected as too low | OpenSea enforces per-collection minimums and increments — raise the amount, don't retry the same price |
+| "You don't have enough WETH" on a bid | Bids are ERC-20; Bankr wraps ETH → WETH for you, but you still need the ETH to wrap |
+| Can't cancel a bid | Only collection-wide bids are cancellable through Bankr; single-token bids must be cancelled on OpenSea |
 
 ## Safety Tips
 

--- a/bankr/references/portfolio.md
+++ b/bankr/references/portfolio.md
@@ -34,6 +34,27 @@ curl -s "https://api.bankr.bot/wallet/portfolio?chains=base,solana" \
 
 The `/wallet/portfolio` endpoint is a read endpoint — any valid API key with a wallet can access it (no feature flags required).
 
+### Response field types
+
+> **`token.balance` is a string, not a number.** It holds the exact decimal amount. Parsing it as a float rounds high-decimal tokens **up**, and a max-size trade built from a rounded balance reverts on-chain. `nativeBalance`, `nativeUsd` and `total` are strings too; `balanceUSD` and `price` are numbers.
+
+```json
+{
+  "network": "base",
+  "token": {
+    "balance": "1000",
+    "balanceUSD": 1000,
+    "baseToken": { "name": "USD Coin", "symbol": "USDC" }
+  }
+}
+```
+
+Other response notes:
+
+- `pnl` is only present when `?include=pnl` is set
+- `nfts` is only populated when `?include=nfts` is set
+- Tokens below $1 USD are filtered by default — pass `?showLowValueTokens=true` to include them
+
 ## Supported Chains
 
 All chains: Base, Polygon, Ethereum, Unichain, Solana, World Chain, Arbitrum, BNB Chain, Robinhood Chain

--- a/bankr/references/safety.md
+++ b/bankr/references/safety.md
@@ -206,6 +206,14 @@ The CLI stores keys in `~/.bankr/config.json`:
 - Use `bankr logout` to clear stored credentials when done on a shared machine
 - For CI/CD, prefer environment variables (`BANKR_API_KEY`, `BANKR_LLM_KEY`) over config files
 
+### CLI Sessions Are Revocable
+
+Email logins from the CLI (`bankr login email`) appear in **Active sessions** at [bankr.bot](https://bankr.bot) → Security, alongside browser sessions — with OS, approximate location, IP, and last-seen time. Log any of them out from there; the logout takes effect server-side immediately, and if MFA is on, revoking another session prompts for your passkey.
+
+`bankr logout` only clears the local config file — it doesn't revoke anything server-side. To cut off a machine you no longer control, revoke the session in Security (and rotate the key if it may have leaked).
+
+Sessions created by an older CLI predate this and won't be listed. If a CLI session is missing from the page, run `bankr update` and sign in again. Sessions drop off the list after 60 days of inactivity.
+
 ### Non-Interactive Login
 
 When running the CLI in automated scripts or AI agent environments where interactive prompts aren't possible:

--- a/bankr/references/safety.md
+++ b/bankr/references/safety.md
@@ -208,7 +208,7 @@ The CLI stores keys in `~/.bankr/config.json`:
 
 ### CLI Sessions Are Revocable
 
-Email logins from the CLI (`bankr login email`) appear in **Active sessions** at [bankr.bot](https://bankr.bot) → Security, alongside browser sessions — with OS, approximate location, IP, and last-seen time. Log any of them out from there; the logout takes effect server-side immediately, and if MFA is on, revoking another session prompts for your passkey.
+Email logins from the CLI (`bankr login email`) appear in **Active sessions** at [bankr.bot](https://bankr.bot) → Security, alongside browser sessions — with OS, approximate location, IP, and last-seen time. Log any of them out from there; revocation is server-side and propagates within seconds. If MFA is on, revoking a session prompts for your passkey.
 
 `bankr logout` only clears the local config file — it doesn't revoke anything server-side. To cut off a machine you no longer control, revoke the session in Security (and rotate the key if it may have leaked).
 

--- a/bankr/references/token-trading.md
+++ b/bankr/references/token-trading.md
@@ -24,7 +24,10 @@ Execute token trades and swaps across multiple blockchains.
 |--------|---------|-------------|
 | USD | `$50` | Dollar amount to spend |
 | Percentage | `50%` | Percentage of your balance |
-| Exact | `0.1 ETH` | Specific token amount |
+| Exact input | `0.1 ETH` | Specific amount to sell |
+| Exact output | `exactly 1,000 PEPE` | Specific amount to **receive** — Bankr sizes the input for you |
+
+**Exact-output orders** work on same-chain EVM and same-chain Solana. On Solana the input is sized from the output token's USD price rather than a reverse quote, so treat the amount you spend as an estimate — the received quantity is the side being pinned.
 
 ## Prompt Examples
 
@@ -33,6 +36,11 @@ Execute token trades and swaps across multiple blockchains.
 - "Buy $50 of BNKR on Base"
 - "Sell 50% of my ETH holdings"
 - "Purchase 100 USDC worth of PEPE"
+
+**Exact-output swaps:**
+- "Buy exactly 1,000 PEPE on Base"
+- "Buy exactly 500 BONK on Solana"
+- "Get me exactly 100 USDC"
 
 **Cross-chain swaps:**
 - "Bridge 0.5 ETH from Ethereum to Base"

--- a/bankr/references/token-trading.md
+++ b/bankr/references/token-trading.md
@@ -25,9 +25,9 @@ Execute token trades and swaps across multiple blockchains.
 | USD | `$50` | Dollar amount to spend |
 | Percentage | `50%` | Percentage of your balance |
 | Exact input | `0.1 ETH` | Specific amount to sell |
-| Exact output | `exactly 1,000 PEPE` | Specific amount to **receive** — Bankr sizes the input for you |
+| Exact output | `exactly 1,000 PEPE` | Target amount to **receive** — Bankr sizes the input for you |
 
-**Exact-output orders** work on same-chain EVM and same-chain Solana. On Solana the input is sized from the output token's USD price rather than a reverse quote, so treat the amount you spend as an estimate — the received quantity is the side being pinned.
+**Exact-output orders** work on same-chain EVM and same-chain Solana. They **target** the output rather than guaranteeing it: on both chains the input is sized from a theoretical price (the output token's USD price on Solana, a reverse quote with fees and slippage zeroed on EVM), and pool price impact then applies to the actual fill. Expect the delivered quantity to land close to your target, not exactly on it. If you need a hard floor on what you receive, use the Wallet API's `minBuyAmount` instead.
 
 ## Prompt Examples
 

--- a/bankr/references/webhooks.md
+++ b/bankr/references/webhooks.md
@@ -1,0 +1,108 @@
+# Webhooks Reference
+
+Deploy your own TypeScript handlers that turn an external event into a Bankr agent run. A Slack message, a GitHub push, a Stripe event, or anything that can POST to a URL becomes a prompt the agent executes on your wallet.
+
+Managed with `bankr webhooks` (or `/webhooks/*` over REST). This is a sibling of [x402 Cloud](x402-cloud.md) — same deploy/list/logs/env shape, minus the pricing and revenue semantics.
+
+## How It Works
+
+1. You write a handler in TypeScript and deploy it with `bankr webhooks deploy`
+2. Bankr gives it a public trigger URL: `https://webhooks.bankr.bot/u/<walletAddress>/<name>`
+3. The external service POSTs to that URL
+4. **Your handler verifies the request** and returns `{ prompt, threadId?, context? }`
+5. The Bankr agent runs that prompt on your wallet
+
+Returning anything else — a `401`, a plain `Response`, nothing at all — means no agent run. Verification failures never reach the agent.
+
+## CLI Commands
+
+```bash
+bankr webhooks init                      # Scaffold webhooks/ + bankr.webhooks.json
+bankr webhooks add notify                # Add a handler (generic template)
+bankr webhooks add slack-bot --provider slack   # slack | github | stripe | generic
+bankr webhooks deploy                    # Deploy every handler in the config
+bankr webhooks deploy notify             # Deploy just one
+bankr webhooks list                      # List deployed webhooks
+bankr webhooks logs notify               # Recent invocations
+bankr webhooks pause notify              # Stop accepting triggers
+bankr webhooks resume notify             # Resume
+bankr webhooks delete notify             # Delete (cannot be undone)
+
+bankr webhooks env set SLACK_SIGNING_SECRET=...   # Encrypted env vars
+bankr webhooks env list                           # Names only, never values
+bankr webhooks env unset SLACK_SIGNING_SECRET
+```
+
+## Handler Contract
+
+```typescript
+export default async function handler(req: Request): Promise<Response> {
+  // 1. Verify the request came from who you think it did
+  // 2. Return the prompt for the agent to run
+  return Response.json({
+    prompt: "Summarize the deploy that just went out and tell me if I should roll back.",
+    threadId: "thr_XYZ",        // optional — continue an existing conversation
+    context: { repo: "acme/api" }, // optional — extra structured context
+  });
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `prompt` | Yes | What the agent should do. Write it as if you were typing it yourself |
+| `threadId` | No | Continue an existing conversation thread instead of starting a new one |
+| `context` | No | Structured data passed alongside the prompt |
+
+## Security — Read This Before Deploying
+
+**The trigger URL is public.** Anyone who guesses or learns it can POST to it, and every accepted POST is an agent run on your wallet. Verification is your handler's job.
+
+- The **`slack`**, **`github`**, and **`stripe`** templates ship with real signature verification — Slack's signing secret (with URL-verification handling), GitHub's HMAC-SHA256, Stripe's timestamped `v1` signatures — and return `401` without ever invoking the agent.
+- The **`generic`** template does **not** verify anything. It is a starting point, not a deployable webhook. Add a verifier before you deploy it.
+- Store signing secrets with `bankr webhooks env set`, never in the handler source.
+- GitHub's signature has no timestamp, so it carries no replay protection. If you need it, dedupe on the `X-GitHub-Delivery` header.
+- A webhook you no longer trust can be paused (`bankr webhooks pause`) or deleted outright.
+
+Because a webhook run is a real agent run on your wallet, everything in [safety.md](safety.md) still applies underneath it — wallet-level pause, spending limits, permitted recipients, and the read-only flag on the key all hold. A webhook cannot exceed what the wallet itself allows.
+
+## Provider Templates
+
+| Provider | Verifies | Typical use |
+|----------|----------|-------------|
+| `slack` | Signing secret + URL verification challenge | Reply in a channel or thread — the agent has a Slack skill bound and can use the channel and `thread_ts` from the prompt |
+| `github` | HMAC-SHA256 over the body | Summarize a push, PR, or release and flag anything that needs action |
+| `stripe` | Timestamped `v1` signatures | React to a payment, dispute, or subscription event |
+| `generic` | **Nothing — add your own** | Anything else |
+
+## REST API
+
+All routes require API key authentication (`X-API-Key`). The public trigger endpoint is served separately, at `webhooks.bankr.bot`.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST` | `/webhooks/deploy` | Deploy from raw TypeScript source (`{ config, bundles }`) |
+| `GET` | `/webhooks` | List your deployed webhooks |
+| `GET` | `/webhooks/:name` | Webhook detail |
+| `PATCH` | `/webhooks/:name` | Update (pause/resume and config) |
+| `DELETE` | `/webhooks/:name` | Delete |
+| `GET` | `/webhooks/:name/logs` | Recent invocations |
+| `GET` | `/webhooks/:name/stats` | Invocation stats |
+| `POST` | `/webhooks/env` | Set an encrypted env var |
+| `GET` | `/webhooks/env` | List env var names |
+| `DELETE` | `/webhooks/env/:key` | Remove an env var |
+
+## Limits
+
+| Resource | Limit |
+|----------|-------|
+| Raw handler source | 1 MB |
+| Name format | Letters, digits, `-` and `_` only |
+
+## Common Issues
+
+| Issue | Resolution |
+|-------|------------|
+| Agent never runs | Handler returned a non-JSON response or failed verification — check `bankr webhooks logs <name>` |
+| `401` on every trigger | Signing secret missing or wrong; check `bankr webhooks env list` and the provider's configured secret |
+| Unexpected agent runs | The URL leaked and your handler doesn't verify — pause the webhook, add a verifier, redeploy |
+| Deploy rejected | Name has characters outside `[a-zA-Z0-9_-]`, or the bundle exceeds 1 MB of source |

--- a/bankr/references/webhooks.md
+++ b/bankr/references/webhooks.md
@@ -97,6 +97,7 @@ All routes require API key authentication (`X-API-Key`). The public trigger endp
 |----------|-------|
 | Raw handler source | 1 MB |
 | Name format | Letters, digits, `-` and `_` only |
+| Name length | 47 characters |
 
 ## Common Issues
 
@@ -105,4 +106,4 @@ All routes require API key authentication (`X-API-Key`). The public trigger endp
 | Agent never runs | Handler returned a non-JSON response or failed verification — check `bankr webhooks logs <name>` |
 | `401` on every trigger | Signing secret missing or wrong; check `bankr webhooks env list` and the provider's configured secret |
 | Unexpected agent runs | The URL leaked and your handler doesn't verify — pause the webhook, add a verifier, redeploy |
-| Deploy rejected | Name has characters outside `[a-zA-Z0-9_-]`, or the bundle exceeds 1 MB of source |
+| Deploy rejected | Name is over 47 characters or has characters outside `[a-zA-Z0-9_-]`, or the bundle exceeds 1 MB of source |

--- a/bankr/references/x402-cloud.md
+++ b/bankr/references/x402-cloud.md
@@ -197,7 +197,13 @@ bankr x402 call <url> -y                          # Skip the payment confirmatio
 
 **`--max-payment` is your cap, and your cap is what gets sent.** The price an endpoint advertises is display-only — it can never raise your cap, and a call whose advertised price exceeds the cap fails closed instead of paying. In non-interactive mode the price probe is skipped entirely, so `--ni` behaves the same as `-y`.
 
-**Smart-contract wallets can pay.** Payment signatures are verified through an ERC-1271/6492-aware path as well as plain ECDSA recovery, so gas-sponsored and 7702-delegated wallets settle x402 payments normally rather than failing verification.
+**Smart-contract wallets can pay — if they're deployed.** The Bankr facilitator verifies Permit2 signatures on-chain, so an **ERC-1271** signature from a *deployed* smart account, or a gas-sponsored **EIP-7702** delegated wallet (such as Bankr's), is accepted alongside a plain ECDSA/EOA signature.
+
+**Counterfactual (ERC-6492) signatures from an undeployed account are rejected** with `invalid_permit2_signature`. Permit2 itself only validates ECDSA and deployed ERC-1271, so such a payment would verify and then fail to settle — deploy the account first.
+
+**`$0` challenges are paid, not rejected.** Some services gate a free endpoint behind a `$0` 402 whose payment payload they verify cryptographically but never settle. Bankr signs it and clears the cap rather than bailing with "could not read this endpoint's payment requirements", and skips the Permit2 allowance check entirely (a `$0` payment pulls no tokens, so there's no gas to burn on an approval).
+
+**A multi-rail 402 is priced on the rail Bankr will actually sign.** Sellers advertise rails in whatever order they like, and Bankr doesn't settle every rail (there's no Solana client, for instance). Pricing, the payment bound, and the signature all select the same entry — the first whose scheme and network Bankr registers — so a seller listing an unsupported rail first no longer makes a payable endpoint read as unpriceable. If nothing on the 402 is signable, it fails closed with the usual error.
 
 ### With x402-fetch (for developers)
 


### PR DESCRIPTION
Weekly sync of the `bankr` skill against what the platform can actually do. Split into what shipped this week and pre-existing gaps the sync surfaced.

## Shipped this week

**NFTs — the sell and bid sides are now usable end to end**
- **Collection-wide bids**: make an offer good for any token in a collection, see the bids you've made, and retract them. Bids are always ERC-20 (WETH on most chains, or whatever currency the collection pins — USDG on some Robinhood Chain collections), never native ETH; a short WETH balance is wrapped from ETH automatically. Only collection-wide bids are cancellable through Bankr — single-token bids have to be cancelled on OpenSea.
- **Best-offer lookup** is now available to ask directly, and an NFT with no live offers is a normal "no offers" answer rather than an error.
- ERC-20-denominated offers and listings on Robinhood Chain (the conduit and payment-currency handling).

**Deploy and verify contracts**
- The agent can deploy an EVM contract from compiled creation bytecode and verify its source on block explorers afterwards. Documented with the caveat that matters: deployment goes through a shared CREATE2 proxy, so `msg.sender` inside the constructor is the proxy, not your wallet — a constructor that assigns ownership or mints to `msg.sender` attributes those to the proxy. Address is deterministic and known pre-broadcast; deploys carry no native value; not for token launches.

**`GET /tokens/holders`**
- New API-key-gated endpoint returning an EVM token's holders joined to Bankr wallet identity and X handle, with cursor pagination. `filter=bankr` for the Bankr users who hold it, `filter=all` for the full on-chain ranking annotated where we recognise the address. Documented alongside the caveats: `balance` is a raw integer string, cursors are query-scoped, and it's a live feed rather than a snapshot (the agent's holder snapshot stays the right tool for airdrop targeting).

**LLM gateway — daily spend budget**
- Optional per-UTC-day cap across all metered LLM spend on the wallet, covering every key it owns plus Max Mode runs. Documented the `dailyBudget` shape on `/v1/credits`, that it's omitted entirely when uncapped, that over-budget spend returns `402 daily_budget_exceeded` (distinct from `insufficient_credits`, and needing a different fix), that read-only `GET`s keep working so you can find out when you're unblocked, and that it's a guardrail with a small overshoot rather than an accounting boundary.

**Gateway models**: added `grok-4.6` and `qwen3.8-max`.

**Avantis (v2)**
- Take-profit and stop-loss are signed intents that now land. An unreachable level — an SL past liquidation, a TP the wrong side of entry — is refused up front with the liquidation price in the message rather than accepted and silently dropped, and "set" now means visible on the position. TP/SL is unsupported in wallet (connected-wallet) mode. Pair catalogue is fetched live from the Avantis data API.

**Exact-output swaps on same-chain Solana** — "buy exactly N TOKEN" now sizes the input there too, rather than throwing.

**x402** — `$0` challenges are signed rather than rejected as unparseable, and a multi-rail 402 is priced and bounded on the rail Bankr will actually sign, so a seller listing an unsupported rail first no longer makes a payable endpoint read as unpriceable.

## Gaps caught while syncing

These were already true; the skill just didn't say so (or said the wrong thing).

- **NFT listing management was entirely missing** — listing for sale, viewing your own listings, and cancelling them.
- **NFT chain coverage was wrong in both directions.** The reference claimed three chains; it's actually six (Base, Ethereum, Polygon, Unichain, Arbitrum, Robinhood Chain) — and explicitly **not** World Chain or BNB Chain, which Bankr trades tokens on but has no marketplace coverage for. Now stated in both places plus the troubleshooting table.
- **Arbitrary-transaction chain table was four chains short** (World Chain, Arbitrum, BNB Chain, Robinhood Chain), now with slugs alongside chain IDs.
- **`bankr webhooks` was undocumented** — a whole command family for deploying handlers that turn an external event into an agent run. New `references/webhooks.md` covering the handler contract, provider templates, the REST surface, and the security point that matters: the trigger URL is public, the `generic` template verifies nothing, and every accepted POST is an agent run on your wallet.
- **CLI surface**: `bankr files mv|rename|info`, the real `bankr wallet sign` / `wallet submit tx|json` forms, `bankr login siwe`, `bankr update`.
- **`/tokens/*` endpoints** (`search`, `trending`, `balance`, `balances`) weren't listed at all.
- **`token.balance` is a string, not a number** — parsing it as a float rounds high-decimal tokens up, and a max-size trade built from a rounded balance reverts on-chain.
- **x402 smart-account payers**: the skill claimed ERC-6492 worked. Corrected — deployed ERC-1271 and EIP-7702 delegated wallets are accepted; counterfactual ERC-6492 from an undeployed account is rejected with `invalid_permit2_signature`, because such a payment would verify and then fail to settle.
- **CLI email logins are listed and revocable in Active sessions**, and `bankr logout` only clears the local config — it revokes nothing server-side.
- **Max Mode out of credits** is a reply asking you to top up (with an X-only fallback to the standard model), and a mid-turn exhaustion saves progress in the thread — the skill previously said messages just fail.
- **Gateway error surface**: `503 provider_unavailable`, the two distinct causes of a `402`, the OpenRouter routing controls that are stripped rather than forwarded, and which errors on `/v1/messages` use the Anthropic envelope versus the OpenAI one.

## Review pass

The second commit corrects three claims from the first that didn't survive verification, worth calling out since two were newly introduced rather than inherited:

1. **NFT coverage is not "every EVM chain."** I'd read the tools' `supportedChains` metadata as marketplace coverage; it's tool availability. World Chain and BNB Chain carry no OpenSea chain mapping, so collections there are rejected outright.
2. **Exact-output swaps target the output, they don't pin it.** The input is sized from a theoretical price on both EVM and Solana, and pool impact then applies to the fill. `minBuyAmount` is the hard floor; the exact-output amount isn't.
3. **The Anthropic error envelope on `/v1/messages` covers request and streaming errors only.** Auth and billing errors use the OpenAI envelope on every surface — which is exactly where the `insufficient_credits` / `daily_budget_exceeded` distinction is read from, so the original phrasing would have misled anyone acting on it.

Plus smaller precision fixes: the Avantis pair count is live-fetched and drifts (so no fixed figure), session revocation propagates within seconds rather than instantly and the MFA step-up covers any session, webhook names cap at 47 characters, and the daily budget applies to Max Mode runs specifically since ordinary agent runs don't draw on LLM credits.

## Files

`SKILL.md` plus `references/`: `nft-operations`, `arbitrary-transaction`, `llm-gateway`, `market-research`, `leverage-trading`, `token-trading`, `portfolio`, `files`, `safety`, `x402-cloud`, and a new `webhooks`.