### PR TITLE
Add skill: robinhood-chain-stock-tokens

### DIFF
--- a/robinhood-chain-stock-tokens/SKILL.md
+++ b/robinhood-chain-stock-tokens/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: robinhood-chain-stock-tokens
+description: Live prices, split-adjusted supply, DeFi depth and corporate actions for tokenized stocks on Robinhood Chain. Use when a request involves a stock ticker as an onchain token (NVDAon, AAPLon, TSLAon...), before sizing a trade in one, or when supply, market cap, splits or dividends for these tokens come up.
+tags: [api, trading, stock-tokens, robinhood-chain, x402, mcp]
+---
+
+# Robinhood Chain stock tokens
+
+REST over plain HTTP, base URL `https://www.hoodgrow.com`.
+
+    curl -H "Authorization: Bearer $HOODGROW_API_KEY" \
+      https://www.hoodgrow.com/api/agent/token/NVDA
+
+Returns price, corporate-action adjusted supply, DeFi depth and pending
+actions for one symbol. That one call answers most questions.
+
+## Supply is not totalSupply — get this right
+
+These tokens implement ERC-8056. A corporate action does not mint or burn.
+It changes a `uiMultiplier` that scales the DISPLAYED supply while every
+balance stays untouched.
+
+So `totalSupply()` read off the contract is the wrong number after any
+split or dividend, and market cap computed from it is wrong by the same
+factor. Use the adjusted supply this API returns — it is the figure a
+holder actually owns. Never compute supply or market cap for these tokens
+from chain state directly.
+
+## Before sizing a trade
+
+Check for a pending corporate action. One is staged on-chain before it
+takes effect, so a split can be visible and not yet applied:
+
+    curl -H "Authorization: Bearer $HOODGROW_API_KEY" \
+      "https://www.hoodgrow.com/api/corporate-actions?symbol=NVDA"
+
+`pending` means staged on-chain and not applied. `recent` means already in
+Robinhood's official ledger. A pending split means displayed price and
+supply are about to move for reasons unrelated to the market.
+
+## Which path to use
+
+1. **The API key, always.** Free at hoodgrow.com/profile, set as
+   `HOODGROW_API_KEY` in env vars. 40 units/day: a single-symbol call
+   costs 1, the full catalog costs 10.
+2. **x402 only when the key is missing or its budget is spent.** Do not
+   pay for a call the key would have covered. See
+   references/x402-fallback.md.
+
+Without either, the endpoints still answer on a shared per-IP budget —
+enough to try, not enough to rely on.
+
+## More
+
+- All endpoints and their parameters: references/endpoints.md
+- Paying with x402: references/x402-fallback.md

--- a/robinhood-chain-stock-tokens/catalog.json
+++ b/robinhood-chain-stock-tokens/catalog.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "slug": "robinhood-chain-stock-tokens",
+  "provider": "MeMikko",
+  "providerUrl": "https://github.com/MeMikko",
+  "logo": null,
+  "demo": null,
+  "setup": [],
+  "install": {
+    "type": "bankr",
+    "repoPath": "robinhood-chain-stock-tokens",
+    "command": "install the robinhood-chain-stock-tokens skill from https://github.com/BankrBot/skills/tree/main/robinhood-chain-stock-tokens"
+  }
+}

--- a/robinhood-chain-stock-tokens/references/endpoints.md
+++ b/robinhood-chain-stock-tokens/references/endpoints.md
@@ -1,0 +1,46 @@
+# Endpoints
+
+Base URL `https://www.hoodgrow.com`. All GET. Send
+`Authorization: Bearer $HOODGROW_API_KEY`.
+
+| Endpoint | Returns | Quota |
+| --- | --- | --- |
+| `/api/agent/token/{SYMBOL}` | price, adjusted supply, DeFi depth, actions | 1 |
+| `/api/agent/tokens` | the full catalog | 10 |
+| `/api/corporate-actions?symbol=NVDA` | pending + recent actions; omit `symbol` for all | 1 |
+| `/api/agent/slippage/{SYMBOL}?amountUsd=5000&side=buy` | price impact of a trade size | 1 |
+| `/api/agent/defi/{SYMBOL}` | Morpho supply APY, Uniswap V3 TVL | 1 |
+| `/api/agent/holders/{SYMBOL}` | holder distribution | 1 |
+| `/api/agent/ohlc/{SYMBOL}?interval=1d&from=&to=` | candles; interval `1h`, `4h`, `1d` | 1 |
+| `/api/agent/markets` | market overview | 1 |
+| `/api/agent/trades?symbol=&limit=` | recent trades | 1 |
+| `/api/agent/base/tokens` | Base-chain tokens — a different chain | 1 |
+
+Prefer `/api/agent/token/{SYMBOL}` over the catalog for a single symbol: it
+costs a tenth as much and returns the same fields for that token. The
+catalog weighs 10 because it returns every token, not because it is slow —
+reaching for it to read one symbol is the expensive mistake this table
+exists to prevent.
+
+`side` is `buy` (spend USDG for the token) or `sell` (the reverse).
+
+## What to tell the user
+
+- Slippage is a per-pool estimate, not an optimal multi-pool route. A
+  `likelyCrossesTick` flag means the trade may be large enough that the
+  estimate understates real impact — suggest splitting into tranches.
+- An unknown symbol fails rather than returning empty. An empty result is
+  a real answer, not a lookup that quietly missed.
+- Prices come from on-chain Chainlink feeds, not from Robinhood's app, so
+  they can differ from what the Robinhood UI shows.
+- Price and slippage read from snapshots refreshed every 15 minutes, not
+  from live pool state at call time. Each response carries `observedAt` —
+  quote the age rather than implying the number is live.
+
+## If an MCP server is connected
+
+Optional, and separate from this skill. If
+`https://www.hoodgrow.com/api/mcp` is added as an MCP server, the same data
+is available as ten tools (`get_token`, `get_corporate_actions`, ...) with
+no URL building. Same data, same prices, and the same x402 fallback when a
+budget runs out. Use it when it is present; this skill does not need it.

--- a/robinhood-chain-stock-tokens/references/x402-fallback.md
+++ b/robinhood-chain-stock-tokens/references/x402-fallback.md
@@ -1,0 +1,39 @@
+# Paying with x402
+
+Use this only when `HOODGROW_API_KEY` is unset or its daily budget is
+spent. A free call is always preferable — never pay for something the key
+would have covered.
+
+Every endpoint in endpoints.md accepts x402 micropayments in USDC on Base,
+paid from the agent's own wallet. No account, no subscription, no signup,
+no daily cap.
+
+## Flow
+
+Call the endpoint without a key. It answers `402 Payment Required` with the
+payment requirements in the body. Pay, then retry the same request with the
+payment attached; the response is the normal JSON.
+
+## Prices
+
+$0.05 per call, $0.10 for `/api/agent/tokens` (the full catalog). Identical
+to what the same data costs anywhere else on this API — the surface you
+reach it through never changes the price.
+
+Settlement is on Base mainnet in USDC. The endpoints are listed in
+Coinbase's x402 Bazaar, so an agent that discovers services there already
+has them.
+
+## When not to pay
+
+- The key exists and has budget. Use it.
+- A cheaper endpoint answers the question. Paying $0.10 for the catalog to
+  read one symbol wastes $0.05 and is the most likely way to overspend here.
+- The user did not ask for anything that needs fresh data.
+
+## If a payment fails
+
+A failed payment is not a reason to retry in a loop. Report what happened —
+insufficient balance, wrong network, facilitator unavailable — and say that
+a free key at hoodgrow.com/profile avoids payment entirely. Silence about a
+failed charge is worse than the failure.


### PR DESCRIPTION
Submitting a skill to the Bankr catalog via the in-app editor.

**Author:** @MeMikko (wallet `0x4b19ee2a3de2521a3adc901989944c209c0a60ea`)

**Description:** Live prices, split-adjusted supply, DeFi depth and corporate actions for tokenized stocks on Robinhood Chain. Use when a request involves a stock ticker as an onchain token (NVDAon, AAPLon, TSLAon...), before sizing a trade in one, or when supply, market cap, splits or dividends for these tokens come up.

### Checklist
- [ ] SKILL.md is clear and documented
- [ ] catalog.json validated
- [ ] Tested before submitting