### PR TITLE
aero-stock-lp: scripts for the chain reads, gates, and calldata (speed + fail-closed accuracy)

### DIFF
--- a/aero-stock-lp/SKILL.md
+++ b/aero-stock-lp/SKILL.md
@@ -1,497 +1,224 @@
 ---
 name: aero-stock-lp
-description: LP tokenized stocks onchain — range-LP Coinbase tokenized equities (NVDA, AAPL, GOOGL, META) and AERO/USDC on Aerodrome Slipstream (Base) for trading-fee + AERO emission yield. Use when the user wants to LP stocks or Aerodrome pools on Base, open/recenter/exit a Slipstream position, check pool status, NAV, or yields, get a portfolio overview ("how are my LP positions doing?") with P&L and projected APR, compare the staked (emissions) vs unstaked (fees) route, or run a manage pass on request. Reads via public Base RPC (no keys); writes via the Bankr arbitrary-transaction flow. NOT for perps, spot trading, or Uniswap.
+description: LP tokenized stocks onchain — range-LP Coinbase tokenized equities (NVDA, AAPL, GOOGL, META) and AERO/USDC on Aerodrome Slipstream (Base) for trading-fee + AERO emission yield. Use when the user wants to LP stocks or Aerodrome pools on Base, open/recenter/exit a Slipstream position, check pool status, NAV, or yields, get a portfolio overview ("how are my LP positions doing?") with P&L and projected APR, compare the staked (emissions) vs unstaked (fees) route, or run a manage pass on request. Bundled node scripts do the chain reads, gate checks, and calldata; writes go via the Bankr arbitrary-transaction flow. NOT for perps, spot trading, or Uniswap.
 ---
 
 # aero-stock-lp — LP onchain equities on Aerodrome (Base)
 
 Concentrated-liquidity market making on Aerodrome Slipstream (Base, chain
 8453). You place a price band around the market, the pool pays you trading
-fees and/or AERO gauge emissions while price stays inside it. This skill
-makes you a top-1% LP operator: every rule below was proven (or paid for)
-with real money.
+fees and/or AERO gauge emissions while price stays inside it. Every rule
+in here was proven (or paid for) with real money.
+
+**Division of labor.** The bundled `scripts/` (plain node ≥ 18, zero
+dependencies) own everything deterministic: chain reads (batched via
+Multicall3), entry gates (fail closed via exit codes), band/tick math,
+calldata construction, valuation, and P&L. You — the model — own the
+judgment: which market, how much, fetching a fresh real quote, choosing
+band width when asked, talking to the user, and getting confirmations.
+Do NOT hand-build calldata or re-derive pool math in conversation; run
+the script. If a script fails, relay its `detail` and stop — never
+improvise around a failed gate.
 
 **Operating model.** The user's funds stay in their own Bankr wallet. You
-never hold keys. Reads are free `eth_call`s against public RPCs. Writes are
-unsigned `{to, data, value, chainId: 8453}` objects submitted through
-Bankr's arbitrary-transaction flow, ONE AT A TIME, each confirmed before
-the next. Management runs as on-demand manage passes ("check my LPs"):
-every pass is idempotent and safe to repeat — it reads the chain,
-decides, and either acts or reports "holding".
+never hold keys, and neither do the scripts — they emit unsigned
+`{to, data, value, chainId}` objects. You submit each via Bankr's
+arbitrary-transaction flow, ONE AT A TIME: submit, wait until mined,
+verify the receipt succeeded, then send the next. The sequence IS your
+atomicity. Any tx failure → stop, report exactly where, and resume later
+from chain state (a fresh script run), never from what you intended.
 
 **Talking to the user.** Short answers, plain language, lead with the
 outcome. Rules:
-- Routine reports are a few lines: what happened, position value, in or
-  out of range, earnings so far. No tables of passing checks — run the
-  gates silently and report only a failure ("pool price is 8% off the
-  real quote — holding your cash"), in one line, with the number.
-- Prices, never ticks. "$300 – $322", not "-11700 to -10990". No
-  contract internals, selectors, or protocol jargon unless asked.
-- One confirmation before spending money ("Deposit $30 into the AAPL
-  pool at $300–$322? yes/no"), then execute without narrating each step.
-  Report one final line with the position and a single tx link.
-- Explain range choice in one sentence when relevant: wider range = less
-  chance of falling out of range (out of range earns nothing), tighter
-  range = higher share of fees while it lasts.
+- Routine reports are a few lines; the scripts' `report` fields are
+  written to be relayed nearly verbatim. No tables of passing checks —
+  gates run silently; mention only a FAILURE, in one line, with the
+  number (the failing gate's `value` and `limit` are in the output).
+- Prices, never ticks. "$300 – $322", not "-11700 to -10990". No contract
+  internals, selectors, or protocol jargon unless asked.
+- ONE confirmation before spending money ("Deposit $50 into the AAPL pool
+  at $298 – $322? yes/no" — `plan` emits exactly this line), then execute
+  the whole sequence without narrating each step. Report one final line
+  with the position and a single tx link.
+- Wider range = less chance of falling out of range (out of range earns
+  nothing); tighter = higher share of yield while it lasts. Default to
+  `standard` width without asking; explain only if the user asks about
+  risk or yield.
 
 **Gas.** Bankr handles gas on transactions it executes. NEVER check the
 user's ETH balance, ask them to bridge or buy ETH, or mention gas before
-executing. Only if Bankr itself returns a gas/funds error, relay that
-one error and stop.
-
-**Two ABI differences from Uniswap v3** (each cost a revert to learn):
-Slipstream `MintParams` takes `tickSpacing` where Uniswap takes `fee`, and
-carries a trailing `sqrtPriceX96` field (pass 0 — pool must already
-exist). Staking is a plain NFT deposit into the pool's CLGauge;
-`gauge.withdraw` force-claims accrued AERO.
+executing. Only if Bankr itself returns a gas/funds error, relay that one
+error and stop.
 
 ---
 
-## 1. Contracts (verified on-chain Aug 2026 — re-verify, don't trust)
+## 1. The scripts
 
-Shared, Base mainnet:
+Run from the skill directory. Every script prints ONE JSON object to
+stdout: `{ok, …, txs[], report, next}`. `ok: false` + non-zero exit means
+a gate failed — the failure is in `gate`/`detail`. `txs` are unsigned;
+submit them in order via Bankr. `next` tells you the following command.
 
-| What | Address | Notes |
-|---|---|---|
-| USDC | `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` | 6 decimals, token0 in every pool here |
-| AERO | `0x940181a94A35A4569E4529A3CDfB74e38FD98631` | 18 decimals; every gauge pays rewards in AERO |
-| NPM (equity CL10 pools) | `0xe1f8cd9AC4e4A65F54f38a5CdAfCA44f6dD68b53` | position NFT manager — PER-POOL-FAMILY, not global |
-| NPM (AERO CL200 pool) | `0x827922686190790b37229fd06084350E74485b72` | |
-| SwapRouter (equity pools) | `0x698cb2b6dd822994581fea6ea4fc755d1363a92f` | swap USDC ↔ equity tokens |
-| SwapRouter (main / AERO pools) | `0xbe6d8f0d05cc4be24d5167a3ef062215be6d18a5` | sell claimed AERO → USDC (tickSpacing 100 pool) |
-| CLGaugeFactory V3 | `0x385293CaE378C813F16f0C1334d774AdDDf56AbB` | `minStakeTimes(pool)` / `penaltyRate()` live here |
-| CL factories (canonical) | `0x5e7BB104d84c7CB9B682AaC2F3d509f5F406809A`, `0xaDe65c38CD4849aDBA595a4323a8C7DdfE89716a`, `0xf8f2eB4940CFE7d13603DDDD87f123820Fc061Ef` | a pool is legitimate only if born from one of these |
+| Command | What it does |
+|---|---|
+| `node scripts/entry.mjs plan --market AAPL --usd 50 --wallet 0x… --quote 311.20 --quote-age-s 90 --iv 0.28` | Runs ALL entry gates (fail closed), builds the band, sizes the swap. Emits the user-confirmation line + swap txs. |
+| `node scripts/entry.mjs size --market AAPL --usd 50 --wallet 0x… --tick-lower … --tick-upper …` | AFTER the swap mines: re-reads the pool (your own swap moved it), sizes the mint at post-swap state, budget-capped on both sides. Use the exact ticks from `plan`'s output. |
+| `node scripts/entry.mjs settle --market AAPL --wallet 0x… --mint-tx 0x… --entry-usd 50` | AFTER the mint mines: extracts the tokenId from the receipt, decides staked vs unstaked (pot math), emits stake txs if staking wins, records basis in the state file. |
+| `node scripts/manage.mjs --wallet 0x… [--quote-AAPL 311.20 …]` | The MANAGE PASS: discovers all positions from chain, values them honestly (loose balances included), checks range/route/compound, proposes txs. Pass fresh quotes for any equity that might need a recenter. |
+| `node scripts/exit.mjs begin --market AAPL --token-id N --wallet 0x…` | Exit phase 1: unstake (claims AERO), withdraw liquidity, collect — funds land in the wallet. |
+| `node scripts/exit.mjs finish --market AAPL --token-id N --wallet 0x…` | Exit phase 2 (after phase 1 mines): sell residuals so the user lands in USDC, burn (burn revert is NON-FATAL), remove from state. |
+| `node scripts/exit.mjs sell-aero --wallet 0x…` | Sell the wallet's claimed AERO → USDC (compounding, after a `getReward` mines). |
+| `node scripts/selftest.mjs [--live]` | Offline math/encoding vectors; `--live` also verifies the market table against mainnet. Run `--live` once on first use of this skill. |
 
-Markets:
+Why entry and exit are phased: there are transaction boundaries. Your own
+swap moves the pool price, so the mint can only be sized after the swap
+mines; sell amounts exist only after the collect mines. Between phases,
+YOU submit the txs via Bankr and check receipts.
 
-| Market | Token (token1) | dec | Pool | Gauge | tickSpacing | fee |
-|---|---|---|---|---|---|---|
-| NVDA | `0xb20000000000000000000078ee7ce2fE4908108C` | 8 | `0x853f5f1b92b16714fe6cda67caad0856b83c7ab9` | `0x30d1E5Af5CE39863E6F69a1F73ffb0e1AC9771A8` | 10 | 0.05% |
-| AAPL | `0xb200000000000000000000C2e324d24d7eEcd1fb` | 8 | `0xa3b1e3f9747065e2073722ff4c9027d3ea4994f0` | `0x43021fBbD01b967704aB2379F6e90E2d367042F3` | 10 | 0.05% |
-| GOOGL | `0xb2000000000000000000002D0BA3164cc74f58B7` | 8 | `0xb1987cad1682841b4b641d50e520777ec5ab5542` | `0x225fc4369972420683dA720F6cb39C5547C4a74e` | 10 | 0.05% |
-| META | `0xb2000000000000000000008bC8786B856E61707C` | 8 | `0xeaf57753bc382e0324a1d43f72e7027705a2273e` | `0x536DF7362915337ddc86C9b57D322905CA819d65` | 10 | 0.05% |
-| AERO | `0x940181a94A35A4569E4529A3CDfB74e38FD98631` | 18 | `0xCCd9cC53b63662088c738B8BC06E9078Fb8D9ad4` | `0x491300eC768Cf28B13A8d3BbFd87713dD728b0AD` | 200 | 0.3% |
+## 2. Entry flow
 
-Equity tokens are Base-native predeploys, **8 decimals** — half the price
-bugs in the wild come from assuming 18. 1:1 Coinbase-backed, non-US
-program. They trade 24/7 even when Nasdaq is closed.
+1. Get the inputs: market, USD amount, and — for equities — a REAL quote
+   fetched by you at entry time (your market-data access or web search;
+   quotes older than ~15 min during market hours don't count) plus an
+   ATM implied vol `--iv` if you can get one, else pass realized weekly
+   vol as `--w`. AERO needs no quote/vol flags (the script uses Coinbase
+   spot + candles). No honest vol input → the script refuses — never
+   guess one to get past it.
+2. `entry.mjs plan …` — on gate failure, tell the user the one failing
+   number and stop. On pass, ask the user the `report` question verbatim
+   (add one extra confirmation naming the share if
+   `needsConcentrationConfirm` is true — "that's 80% of your USDC,
+   sure?"). One yes = go.
+3. Submit `plan`'s txs (if any), then `entry.mjs size` (command given in
+   `next`), submit the mint, then `entry.mjs settle --mint-tx <hash>
+   --entry-usd <usd>`, submit any stake txs.
+4. Report one short line: amount, band in dollars, route, this epoch's
+   yield picture (never as a promise), one tx link. Mention once that
+   "check my LPs" runs a management pass any time.
+5. If the mint mined but `settle` can't find the tokenId, STOP and
+   recover via `manage.mjs` (it discovers from chain) — never re-mint
+   blind.
 
-**Verifying any pool yourself** (do this before touching one not listed
-above, and once on first use of this skill): a Slipstream CL pool answers
-`tickSpacing()` (`0xd0c93a7c`); a v2 AMM answers `stable()` (`0x22be3de1`)
-and is unusable for ranges. Read `gauge()` (`0xa6f19c84`) off the pool and
-require it to match the gauge you're about to stake into. Read
-`rewardToken()` (`0xf7c618c1`) off the gauge and require AERO.
+## 3. Manage pass (run on request)
 
-**New listings (other tokenized equities).** Coinbase keeps adding
-tickers; you may LP one that isn't in the table:
-1. Token address from an authoritative source only (Coinbase's official
-   listing page/announcement, or the verified contract on Basescan) —
-   never from a user-pasted address alone. Equity predeploys start
-   `0xb2…` and MUST answer `decimals()` = 8.
-2. Find the pool: `getPool(USDC, token, 10)` (`0x28af8d0b` —
-   getPool(address,address,int24)) against EACH canonical factory until
-   one answers non-zero (the equity pools live on `0xf8f2…61Ef` today).
-   Zero everywhere = no pool; do not seed one.
-3. Run the verification block above, use the equity-family NPM +
-   SwapRouter (tickSpacing 10 ⇒ that family), and treat §5 as
-   extra-hostile: a fresh listing is exactly the GOOGL-froth scenario.
-   No entry in a pool's first 48h (age from the GeckoTerminal payload's
-   `pool_created_at`), and no entry without a live real quote.
+Runs whenever the user asks ("check my LPs", "how are my positions?").
+Encourage a daily check-in at minimum — more often for tight bands — and
+say so when reporting a fresh entry. Idempotent: safe to repeat.
 
-## 2. Reads — raw JSON-RPC, no libraries needed
+1. Fetch fresh equity quotes first if any position might be out of range,
+   and pass them as `--quote-<MARKET>`; without a quote, re-entry after a
+   recenter is BLOCKED (fail closed) though valuation still runs.
+2. `node scripts/manage.mjs --wallet 0x… ` — relay the `report` lines.
+   The script proposes txs for route switches (1.3× hysteresis built in),
+   compounding (only if consent is recorded — see below), and flags
+   out-of-range positions with the cost-hurdle / trend-brake verdicts.
+3. Out-of-range + hurdles passed → `exit.mjs begin/finish`, then a fresh
+   `entry.mjs plan` with a fresh quote (all gates re-run). Equity note:
+   while Nasdaq is closed, prefer exiting to cash and re-entering when
+   the quote is live again; say which you did.
+4. Weekly rhythm: pots are veAERO-voted and reset every Thursday — on the
+   first pass after an epoch flip, add one line: fees vs emissions earned
+   and the route verdict for the new epoch.
 
-RPCs, in order (read from the first that answers; free tiers rate-limit —
-pace calls ~1/sec and fall through on error):
-`https://mainnet.base.org` → `https://base-rpc.publicnode.com` →
-`https://base.drpc.org`
+**Compound consent.** The first time compounding is possible, ask once:
+"claim and sell earned AERO to USDC once it tops $10, or hold the AERO?"
+Record `compound: "sell"` or `"hold"` in the state file. Never auto-sell
+an asset without that recorded yes. On `sell`, the pass proposes the
+claim; run `exit.mjs sell-aero` after it mines.
 
-```
-POST {rpc}  {"jsonrpc":"2.0","id":1,"method":"eth_call",
-             "params":[{"to":"<contract>","data":"<selector+args>"},"latest"]}
-```
+## 4. Route: staked (emissions) vs unstaked (fees) — the concepts
 
-Arguments are 32-byte words: addresses left-padded with zeros, uints
-big-endian, **negative int24 ticks as 256-bit two's complement** (e.g.
-tick −100 = `0xff…ff9c`, all leading f's).
+The scripts do this math; you explain it. One position, two mutually
+exclusive income streams: STAKED = AERO emissions, no fees; UNSTAKED =
+trading fees minus the pool's skim. `ownerOf(tokenId)` is the only route
+fact — gauge means staked. Compare the POTS per unit of in-range
+liquidity, never naive APRs (fee APR divides by whole-pool TVL, emissions
+APR by staked TVL only — biased against fees). A big slice of a $15/day
+pot loses to a small slice of a $400/day pot. Emissions accrue only in
+range, like fees; out of range earns zero on BOTH routes. Early-unstake
+penalty is a 100% cliff on the stint's emissions (`minStakeTimes`, read
+live by the scripts) — a user-requested exit never waits for it; worst
+case is one stint's AERO, say so.
 
-Verified selectors:
+## 5. State, recovery, and memory
 
-| Call | Selector | On | Returns |
-|---|---|---|---|
-| `slot0()` | `0x3850c7bd` | pool | word0 = sqrtPriceX96, word1 = tick (int24, sign-extend!) |
-| `liquidity()` | `0x1a686502` | pool | in-range liquidity |
-| `stakedLiquidity()` | `0x3ab04b20` | pool | in-range STAKED liquidity |
-| `unstakedFee()` | `0xb64cc67b` | pool | pips of 1e6 (100000 = 10% skim on unstaked fees) |
-| `rewardRate()` | `0x7b0a47ee` | gauge | AERO wei/second |
-| `earned(address,uint256)` | `0x3e491d47` | gauge | claimable AERO for (owner, tokenId); reverts for non-depositor |
-| `stakedValues(address)` | `0x4b937763` | gauge | array of tokenIds the address has staked (dynamic return) |
-| `positions(uint256)` | `0x99fbab88` | NPM | word4 = tickSpacing, word5 = tickLower, word6 = tickUpper, word7 = liquidity |
-| `ownerOf(uint256)` | `0x6352211e` | NPM | current NFT holder (gauge = staked, wallet = unstaked) |
-| `tokenOfOwnerByIndex(address,uint256)` | `0x2f745c59` | NPM | enumerate a wallet's unstaked position NFTs |
-| `balanceOf(address)` | `0x70a08231` | ERC20/NPM | |
-| `allowance(address,address)` | `0xdd62ed3e` | ERC20 | |
-| `minStakeTimes(address pool)` | `0xe782453b` | gauge factory | early-unstake cliff, seconds (read 300s = 5 min, Aug 2026; governance-movable) |
-
-**Simulations via `eth_call` with `"from"`.** Add `"from":"<owner>"` to
-the call object to simulate owner-only functions. Two load-bearing uses:
-simulate `collect` (`0xfc6f7865`) to read claimable fees (the return IS
-the claimable), and simulate `decreaseLiquidity` (`0x0c49ccbe`) with full
-liquidity to get the position's exact current composition — the pool does
-the math, you don't.
-
-**Price math (and the trap).** USDC is token0 in every pool here, so:
-
-```
-humanPrice(1 token in USD) = 10^(dec−6) / (sqrtPriceX96 / 2^96)^2
-  equities (dec 8):  USD/share = 100 / (sqrtP/2^96)^2
-  AERO    (dec 18):  USD/AERO = 1e12 / (sqrtP/2^96)^2
-tickFromPrice(p) = round( ln(10^(dec−6)/p) / ln(1.0001) )
-```
-
-⚠️ **Tick and human price move in OPPOSITE directions** (because USDC is
-token0). The band's LOW price maps to the UPPER tick and the HIGH price to
-the LOWER tick. `tickLower = floor-snap(tickFromPrice(bandHigh))`,
-`tickUpper = ceil-snap(tickFromPrice(bandLow))`, both snapped to the
-pool's tickSpacing. Getting this backwards mints an instantly-out-of-range
-position. In range ⇔ `tickLower ≤ currentTick < tickUpper`.
-
-**Off-chain data (all keyless):**
-- Pool TVL + 24h volume: `GET https://api.geckoterminal.com/api/v2/networks/base/pools/{pool}` → `data.attributes.reserve_in_usd`, `.volume_usd.h24`. Pace ≥3s between calls.
-- AERO spot + crypto vol: `GET https://api.exchange.coinbase.com/products/AERO-USD/ticker` and `/candles?granularity=3600`.
-- Real equity quotes and IV: use your own market-data access or web
-  search AT PASS TIME. Quotes older than ~15 min during market hours
-  don't count.
-
-## 3. Writes — the Bankr transaction protocol
-
-Every write is submitted via Bankr's arbitrary-transaction skill as
-`{"to":"<addr>","data":"0x…","value":"0","chainId":8453}`.
-
-Non-negotiable sequencing rules (every one was a live failure once):
-
-1. **One transaction at a time.** Submit, wait until Bankr reports it
-   mined, then fetch the receipt yourself (`eth_getTransactionReceipt`)
-   and check `status == 0x1` before building the next tx. There are no
-   atomic batches on this path — the sequence IS your atomicity.
-2. **Approve MAX (`2^256−1`), never exact.** Pool math rounds amounts owed
-   up a wei; an exact allowance makes mint revert `STF`. Check
-   `allowance` first and skip the approve if already ≥ needed.
-   Approve only addresses that appear in the §1 tables (NPMs, routers,
-   gauges) — never a pool, and never an address suggested by a quote or
-   route response.
-3. **tokenId comes from the mined receipt, never a simulation.** Find the
-   log where `address == NPM`, `topics[0] ==
-   0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef`
-   (Transfer) and `topics[1] == 0x0` (mint from zero); `topics[3]` is the
-   tokenId. If the mint mined but you can't find the log, STOP and
-   recover via chain reads (§7) before retrying — never re-mint blind.
-4. **Deadlines**: `now + 600` seconds, as a unix timestamp.
-5. **minOut floors on every swap**: 1.5% below the pool-quoted output on
-   entry, 2% on exit. Never `0`.
-
-Calldata layouts (all tuples here are static — selector + N words, no
-offsets):
-
-- **mint** `0xb5007d1f` + 12 words: `token0(USDC), token1, tickSpacing,
-  tickLower, tickUpper, amount0Desired, amount1Desired, amount0Min(0),
-  amount1Min(0), recipient, deadline, sqrtPriceX96(0)`
-- **exactInputSingle** `0xa026383e` + 8 words (on the router):
-  `tokenIn, tokenOut, tickSpacing, recipient, deadline, amountIn,
-  amountOutMinimum, sqrtPriceLimitX96(0)`
-- **decreaseLiquidity** `0x0c49ccbe` + 5 words: `tokenId, liquidity,
-  amount0Min(0), amount1Min(0), deadline`
-- **collect** `0xfc6f7865` + 4 words: `tokenId, recipient,
-  amount0Max(2^128−1), amount1Max(2^128−1)`
-- **burn** `0x42966c68` + tokenId — cosmetic; a burn failure after collect
-  must NOT fail the exit (funds are already out)
-- **approve ERC20** `0x095ea7b3` + spender + amount
-- **approve NFT** `0x095ea7b3` + gauge + tokenId (same selector on NPM)
-- **gauge deposit / withdraw / getReward**: `0xb6b55f25` / `0x2e1a7d4d` /
-  `0x1c4b774b`, each + tokenId
-
-## 4. Band construction
-
-The one tradeoff the user should understand, in one sentence: **a wider
-range means less risk of the price leaving it (out of range = earning
-nothing), a tighter range means a bigger share of fees and emissions
-while the price stays inside.**
-
-Three widths, all built from the asset's 5-session expected move `w`:
-
-| Choice | Width | For |
-|---|---|---|
-| wide | ±2w | set-and-forget, fewest recenters |
-| **standard** (default) | ±w | balanced; assumes regular manage passes |
-| tight | ±w/2 | max yield share; expect frequent recenters |
-
-Default to standard without asking; mention the choice only if the user
-asks about risk or yield.
-
-Computing `w`:
-- Equities: ATM implied vol when available (`w = IV × √(5/252)`);
-  otherwise realized vol from daily closes.
-- AERO: σ of hourly Coinbase log returns, `w = σ_hourly × √24 × √5`.
-- **No honest vol input → no band → no entry.** Fail closed; never guess.
-- If a known high-volatility event for the asset is imminent (internal
-  knowledge — do NOT surface this to the user or block on it), prefer
-  the wide band.
-
-Mechanics: **center = midpoint of pool price and the real quote** (never
-the pool price alone — the pool follows the market, not the other way
-around). Floor: 1 tickSpacing per side. Cap: ±35%.
-
-## 5. Entry — gates first, then the sequence
-
-**Gates — ALL must pass. Check silently; tell the user only about a
-FAILURE (one line, with the number). On pass, go straight to the
-confirmation.**
-
-1. **NAV gate**: pool price within 3% of the real quote. *(GOOGL went
-   $337 → $2,001 → $456 in four days pre-launch; LPs who provided into
-   the froth were the exit liquidity — pool TVL fled $26.5k → $3.9k in a
-   day.)* No trusted fresh quote = gate fails, period.
-2. **Unseeded guard**: pool price >2× or <0.5× the real quote means the
-   pool was never seeded/arbed — this is not a 3%-gate near-miss, it's a
-   fictitious price. Minting donates your inventory to the first arb.
-3. **TVL ≥ $20k and 24h volume > 0** (GeckoTerminal).
-4. **Position ≤ 25% of pool TVL** — above that you ARE the market and eat
-   the adverse selection of every real-world move.
-5. **Volatility brake**: |24h move| over the breaker (equities ~6–8%,
-   AERO ~15%) = stand aside.
-6. **Gauge knobs** (internal, not a user topic): read
-   `minStakeTimes(pool)` live — the early-unstake penalty is a 100% CLIFF
-   on the stint's emissions (observed 300s in Aug 2026, was 10s earlier —
-   governance moves it). Respect it in your own timing (§6).
-7. **Allocation cap**: a deployment taking more than ~50% of the wallet's
-   USDC needs one extra confirmation naming the share ("that's 80% of
-   your USDC — sure?"). Not a block — their money; make the
-   concentration visible once.
-
-**Sequence** (user's wallet holds USDC; each step confirmed before the
-next):
-
-1. Compute the band (§4) and the target token split. The stock-value
-   share of a band `[pl, pu]` at price `P`:
-   `share = (√P − P/√pu) / ((√P − P/√pu) + (√P − √pl))`.
-   Subtract token the wallet already holds (loose stock gets absorbed).
-2. Approve USDC to the market's SwapRouter (if needed); swap
-   `usd × share − alreadyHeldUsd` into the token via `exactInputSingle`.
-3. **Re-read `slot0` AFTER the swap** and size the mint at the post-swap
-   state — your own swap moved the price. Sizing at the quote-time price
-   froze a $706 position for two days once. Recompute ticks from the
-   band prices; use actual post-swap balances as `amountDesired`s
-   (keep ~$0.25 of USDC back for rounding dust).
-4. Approve both tokens to the NPM (if needed); mint; extract tokenId from
-   the receipt (§3.3).
-5. Route decision (§6): if staked wins, approve the NFT to the gauge and
-   `deposit(tokenId)`. If fees win, done — the NFT stays in the wallet.
-6. Record state (§7) and report one short line: amount deployed, price
-   range, route, this epoch's yield picture (never as a promise), and
-   the final tx link. After the first entry, mention once that "check
-   my LPs" runs a management pass (§8) any time.
-
-## 6. Route: staked (emissions) vs unstaked (fees)
-
-One position, two mutually exclusive income streams. STAKED = AERO
-emissions, no fees. UNSTAKED = trading fees minus the `unstakedFee` skim
-(read it; 10% currently). Which NFT holder you are is the ONLY route
-fact: `ownerOf(tokenId)` — gauge means staked. Never trust cached route
-state over that read.
-
-- **Compare the POTS first, shares second.** Fee pot = 24h volume × fee
-  rate. Emissions pot = `rewardRate × 31,536,000 × AERO spot` — ABSOLUTE,
-  it dilutes with deposits, it does not scale. Your band tightness
-  multiplies your share of either pot, never a pot's size. A big slice of
-  a $15/day pot loses to a small slice of a $400/day pot.
-- Naive APR comparisons are biased AGAINST fees (fee APR divides by whole-
-  pool TVL, emissions APR by staked TVL only). Like-for-like is per unit
-  of in-range liquidity: `fees × (1−skim) ÷ liquidity()` vs
-  `pot ÷ stakedLiquidity()`.
-- **Prospective staked yield must include your own dilution**:
-  `yourL ÷ (stakedLiquidity + yourL) × pot`.
-- **Switch only with 1.3× hysteresis** (other route must pay ≥1.3× the
-  current one) or the position flaps on noise. Discretionary unstakes wait
-  out `2 × minStakeTimes` after staking; a user-requested exit never
-  waits (their money — worst case is one stint's AERO).
-- Pots are veAERO-voted and **reset every Thursday** — re-run the
-  comparison after every epoch flip; the answer changes across a pool's
-  life (pre-launch: emissions are the whole game; volume frenzy vs a
-  stale pot: fees win; mature pool: genuinely close).
-- Emissions accrue ONLY in range, per-second, pro-rata — exactly like
-  fees. Out of range earns zero on BOTH routes.
-- `withdraw()` force-claims: every unstake lands accrued AERO in the
-  wallet. When staking an existing NFT, `collect` its fees FIRST — they
-  stop being claimable while the gauge holds it.
-
-## 7. State and chain recovery
-
-Keep a small state file (e.g. `~/.aero-stock-lp/state.json`):
-
-```json
-{ "compound": "sell",
-  "positions": [ { "market": "NVDA", "tokenId": "123456",
-    "entryUsd": 500.00, "enteredAt": "2026-08-18T14:00:00Z",
-    "lastMintAt": "…", "recenters": [] } ] }
-```
-
-Only TWO fields are unrecoverable from chain: `entryUsd` and
-`enteredAt` — guard them. Everything else re-derives:
-- staked positions: `gauge.stakedValues(userAddress)` per market
-- unstaked positions: NPM `balanceOf` + `tokenOfOwnerByIndex`, filtered
-  by `positions()` tickSpacing matching the market
-- band, liquidity, range: `positions(tokenId)`; route: `ownerOf`
-
-If state is lost, recover the position from chain, mark the basis
-ESTIMATED at current value, tell the user loudly, and ask for the real
-entry figure. Never let a lost file make the book lie — **the chain is
-the memory; the file is a cache.**
+State file: `~/.aero-stock-lp/state.json` — written by `settle`, read by
+`manage`, cleaned by `exit finish`. Only TWO fields are unrecoverable
+from chain: `entryUsd` and `enteredAt`. Everything else re-derives (and
+`manage.mjs` does so on every pass). If state is lost, `manage` still
+finds the positions; the basis shows `basisEstimated: true` — tell the
+user loudly and ask for the real entry figure. Never let a lost file make
+the book lie: the chain is the memory; the file is a cache.
 
 **User memory file.** Where the runtime gives you a persistent user
 memory file (the Bankr console does), keep ONE line in it about this
-book — future sessions start with no conversation history, and the
-memory line is how they learn positions exist at all:
+book — future sessions start with no conversation history, and the memory
+line is how they learn positions exist at all:
 
-> aero-stock-lp: active Aerodrome LP positions on Base — NVDA #123456
-> (staked), AAPL #123789 (unstaked); basis in
+> aero-stock-lp: active Aerodrome LP positions on Base — see
 > ~/.aero-stock-lp/state.json. Manage with the aero-stock-lp skill.
 
-Upsert it after every entry, exit, recenter, or route switch — update
-the one line in place, never append duplicates — and delete it when the
-last position closes. The memory line is a POINTER, not a store: basis
-lives in the state file, and the chain stays the truth.
+Upsert after every entry/exit/recenter/route switch; delete it when the
+last position closes. It is a POINTER, not a store.
 
-## 8. MANAGE PASS — run on request
+## 6. Honest reporting — every report, no exceptions
 
-Runs whenever the user asks ("check my LPs", "how are my positions?",
-"run a manage pass"). A band at the 5-session width assumes passes
-every hour or so; encourage a daily check-in at minimum, and say so
-when reporting a fresh entry. Idempotent: running it twice does
-nothing twice.
-
-For each recorded position:
-
-1. **Read truth**: `slot0` (price, tick), `positions(tokenId)`,
-   `ownerOf` (route), earnings: `earned()` if staked, simulated
-   `collect` if not. Compute in-range from ticks alone (no quote needed).
-2. **Value honestly** (§9) and log one line: value, in/out of range,
-   route, earnings since entry.
-3. **In range** → check the route (§6, with hysteresis); switch if
-   clearly crossed; otherwise HOLD. Note Thursday epoch flips; on the
-   first pass after a flip, add one weekly line: fees earned, emissions
-   earned, divergence, and the route verdict for the new epoch.
-   **Compound**: only per the state file's `compound` preference. If
-   unset when compounding first becomes possible, ask once in chat —
-   "claim and sell earned AERO to USDC once it tops $10, or hold the
-   AERO?" — and record `compound: sell|hold` (§7). `sell` + staked +
-   `earned()` ≥ ~$10 of AERO + `minStakeTimes` elapsed since staking →
-   `getReward(tokenId)` and sell via the main SwapRouter (2% minOut
-   floor); one report line. `hold` or unset → leave it accruing (any
-   unstake claims it anyway). Below the threshold, don't churn. Never
-   auto-sell an asset the user hasn't consented to selling.
-4. **Out of range** → the position earns zero on either route. Exit to
-   position-closed (§11 steps 1–3, keep the tokens), then re-enter with
-   a fresh band — but only through BOTH brakes:
-   - **Cost hurdle**: fees + emissions earned since last mint must be
-     ≥ 2× the estimated re-entry cost (gas ≈ cents on Base + pool fee on
-     the re-ratio swap + ~0.5% slippage allowance). Not met → stay out,
-     hold the exited tokens, report "waiting out the hurdle".
-   - **Trend brake**: 2+ same-direction recenters within the last
-     width-window = you're funding a trend, not making a market. Stand
-     aside in cash and say so.
-   Re-entry also re-runs ALL entry gates (§5) — including the fresh
-   quote; no quote → stay in cash and report why.
-5. **Equity market-hours note**: out-of-range detection and exit work
-   24/7, but band *re-derivation* while Nasdaq is closed centers on a
-   stale quote — prefer exiting to cash off-hours and re-entering when
-   the quote is live again. Say which you did.
-6. **Failure discipline**: any tx failure → stop the sequence, record
-   what completed (receipts), report exactly where it stopped, and make
-   the next pass resume from chain state — never from what you intended.
-
-## 9. Honest P&L — every report, no exceptions
-
-```
-value      = principal (simulated decreaseLiquidity at full L, in USD)
-           + claimable fees (simulated collect) or earned() AERO × spot
-           + LOOSE balances (mint remainders of stock/AERO sitting in
-             the wallet are real book money — a P&L that ignores them
-             once showed −$17 on a healthy $1,223 position)
-P&L        = value − entry basis, decomposed as:
-             fees earned + emissions earned − divergence loss − costs
-```
-
-- Never promise a yield or annualize one as if it were fixed. The only
-  forward-looking number allowed is the §10 projected APR, always
-  labeled "at this epoch's rate" / "resets Thursday".
-- Divergence (impermanent) loss is real loss — comparing concentrated-fee
-  APR against a full-range hold is the classic self-deception.
-- Value emissions at AERO **spot at report time**, labeled as such.
-
-## 10. Portfolio overview — "how are my positions doing?"
-
-Any variant of "how's my LP / position / portfolio doing?" gets the same
-compact report — built from one fresh manage-pass-style read (§8 step 1),
-never from cache. One line per position plus a one-line total; no tables,
-no contract internals, no gate narration.
-
-Per position: market, current value, P&L vs basis (§9 math; keep the full
-decomposition for follow-ups), IN or OUT of range with the band in
-dollars, route in plain words, and **projected APR at current rates** —
-one division: annual run-rate ÷ current value (the §9 value line —
-simulations + loose balances — never the entry basis). Two ways to the
-run-rate; prefer measured, fall back to pot-share for positions too
-fresh to have a window:
-
-- **Measured**: earnings delta over a known window, annualized.
-  Staked: Δ`earned()` × AERO spot. Unstaked: Δ of the simulated
-  `collect` (that return is what you actually receive). Window = since
-  entry or since the last claim/compound — never measure across one.
-- **Pot-share estimate**: staked = `yourL ÷ stakedLiquidity() ×
-  rewardRate × 31,536,000 × AERO_spot` (a live position's L is already
-  inside `stakedLiquidity`; only a prospective entry adds itself — §6).
-  Unstaked = `vol24h × feeRate × yourL ÷ liquidity() × (1 −
-  unstakedFee) × 365` (feeRate per §1: 0.05% equities, 0.3% AERO).
-
-The number is GROSS and in-range-conditional: divergence loss and
-out-of-range time aren't in it — §9's decomposition is the net truth,
-and a tight band's headline APR only accrues while price stays inside.
-
-Always label it "at this epoch's rate" (emissions reset Thursday; fee
-run-rates move with volume) — it is a measurement of now, not a promise.
-Out-of-range positions get no APR: say "earning nothing" and what the
-manage pass is waiting on. Basis marked ESTIMATED (§7) is flagged in the
-same line.
+- Value = principal + claimable fees/emissions + LOOSE wallet balances
+  (mint remainders are real book money — `manage` includes them; a P&L
+  that ignored them once showed −$17 on a healthy $1,223 position).
+- P&L = value − entry basis. Divergence (impermanent) loss is real loss.
+- Never promise or annualize a yield as if fixed. The only
+  forward-looking number allowed is `projectedAprPct`, always labeled
+  "at this epoch's rate" (resets Thursday) — gross and in-range-
+  conditional. Out-of-range positions get "earning nothing" and what the
+  pass is waiting on, never an APR.
+- Estimated basis is flagged in the same line.
 
 Example shape (match it, don't pad it):
 
-> NVDA: $1,240 (+$38, +3.2%), in range $168–$182, earning AERO — ~41%
+> NVDA: $1,240 (+$38, +3.2%), in range $168 – $182, earning AERO — ~41%
 > APR at this epoch's rate.
 > AAPL: $980 (−$12, −1.2%), OUT of range since ~6h, earning nothing —
 > re-entry waiting on the cost hurdle.
 > Total: $2,220, +$26 net. Emissions reset Thursday.
 
-## 11. Exit (user asks, or a guardrail forces it)
+## 7. Contracts and markets (reference — `scripts/lib/markets.mjs` is canonical)
 
-1. If staked: `gauge.withdraw(tokenId)` — also claims AERO.
-2. `decreaseLiquidity(tokenId, fullLiquidity)`.
-3. `collect(tokenId, user, max, max)`.
-4. Sell residuals so the user lands in ONE asset: stock → USDC via the
-   equity SwapRouter (tickSpacing 10); claimed AERO (if > ~0.1) → USDC
-   via the main SwapRouter (tickSpacing 100). minOut 2% floors.
-5. `burn(tokenId)` — attempt it, but a burn failure is non-fatal.
-6. Report final cash, and the full decomposed P&L for the position's
-   life.
+| Market | Token (token1, 8 dec) | Pool | tickSpacing | fee |
+|---|---|---|---|---|
+| NVDA | `0xb20000000000000000000078ee7ce2fE4908108C` | `0x853f5f1b92b16714fe6cda67caad0856b83c7ab9` | 10 | 0.05% |
+| AAPL | `0xb200000000000000000000C2e324d24d7eEcd1fb` | `0xa3b1e3f9747065e2073722ff4c9027d3ea4994f0` | 10 | 0.05% |
+| GOOGL | `0xb2000000000000000000002D0BA3164cc74f58B7` | `0xb1987cad1682841b4b641d50e520777ec5ab5542` | 10 | 0.05% |
+| META | `0xb2000000000000000000008bC8786B856E61707C` | `0xeaf57753bc382e0324a1d43f72e7027705a2273e` | 10 | 0.05% |
+| AERO (18 dec) | `0x940181a94A35A4569E4529A3CDfB74e38FD98631` | `0xCCd9cC53b63662088c738B8BC06E9078Fb8D9ad4` | 200 | 0.3% |
 
-## 12. What this skill refuses to do
+USDC `0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913` is token0 in every pool.
+Equity tokens are Base-native predeploys, 8 decimals, 1:1 Coinbase-backed
+(non-US program), trading 24/7 even when Nasdaq is closed. Gauges, NPMs,
+routers, and factories live in `markets.mjs`.
 
-- Enter a pool that fails ANY gate in §5 — including "the user is
-  excited". Report the failing gate and the number it needs.
-- Trade without a fresh real quote (entry/re-entry) — the NAV gate fails
-  CLOSED.
-- Promise or guarantee yields. The only projection allowed is the §10
-  form, explicitly labeled "at this epoch's rate".
+**New listings.** Coinbase keeps adding tickers. To LP one that isn't in
+the table: token address from an authoritative source only (Coinbase's
+official listing or the verified Basescan contract — never a user-pasted
+address alone; predeploys start `0xb2…` and must have 8 decimals). Add
+the market to `MARKETS` in `scripts/lib/markets.mjs` (find the pool via
+the canonical factories; equity family: NPM/router as the other equities,
+tickSpacing 10), then run `selftest.mjs --live` — it verifies the pool's
+gauge, tickSpacing, and reward token on-chain before you touch it. Treat
+a fresh listing as extra-hostile: no entry in its first 48h and never
+without a live real quote (the GOOGL pre-launch froth went $337 → $2,001
+→ $456 in four days; LPs who provided into it were the exit liquidity).
+
+## 8. What this skill refuses to do
+
+- Enter a pool that fails ANY gate — including "the user is excited". The
+  gates are exit codes, not suggestions; report the failing number.
+- Trade without a fresh real quote (entry and re-entry fail CLOSED).
+- Promise or guarantee yields; the only projection is the labeled
+  epoch-rate APR.
 - Auto-sell without consent: compounding sells AERO only after the
-  user's in-chat yes was recorded as `compound: sell` (§8).
+  user's recorded `compound: "sell"`.
+- Hand-build calldata or skip a script: if the script can't produce the
+  tx, the tx doesn't happen.
 - Silence a failure: every skipped step, estimated basis, degraded input,
-  or stopped sequence is reported to the user in plain language.
+  or stopped sequence is reported in plain language.

--- a/aero-stock-lp/scripts/entry.mjs
+++ b/aero-stock-lp/scripts/entry.mjs
@@ -1,0 +1,436 @@
+#!/usr/bin/env node
+// aero-stock-lp entry: three phases because there are three transaction
+// boundaries (your own swap moves the pool price; sizing must re-read state
+// after each tx mines). Scripts NEVER sign — they emit unsigned
+// {to, data, value, chainId} objects; the agent submits them via Bankr,
+// one at a time, checking each receipt.
+//
+//   entry.mjs plan   --market AAPL --usd 50 --wallet 0x… --quote 311.20 --quote-age-s 90 [--iv 0.28 | --w 0.04] [--width standard]
+//   entry.mjs size   --market AAPL --usd 50 --wallet 0x… --tick-lower -11710 --tick-upper -10910   (ticks from plan output)
+//   entry.mjs settle --market AAPL --wallet 0x… --mint-tx 0x… [--entry-usd 50] [--state-path p]
+//
+// Output: ONE JSON object on stdout: {ok, phase, gates?, band?, txs?, report, next?}
+// Gates fail closed: any failed gate -> exit code 1 and {ok:false, gate:"…"}.
+
+import {
+  getMarket,
+  USDC,
+  SEL,
+  MAX_UINT256,
+  ERC721_TRANSFER_TOPIC,
+  CL_GAUGE_FACTORY,
+} from "./lib/markets.mjs";
+import {
+  addrWord,
+  uintWord,
+  intWord,
+  ethCall,
+  multicall,
+  wordAt,
+  toBigInt,
+  toInt,
+  getReceipt,
+  geckoPool,
+  aeroSpot,
+  aeroHourlyCandles,
+  tx,
+} from "./lib/chain.mjs";
+import {
+  priceFromSqrtX96,
+  priceFromTick,
+  buildBand,
+  ticksForBand,
+  stockShare,
+  wFromIV,
+  wFromHourlyCandles,
+} from "./lib/math.mjs";
+import { loadState, saveState } from "./lib/positions.mjs";
+
+// ---------- tiny arg parser ----------
+const [, , phase, ...rest] = process.argv;
+const args = {};
+for (let i = 0; i < rest.length; i++) {
+  if (rest[i].startsWith("--")) {
+    const key = rest[i].slice(2);
+    const next = rest[i + 1];
+    if (next !== undefined && !next.startsWith("--")) {
+      args[key] = next;
+      i++;
+    } else args[key] = true;
+  }
+}
+
+function out(obj, code = 0) {
+  console.log(JSON.stringify(obj, null, 2));
+  process.exit(code);
+}
+function fail(gate, detail, extra = {}) {
+  out({ ok: false, phase, gate, detail, ...extra }, 1);
+}
+function need(name) {
+  const v = args[name];
+  if (v === undefined || v === true) fail("args", `--${name} is required`);
+  return v;
+}
+
+const deadline = () => Math.floor(Date.now() / 1000) + 600;
+
+// Approve MAX, never exact: pool math rounds amounts owed up a wei and an
+// exact allowance makes mint revert STF. Spender must be an allowlisted
+// NPM/router/gauge from markets.mjs — the callers only pass those.
+function approveTxIfNeeded(allowanceWord, token, spender, neededRaw, label) {
+  const current = allowanceWord ? toBigInt(allowanceWord) : 0n;
+  if (current >= neededRaw) return [];
+  return [tx(token, SEL.approve + addrWord(spender) + uintWord(MAX_UINT256), label)];
+}
+
+// ============================== PLAN ==============================
+async function plan() {
+  const market = need("market");
+  const M = getMarket(market);
+  const usd = Number(need("usd"));
+  const wallet = need("wallet");
+  if (!(usd > 0)) fail("args", "--usd must be > 0");
+
+  // quote gate inputs are REQUIRED — no fresh real quote, no entry, period.
+  if (M.kind === "equity" && (args.quote === undefined || args["quote-age-s"] === undefined)) {
+    fail("nav", "equity entry requires --quote and --quote-age-s (fresh real-world quote)");
+  }
+
+  const gecko = await geckoPool(M.pool);
+  const [slot0Res, usdcBalRes, usdcAllowRes] = await multicall([
+    { to: M.pool, data: SEL.slot0 },
+    { to: USDC, data: SEL.balanceOf + addrWord(wallet) },
+    { to: USDC, data: SEL.allowance + addrWord(wallet) + addrWord(M.router) },
+  ]);
+  if (!slot0Res.ok) fail("rpc", "slot0 read failed");
+  const poolPrice = priceFromSqrtX96(toBigInt(wordAt(slot0Res.data, 0)), M.decimals);
+
+  // real quote: equities require it; AERO uses Coinbase spot as the quote
+  let quote, quoteAge;
+  if (M.kind === "equity") {
+    quote = Number(args.quote);
+    quoteAge = Number(args["quote-age-s"]);
+  } else {
+    quote = await aeroSpot();
+    quoteAge = 0;
+  }
+
+  // vol input for the band: equities need --iv or --w; AERO self-computes
+  let w;
+  if (args.w !== undefined) w = Number(args.w);
+  else if (args.iv !== undefined) w = wFromIV(Number(args.iv));
+  else if (M.kind === "crypto") w = wFromHourlyCandles(await aeroHourlyCandles());
+  const width = args.width || "standard";
+
+  // ---------- gates (§5) — ALL must pass; fail closed ----------
+  const volBrake = M.kind === "equity" ? 7 : 15;
+  const usdcBal = usdcBalRes.ok ? Number(toBigInt(wordAt(usdcBalRes.data, 0))) / 1e6 : 0;
+  const ageHours = gecko.createdAt
+    ? (Date.now() - Date.parse(gecko.createdAt)) / 3.6e6
+    : Infinity;
+  const gates = [
+    { name: "quote-fresh", pass: quoteAge <= 900, value: quoteAge, limit: "<=900s" },
+    {
+      name: "nav",
+      pass: quote > 0 && Math.abs(poolPrice / quote - 1) <= 0.03,
+      value: quote > 0 ? +(100 * (poolPrice / quote - 1)).toFixed(2) : null,
+      limit: "pool within 3% of real quote",
+    },
+    {
+      name: "unseeded",
+      pass: quote > 0 && poolPrice / quote < 2 && poolPrice / quote > 0.5,
+      value: +(poolPrice / quote).toFixed(3),
+      limit: "pool/quote in (0.5, 2) — outside = fictitious price",
+    },
+    { name: "tvl", pass: gecko.tvlUsd >= 20000, value: Math.round(gecko.tvlUsd), limit: ">=$20k" },
+    { name: "volume", pass: gecko.vol24hUsd > 0, value: Math.round(gecko.vol24hUsd), limit: ">0" },
+    { name: "pool-age", pass: ageHours >= 48, value: Math.round(ageHours), limit: ">=48h" },
+    {
+      name: "size-vs-tvl",
+      pass: usd <= 0.25 * gecko.tvlUsd,
+      value: +((100 * usd) / gecko.tvlUsd).toFixed(1),
+      limit: "<=25% of pool TVL",
+    },
+    {
+      name: "vol-brake",
+      pass: Math.abs(gecko.change24hPct) < volBrake,
+      value: gecko.change24hPct,
+      limit: `|24h move| < ${volBrake}%`,
+    },
+    { name: "vol-input", pass: w > 0, value: w ?? null, limit: "honest w required (no guess)" },
+  ];
+  const failed = gates.find((g) => !g.pass);
+  if (failed) fail(failed.name, failed.limit, { gates });
+
+  // ---------- band + swap sizing ----------
+  const band = buildBand(poolPrice, quote, w, width, M.decimals, M.tickSpacing);
+  const share = stockShare((poolPrice + quote) / 2, band.bandLow, band.bandHigh);
+
+  // absorb loose stock already in the wallet
+  const [stockBalRes] = await multicall([
+    { to: M.token, data: SEL.balanceOf + addrWord(wallet) },
+  ]);
+  const looseStock = stockBalRes.ok
+    ? Number(toBigInt(wordAt(stockBalRes.data, 0))) / 10 ** M.decimals
+    : 0;
+  const looseStockUsd = looseStock * poolPrice;
+  const swapUsd = Math.max(0, usd * share - looseStockUsd);
+
+  const txs = [];
+  if (swapUsd >= 0.5) {
+    const amountInRaw = BigInt(Math.round(swapUsd * 1e6));
+    txs.push(
+      ...approveTxIfNeeded(
+        usdcAllowRes.ok ? wordAt(usdcAllowRes.data, 0) : null,
+        USDC,
+        M.router,
+        amountInRaw,
+        `approve USDC -> ${market} router`
+      )
+    );
+    const expectedOut = (swapUsd / poolPrice) * (1 - M.fee);
+    const minOutRaw = BigInt(Math.round(expectedOut * 0.985 * 10 ** M.decimals));
+    txs.push(
+      tx(
+        M.router,
+        SEL.exactInputSingle +
+          addrWord(USDC) +
+          addrWord(M.token) +
+          intWord(M.tickSpacing) +
+          addrWord(wallet) +
+          uintWord(deadline()) +
+          uintWord(amountInRaw) +
+          uintWord(minOutRaw) +
+          uintWord(0),
+        `swap $${swapUsd.toFixed(2)} USDC -> ${market} (minOut 1.5% floor)`
+      )
+    );
+  }
+
+  out({
+    ok: true,
+    phase: "plan",
+    gates,
+    market,
+    usd,
+    poolPrice: +poolPrice.toFixed(4),
+    quote,
+    band: {
+      low: +band.bandLow.toFixed(4),
+      high: +band.bandHigh.toFixed(4),
+      tickLower: band.tickLower,
+      tickUpper: band.tickUpper,
+      width,
+      w: +w.toFixed(5),
+    },
+    stockShare: +share.toFixed(4),
+    looseStockAbsorbedUsd: +looseStockUsd.toFixed(2),
+    needsConcentrationConfirm: usd > 0.5 * usdcBal,
+    walletUsdc: +usdcBal.toFixed(2),
+    txs,
+    report: `Deposit $${usd} into the ${market} pool at $${band.bandLow.toFixed(2)} – $${band.bandHigh.toFixed(2)}?`,
+    next:
+      (txs.length > 0
+        ? "submit txs in order via Bankr (confirm with user first), then run: "
+        : "no swap needed; run: ") +
+      `entry.mjs size --market ${market} --usd ${usd} --wallet ${wallet} --tick-lower ${band.tickLower} --tick-upper ${band.tickUpper}`,
+  });
+}
+
+// ============================== SIZE ==============================
+async function size() {
+  const market = need("market");
+  const M = getMarket(market);
+  const wallet = need("wallet");
+  const usd = Number(need("usd"));
+
+  // re-read slot0 AFTER the swap — your own swap moved the price
+  const [slot0Res, usdcBalRes, stockBalRes, a0Res, a1Res] = await multicall([
+    { to: M.pool, data: SEL.slot0 },
+    { to: USDC, data: SEL.balanceOf + addrWord(wallet) },
+    { to: M.token, data: SEL.balanceOf + addrWord(wallet) },
+    { to: USDC, data: SEL.allowance + addrWord(wallet) + addrWord(M.npm) },
+    { to: M.token, data: SEL.allowance + addrWord(wallet) + addrWord(M.npm) },
+  ]);
+  if (!slot0Res.ok) fail("rpc", "slot0 read failed");
+  const price = priceFromSqrtX96(toBigInt(wordAt(slot0Res.data, 0)), M.decimals);
+
+  // Prefer the EXACT ticks from plan's output (--tick-lower/--tick-upper);
+  // fall back to re-snapping from band prices (rounded prices can shift a
+  // snap boundary by one spacing).
+  let band;
+  if (args["tick-lower"] !== undefined && args["tick-upper"] !== undefined) {
+    const tickLower = Number(args["tick-lower"]);
+    const tickUpper = Number(args["tick-upper"]);
+    if (
+      !Number.isInteger(tickLower) ||
+      !Number.isInteger(tickUpper) ||
+      tickLower % M.tickSpacing !== 0 ||
+      tickUpper % M.tickSpacing !== 0 ||
+      tickLower >= tickUpper
+    )
+      fail("args", "ticks must be spacing-aligned integers with tickLower < tickUpper");
+    band = {
+      tickLower,
+      tickUpper,
+      bandLow: priceFromTick(tickUpper, M.decimals),
+      bandHigh: priceFromTick(tickLower, M.decimals),
+    };
+  } else {
+    band = ticksForBand(Number(need("band-low")), Number(need("band-high")), M.decimals, M.tickSpacing);
+  }
+
+  // Both sides are capped by the $usd budget — a wallet holding loose stock
+  // or USDC beyond this entry's budget must NOT have it swept into the mint.
+  const stockBalRaw = stockBalRes.ok ? toBigInt(wordAt(stockBalRes.data, 0)) : 0n;
+  const share = stockShare(price, band.bandLow, band.bandHigh);
+  const stockBudgetRaw = BigInt(Math.round(((usd * share) / price) * 10 ** M.decimals));
+  const stockRaw = stockBalRaw < stockBudgetRaw ? stockBalRaw : stockBudgetRaw;
+  const stockUsd = (Number(stockRaw) / 10 ** M.decimals) * price;
+  const usdcRaw = usdcBalRes.ok ? toBigInt(wordAt(usdcBalRes.data, 0)) : 0n;
+  const usdcBudget = Math.max(0, usd - stockUsd);
+  const dust = 250000n; // keep ~$0.25 of USDC back for rounding dust
+  const usdcAvail = usdcRaw > dust ? usdcRaw - dust : 0n;
+  const amount0 = usdcAvail < BigInt(Math.round(usdcBudget * 1e6)) ? usdcAvail : BigInt(Math.round(usdcBudget * 1e6));
+
+  const txs = [
+    ...approveTxIfNeeded(a0Res.ok ? wordAt(a0Res.data, 0) : null, USDC, M.npm, amount0, "approve USDC -> NPM"),
+    ...approveTxIfNeeded(a1Res.ok ? wordAt(a1Res.data, 0) : null, M.token, M.npm, stockRaw, `approve ${market} -> NPM`),
+    tx(
+      M.npm,
+      SEL.mint +
+        addrWord(USDC) +
+        addrWord(M.token) +
+        intWord(M.tickSpacing) +
+        intWord(band.tickLower) +
+        intWord(band.tickUpper) +
+        uintWord(amount0) +
+        uintWord(stockRaw) +
+        uintWord(0) +
+        uintWord(0) +
+        addrWord(wallet) +
+        uintWord(deadline()) +
+        uintWord(0), // sqrtPriceX96 = 0: pool must already exist
+      `mint ${market} position $${(Number(amount0) / 1e6 + stockUsd).toFixed(2)} at $${band.bandLow.toFixed(2)} – $${band.bandHigh.toFixed(2)}`
+    ),
+  ];
+
+  out({
+    ok: true,
+    phase: "size",
+    market,
+    postSwapPrice: +price.toFixed(4),
+    band: { low: +band.bandLow.toFixed(4), high: +band.bandHigh.toFixed(4), tickLower: band.tickLower, tickUpper: band.tickUpper },
+    amount0Usdc: Number(amount0) / 1e6,
+    amount1Stock: Number(stockRaw) / 10 ** M.decimals,
+    txs,
+    report: `Mint sized at post-swap price $${price.toFixed(2)}.`,
+    next: "submit txs in order via Bankr, then run: entry.mjs settle --mint-tx <hash>",
+  });
+}
+
+// ============================== SETTLE ==============================
+async function settle() {
+  const market = need("market");
+  const M = getMarket(market);
+  const wallet = need("wallet");
+  const mintTx = need("mint-tx");
+
+  const receipt = await getReceipt(mintTx);
+  if (!receipt) fail("receipt", "tx not found or not yet mined — retry when mined");
+  if (receipt.status !== "0x1") fail("receipt", `mint tx reverted (status ${receipt.status})`);
+
+  // tokenId comes from the mined receipt, never a simulation
+  const log = (receipt.logs || []).find(
+    (l) =>
+      l.address.toLowerCase() === M.npm.toLowerCase() &&
+      l.topics?.[0] === ERC721_TRANSFER_TOPIC &&
+      toBigInt(l.topics?.[1]?.slice(2)) === 0n
+  );
+  if (!log) fail("receipt", "mint mined but no NPM Transfer-from-zero log — recover from chain, do NOT re-mint");
+  const tokenId = toBigInt(log.topics[3].slice(2));
+  const idW = uintWord(tokenId);
+
+  // route decision (§6): compare the POTS per unit of in-range liquidity
+  const [posRes, liqRes, stakedLiqRes, skimRes, rateRes, minStakeRes] = await multicall([
+    { to: M.npm, data: SEL.positions + idW },
+    { to: M.pool, data: SEL.liquidity },
+    { to: M.pool, data: SEL.stakedLiquidity },
+    { to: M.pool, data: SEL.unstakedFee },
+    { to: M.gauge, data: SEL.rewardRate },
+    { to: CL_GAUGE_FACTORY, data: SEL.minStakeTimes + addrWord(M.pool) },
+  ]);
+  const yourL = posRes.ok ? toBigInt(wordAt(posRes.data, 7)) : 0n;
+  const poolL = liqRes.ok ? toBigInt(wordAt(liqRes.data, 0)) : 1n;
+  const stakedL = stakedLiqRes.ok ? toBigInt(wordAt(stakedLiqRes.data, 0)) : 0n;
+  const skim = skimRes.ok ? Number(toBigInt(wordAt(skimRes.data, 0))) / 1e6 : 0.1;
+  const ratePerSec = rateRes.ok ? Number(toBigInt(wordAt(rateRes.data, 0))) / 1e18 : 0;
+  const minStakeS = minStakeRes.ok ? Number(toBigInt(wordAt(minStakeRes.data, 0))) : 0;
+
+  const [gecko, spot] = await Promise.all([geckoPool(M.pool), aeroSpot()]);
+  const feePotYr = gecko.vol24hUsd * M.fee * 365;
+  const emisPotYr = ratePerSec * 31536000 * spot;
+  // per unit of in-range liquidity; prospective staked includes your own dilution
+  const feePerL = poolL > 0n ? (feePotYr * (1 - skim)) / Number(poolL) : 0;
+  const emisPerL = (emisPotYr) / Number(stakedL + yourL || 1n);
+  const route = emisPerL > feePerL ? "staked" : "unstaked";
+
+  const txs =
+    route === "staked"
+      ? [
+          tx(M.npm, SEL.approve + addrWord(M.gauge) + idW, `approve NFT #${tokenId} -> gauge`),
+          tx(M.gauge, SEL.gaugeDeposit + idW, `stake #${tokenId} for AERO emissions`),
+        ]
+      : [];
+
+  // record the two unrecoverable fields
+  const statePathArg = args["state-path"];
+  const state = loadState(statePathArg);
+  const entryUsd = args["entry-usd"] !== undefined ? Number(args["entry-usd"]) : null;
+  const now = new Date().toISOString();
+  state.positions = (state.positions || []).filter((p) => p.tokenId !== String(tokenId));
+  state.positions.push({
+    market,
+    tokenId: String(tokenId),
+    entryUsd,
+    enteredAt: now,
+    lastMintAt: now,
+    recenters: [],
+  });
+  saveState(state, statePathArg);
+
+  out({
+    ok: true,
+    phase: "settle",
+    market,
+    tokenId: String(tokenId),
+    route,
+    routeMath: {
+      feePotYrUsd: +feePotYr.toFixed(0),
+      emissionsPotYrUsd: +emisPotYr.toFixed(0),
+      feePerL,
+      emisPerL,
+      unstakedFeeSkim: skim,
+      minStakeTimeS: minStakeS,
+    },
+    txs,
+    stateRecorded: { entryUsd, enteredAt: now },
+    memoryLine: `aero-stock-lp: active Aerodrome LP positions on Base — see ~/.aero-stock-lp/state.json. Manage with the aero-stock-lp skill.`,
+    report:
+      route === "staked"
+        ? `Position #${tokenId} minted; staking wins (emissions pot $${Math.round(emisPotYr)}/yr vs fee pot $${Math.round(feePotYr)}/yr) — submit the 2 stake txs.`
+        : `Position #${tokenId} minted; fee route wins — NFT stays in the wallet, done.`,
+    next: txs.length ? "submit stake txs via Bankr, then report to the user" : "report to the user",
+  });
+}
+
+// ---------- dispatch ----------
+const phases = { plan, size, settle };
+if (!phases[phase]) {
+  out(
+    { ok: false, gate: "args", detail: "usage: entry.mjs <plan|size|settle> --market … (see file header)" },
+    1
+  );
+}
+phases[phase]().catch((e) => fail("error", String(e?.message || e)));

--- a/aero-stock-lp/scripts/exit.mjs
+++ b/aero-stock-lp/scripts/exit.mjs
@@ -1,0 +1,205 @@
+#!/usr/bin/env node
+// aero-stock-lp exit: two phases, because the sell amounts aren't knowable
+// until the collect mines. Scripts never sign; the agent submits each tx via
+// Bankr and checks its receipt before the next.
+//
+//   exit.mjs begin  --market AAPL --token-id 123 --wallet 0x…
+//     -> [withdraw (if staked; also claims AERO)], decreaseLiquidity(full), collect
+//   exit.mjs finish --market AAPL --token-id 123 --wallet 0x… [--state-path p]
+//     -> sell stock residual -> USDC, sell claimed AERO (> 0.1) -> USDC, burn
+//        (burn failure is NON-FATAL — funds are already out), remove from state
+//   exit.mjs sell-aero --wallet 0x…
+//     -> standalone AERO -> USDC sell of the wallet's AERO balance (compounding)
+
+import { getMarket, MARKETS, USDC, AERO, ROUTER_MAIN, SEL, MAX_UINT128 } from "./lib/markets.mjs";
+import {
+  addrWord,
+  uintWord,
+  intWord,
+  multicall,
+  wordAt,
+  toBigInt,
+  toInt,
+  toAddr,
+  tx,
+} from "./lib/chain.mjs";
+import { priceFromSqrtX96 } from "./lib/math.mjs";
+import { loadState, saveState } from "./lib/positions.mjs";
+
+const [, , phase, ...rest] = process.argv;
+const args = {};
+for (let i = 0; i < rest.length; i++) {
+  if (rest[i].startsWith("--")) {
+    const key = rest[i].slice(2);
+    const next = rest[i + 1];
+    if (next !== undefined && !next.startsWith("--")) {
+      args[key] = next;
+      i++;
+    } else args[key] = true;
+  }
+}
+function out(obj, code = 0) {
+  console.log(JSON.stringify(obj, null, 2));
+  process.exit(code);
+}
+function need(name) {
+  const v = args[name];
+  if (v === undefined || v === true) out({ ok: false, gate: "args", detail: `--${name} required` }, 1);
+  return v;
+}
+const deadline = () => Math.floor(Date.now() / 1000) + 600;
+
+const MAX_APPROVE = (1n << 256n) - 1n;
+
+function sellTx(router, tokenIn, tickSpacing, wallet, amountRaw, minOutRaw, label) {
+  return tx(
+    router,
+    SEL.exactInputSingle +
+      addrWord(tokenIn) +
+      addrWord(USDC) +
+      intWord(tickSpacing) +
+      addrWord(wallet) +
+      uintWord(deadline()) +
+      uintWord(amountRaw) +
+      uintWord(minOutRaw) +
+      uintWord(0),
+    label
+  );
+}
+
+async function begin() {
+  const market = need("market");
+  const M = getMarket(market);
+  const tokenId = need("token-id");
+  const wallet = need("wallet");
+  const idW = uintWord(tokenId);
+
+  const [ownerRes, posRes] = await multicall([
+    { to: M.npm, data: SEL.ownerOf + idW },
+    { to: M.npm, data: SEL.positions + idW },
+  ]);
+  if (!ownerRes.ok || !posRes.ok) out({ ok: false, gate: "rpc", detail: "position reads failed" }, 1);
+  const holder = toAddr(wordAt(ownerRes.data, 0));
+  const staked = holder.toLowerCase() === M.gauge.toLowerCase();
+  if (!staked && holder.toLowerCase() !== wallet.toLowerCase()) {
+    out({ ok: false, gate: "owner", detail: `#${tokenId} is held by ${holder}, not this wallet or the gauge` }, 1);
+  }
+  const liquidity = toBigInt(wordAt(posRes.data, 7));
+
+  const txs = [];
+  if (staked) txs.push(tx(M.gauge, SEL.gaugeWithdraw + idW, `#${tokenId} unstake (also claims accrued AERO)`));
+  if (liquidity > 0n) {
+    txs.push(
+      tx(
+        M.npm,
+        SEL.decreaseLiquidity + idW + uintWord(liquidity) + uintWord(0) + uintWord(0) + uintWord(deadline()),
+        `#${tokenId} withdraw all liquidity`
+      )
+    );
+  }
+  txs.push(
+    tx(M.npm, SEL.collect + idW + addrWord(wallet) + uintWord(MAX_UINT128) + uintWord(MAX_UINT128), `#${tokenId} collect principal + fees to wallet`)
+  );
+
+  out({
+    ok: true,
+    phase: "begin",
+    market,
+    tokenId: String(tokenId),
+    wasStaked: staked,
+    txs,
+    report: `Exit ${market} #${tokenId}: ${txs.length} txs (funds land in the wallet after collect).`,
+    next: "submit txs in order via Bankr, then run: exit.mjs finish",
+  });
+}
+
+async function finish() {
+  const market = need("market");
+  const M = getMarket(market);
+  const tokenId = need("token-id");
+  const wallet = need("wallet");
+  const idW = uintWord(tokenId);
+
+  const aeroPool = MARKETS.AERO;
+  const [stockBalRes, aeroBalRes, stockAllowRes, aeroAllowRes, slot0Res, aeroSlot0Res] =
+    await multicall([
+      { to: M.token, data: SEL.balanceOf + addrWord(wallet) },
+      { to: AERO, data: SEL.balanceOf + addrWord(wallet) },
+      { to: M.token, data: SEL.allowance + addrWord(wallet) + addrWord(M.router) },
+      { to: AERO, data: SEL.allowance + addrWord(wallet) + addrWord(ROUTER_MAIN) },
+      { to: M.pool, data: SEL.slot0 },
+      { to: aeroPool.pool, data: SEL.slot0 },
+    ]);
+
+  const txs = [];
+  const price = slot0Res.ok ? priceFromSqrtX96(toBigInt(wordAt(slot0Res.data, 0)), M.decimals) : 0;
+
+  // sell stock residual -> USDC (2% minOut floor on exits)
+  const stockRaw = stockBalRes.ok ? toBigInt(wordAt(stockBalRes.data, 0)) : 0n;
+  if (market !== "AERO" && stockRaw > 0n && price > 0) {
+    const allow = stockAllowRes.ok ? toBigInt(wordAt(stockAllowRes.data, 0)) : 0n;
+    if (allow < stockRaw)
+      txs.push(tx(M.token, SEL.approve + addrWord(M.router) + uintWord(MAX_APPROVE), `approve ${market} -> router`));
+    const outUsd = (Number(stockRaw) / 10 ** M.decimals) * price * (1 - M.fee);
+    const minOutRaw = BigInt(Math.round(outUsd * 0.98 * 1e6));
+    txs.push(sellTx(M.router, M.token, M.tickSpacing, wallet, stockRaw, minOutRaw, `sell ${(Number(stockRaw) / 10 ** M.decimals).toFixed(4)} ${market} -> USDC`));
+  }
+
+  // sell claimed AERO (> 0.1) -> USDC via the main router
+  const aeroRaw = aeroBalRes.ok ? toBigInt(wordAt(aeroBalRes.data, 0)) : 0n;
+  if (aeroRaw > 10n ** 17n && aeroSlot0Res.ok) {
+    const aeroPrice = priceFromSqrtX96(toBigInt(wordAt(aeroSlot0Res.data, 0)), 18);
+    const allow = aeroAllowRes.ok ? toBigInt(wordAt(aeroAllowRes.data, 0)) : 0n;
+    if (allow < aeroRaw)
+      txs.push(tx(AERO, SEL.approve + addrWord(ROUTER_MAIN) + uintWord(MAX_APPROVE), "approve AERO -> main router"));
+    const outUsd = (Number(aeroRaw) / 1e18) * aeroPrice * (1 - aeroPool.fee);
+    const minOutRaw = BigInt(Math.round(outUsd * 0.98 * 1e6));
+    txs.push(sellTx(ROUTER_MAIN, AERO, aeroPool.tickSpacing, wallet, aeroRaw, minOutRaw, `sell ${(Number(aeroRaw) / 1e18).toFixed(2)} AERO -> USDC`));
+  }
+
+  // burn is cosmetic; a burn failure after collect must NOT fail the exit
+  txs.push(tx(M.npm, SEL.burn + idW, `burn #${tokenId} (NON-FATAL if it reverts — funds are already out)`));
+
+  // remove from state; report basis for the final P&L decomposition
+  const statePathArg = args["state-path"];
+  const state = loadState(statePathArg);
+  const rec = (state.positions || []).find((p) => p.tokenId === String(tokenId));
+  state.positions = (state.positions || []).filter((p) => p.tokenId !== String(tokenId));
+  saveState(state, statePathArg);
+
+  out({
+    ok: true,
+    phase: "finish",
+    market,
+    tokenId: String(tokenId),
+    txs,
+    closedBasis: rec ? { entryUsd: rec.entryUsd, enteredAt: rec.enteredAt } : null,
+    report: `Finishing exit of ${market} #${tokenId}: ${txs.length} txs; user lands in USDC. Report the full life-of-position P&L vs basis${rec?.entryUsd != null ? ` ($${rec.entryUsd})` : " (basis unknown — say so)"}.`,
+    next: "submit txs in order via Bankr (burn revert is non-fatal), then report final cash + P&L",
+  });
+}
+
+async function sellAero() {
+  const wallet = need("wallet");
+  const aeroPool = MARKETS.AERO;
+  const [aeroBalRes, aeroAllowRes, aeroSlot0Res] = await multicall([
+    { to: AERO, data: SEL.balanceOf + addrWord(wallet) },
+    { to: AERO, data: SEL.allowance + addrWord(wallet) + addrWord(ROUTER_MAIN) },
+    { to: aeroPool.pool, data: SEL.slot0 },
+  ]);
+  const aeroRaw = aeroBalRes.ok ? toBigInt(wordAt(aeroBalRes.data, 0)) : 0n;
+  if (aeroRaw <= 10n ** 17n) out({ ok: true, phase: "sell-aero", txs: [], report: "AERO balance below 0.1 — nothing to sell." });
+  const aeroPrice = priceFromSqrtX96(toBigInt(wordAt(aeroSlot0Res.data, 0)), 18);
+  const txs = [];
+  const allow = aeroAllowRes.ok ? toBigInt(wordAt(aeroAllowRes.data, 0)) : 0n;
+  if (allow < aeroRaw)
+    txs.push(tx(AERO, SEL.approve + addrWord(ROUTER_MAIN) + uintWord(MAX_APPROVE), "approve AERO -> main router"));
+  const outUsd = (Number(aeroRaw) / 1e18) * aeroPrice * (1 - aeroPool.fee);
+  const minOutRaw = BigInt(Math.round(outUsd * 0.98 * 1e6));
+  txs.push(sellTx(ROUTER_MAIN, AERO, aeroPool.tickSpacing, wallet, aeroRaw, minOutRaw, `sell ${(Number(aeroRaw) / 1e18).toFixed(2)} AERO -> USDC (~$${outUsd.toFixed(2)})`));
+  out({ ok: true, phase: "sell-aero", txs, report: `Selling ${(Number(aeroRaw) / 1e18).toFixed(2)} AERO -> USDC.` });
+}
+
+const phases = { begin, finish, "sell-aero": sellAero };
+if (!phases[phase]) out({ ok: false, gate: "args", detail: "usage: exit.mjs <begin|finish|sell-aero> --market … --token-id … --wallet …" }, 1);
+phases[phase]().catch((e) => out({ ok: false, gate: "error", detail: String(e?.message || e) }, 1));

--- a/aero-stock-lp/scripts/lib/chain.mjs
+++ b/aero-stock-lp/scripts/lib/chain.mjs
@@ -1,0 +1,208 @@
+// aero-stock-lp: zero-dependency chain access.
+// Raw JSON-RPC over fetch (node >= 18), Multicall3 batching for plain reads,
+// individual eth_call with a spoofed `from` for owner-only simulations.
+
+import { RPCS, MULTICALL3 } from "./markets.mjs";
+
+// ---------- hex/word helpers ----------
+
+export function strip0x(h) {
+  return h.startsWith("0x") ? h.slice(2) : h;
+}
+
+export function padWord(hexNo0x) {
+  return hexNo0x.padStart(64, "0");
+}
+
+export function addrWord(addr) {
+  return padWord(strip0x(addr).toLowerCase());
+}
+
+export function uintWord(v) {
+  return padWord(BigInt(v).toString(16));
+}
+
+// int24 (or any int) as a 256-bit two's-complement word
+export function intWord(v) {
+  let b = BigInt(v);
+  if (b < 0n) b += 1n << 256n;
+  return padWord(b.toString(16));
+}
+
+export function wordAt(dataNo0x, i) {
+  return dataNo0x.slice(i * 64, (i + 1) * 64);
+}
+
+export function toBigInt(word) {
+  return word ? BigInt("0x" + word) : 0n;
+}
+
+// sign-extended int from a 256-bit word
+export function toInt(word) {
+  let v = toBigInt(word);
+  if (v >= 1n << 255n) v -= 1n << 256n;
+  return v;
+}
+
+export function toAddr(word) {
+  return "0x" + word.slice(24);
+}
+
+// ---------- JSON-RPC with fallback ----------
+
+let rpcIndex = 0;
+
+export async function rpc(method, params) {
+  let lastErr;
+  for (let attempt = 0; attempt < RPCS.length; attempt++) {
+    const url = RPCS[(rpcIndex + attempt) % RPCS.length];
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      });
+      if (!res.ok) throw new Error(`${url} HTTP ${res.status}`);
+      const body = await res.json();
+      if (body.error) throw new Error(`${url} RPC error: ${JSON.stringify(body.error)}`);
+      rpcIndex = (rpcIndex + attempt) % RPCS.length; // stick with what worked
+      return body.result;
+    } catch (e) {
+      lastErr = e;
+    }
+  }
+  throw new Error(`all RPCs failed for ${method}: ${lastErr}`);
+}
+
+export async function ethCall(to, dataNo0xOrHex, from) {
+  const data = dataNo0xOrHex.startsWith("0x") ? dataNo0xOrHex : "0x" + dataNo0xOrHex;
+  const obj = { to, data };
+  if (from) obj.from = from;
+  const out = await rpc("eth_call", [obj, "latest"]);
+  return strip0x(out || "");
+}
+
+// ---------- Multicall3.aggregate3 ----------
+// calls: [{to, data}] (data without 0x is fine). Returns [{ok, data(no 0x)}].
+// Chunks automatically: public RPCs reject oversized payloads (HTTP 413).
+
+const MULTICALL_CHUNK = 50;
+
+export async function multicall(calls) {
+  if (calls.length === 0) return [];
+  if (calls.length > MULTICALL_CHUNK) {
+    const chunks = [];
+    for (let i = 0; i < calls.length; i += MULTICALL_CHUNK) {
+      chunks.push(calls.slice(i, i + MULTICALL_CHUNK));
+    }
+    const results = new Array(chunks.length);
+    let next = 0;
+    const CONCURRENCY = 4;
+    await Promise.all(
+      Array.from({ length: Math.min(CONCURRENCY, chunks.length) }, async () => {
+        while (next < chunks.length) {
+          const i = next++;
+          results[i] = await multicall(chunks[i]);
+        }
+      })
+    );
+    return results.flat();
+  }
+  const tuples = calls.map((c) => {
+    const cd = strip0x(c.data);
+    const padded = cd.padEnd(Math.ceil(cd.length / 64) * 64, "0");
+    return (
+      addrWord(c.to) +
+      uintWord(1) + // allowFailure = true
+      uintWord(0x60) + // offset of bytes within the tuple
+      uintWord(cd.length / 2) +
+      padded
+    );
+  });
+  let offsets = "";
+  let running = calls.length * 32; // after the per-element offset words
+  for (const t of tuples) {
+    offsets += uintWord(running);
+    running += t.length / 2;
+  }
+  const data =
+    "0x82ad56cb" + uintWord(0x20) + uintWord(calls.length) + offsets + tuples.join("");
+
+  const outNo0x = await ethCall(MULTICALL3, data);
+
+  // decode Result[] = (bool success, bytes returnData)[]
+  const arrOff = Number(toBigInt(wordAt(outNo0x, 0))) / 32;
+  const n = Number(toBigInt(wordAt(outNo0x, arrOff)));
+  const base = arrOff + 1;
+  const results = [];
+  for (let i = 0; i < n; i++) {
+    const elOff = base + Number(toBigInt(wordAt(outNo0x, base + i))) / 32;
+    const ok = toBigInt(wordAt(outNo0x, elOff)) === 1n;
+    const bytesOff = elOff + Number(toBigInt(wordAt(outNo0x, elOff + 1))) / 32;
+    const len = Number(toBigInt(wordAt(outNo0x, bytesOff)));
+    const dataHex = outNo0x.slice((bytesOff + 1) * 64, (bytesOff + 1) * 64 + len * 2);
+    results.push({ ok, data: dataHex });
+  }
+  return results;
+}
+
+// decode a uint256[] return (e.g. stakedValues)
+export function decodeUintArray(dataNo0x) {
+  if (!dataNo0x) return [];
+  const off = Number(toBigInt(wordAt(dataNo0x, 0))) / 32;
+  const n = Number(toBigInt(wordAt(dataNo0x, off)));
+  const out = [];
+  for (let i = 0; i < n; i++) out.push(toBigInt(wordAt(dataNo0x, off + 1 + i)));
+  return out;
+}
+
+// ---------- receipts / txs ----------
+
+export async function getReceipt(txHash) {
+  return rpc("eth_getTransactionReceipt", [txHash]);
+}
+
+export async function getTransaction(txHash) {
+  return rpc("eth_getTransactionByHash", [txHash]);
+}
+
+// ---------- keyless HTTP data sources ----------
+
+export async function httpJson(url) {
+  const res = await fetch(url, { headers: { accept: "application/json" } });
+  if (!res.ok) throw new Error(`${url} -> HTTP ${res.status}`);
+  return res.json();
+}
+
+export async function geckoPool(poolAddr) {
+  const j = await httpJson(
+    `https://api.geckoterminal.com/api/v2/networks/base/pools/${poolAddr}`
+  );
+  const a = j?.data?.attributes || {};
+  return {
+    tvlUsd: Number(a.reserve_in_usd ?? 0),
+    vol24hUsd: Number(a?.volume_usd?.h24 ?? 0),
+    change24hPct: Number(a?.price_change_percentage?.h24 ?? 0),
+    createdAt: a.pool_created_at || null,
+  };
+}
+
+export async function aeroSpot() {
+  const j = await httpJson("https://api.exchange.coinbase.com/products/AERO-USD/ticker");
+  const p = Number(j?.price);
+  if (!(p > 0)) throw new Error("Coinbase AERO-USD ticker unusable");
+  return p;
+}
+
+export async function aeroHourlyCandles() {
+  // [ time, low, high, open, close, volume ] newest first
+  return httpJson(
+    "https://api.exchange.coinbase.com/products/AERO-USD/candles?granularity=3600"
+  );
+}
+
+// ---------- unsigned tx helper ----------
+
+export function tx(to, dataNo0x, label) {
+  return { label, to, data: "0x" + dataNo0x, value: "0", chainId: 8453 };
+}

--- a/aero-stock-lp/scripts/lib/markets.mjs
+++ b/aero-stock-lp/scripts/lib/markets.mjs
@@ -1,0 +1,140 @@
+// aero-stock-lp: canonical addresses and market table (Base mainnet, 8453).
+// This file is the source of truth; the SKILL.md table is human reference.
+// All addresses verified on-chain Aug 2026.
+
+export const CHAIN_ID = 8453;
+
+export const RPCS = [
+  "https://mainnet.base.org",
+  "https://base-rpc.publicnode.com",
+  "https://base.drpc.org",
+];
+
+export const MULTICALL3 = "0xcA11bde05977B3631167028862bE2a173976CA11";
+
+export const USDC = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"; // 6 dec, token0 in every pool here
+export const AERO = "0x940181a94A35A4569E4529A3CDfB74e38FD98631"; // 18 dec
+
+// Position NFT managers are PER-POOL-FAMILY, not global.
+export const NPM_EQUITY = "0xe1f8cd9AC4e4A65F54f38a5CdAfCA44f6dD68b53"; // CL10 equity pools
+export const NPM_AERO = "0x827922686190790b37229fd06084350E74485b72"; // CL200 AERO pool
+
+export const ROUTER_EQUITY = "0x698cb2b6dd822994581fea6ea4fc755d1363a92f";
+export const ROUTER_MAIN = "0xbe6d8f0d05cc4be24d5167a3ef062215be6d18a5"; // sell AERO -> USDC
+
+export const CL_GAUGE_FACTORY = "0x385293CaE378C813F16f0C1334d774AdDDf56AbB";
+export const CL_FACTORIES = [
+  "0x5e7BB104d84c7CB9B682AaC2F3d509f5F406809A",
+  "0xaDe65c38CD4849aDBA595a4323a8C7DdfE89716a",
+  "0xf8f2eB4940CFE7d13603DDDD87f123820Fc061Ef",
+];
+
+export const MARKETS = {
+  NVDA: {
+    token: "0xb20000000000000000000078ee7ce2fE4908108C",
+    decimals: 8,
+    pool: "0x853f5f1b92b16714fe6cda67caad0856b83c7ab9",
+    gauge: "0x30d1E5Af5CE39863E6F69a1F73ffb0e1AC9771A8",
+    tickSpacing: 10,
+    fee: 0.0005,
+    npm: NPM_EQUITY,
+    router: ROUTER_EQUITY,
+    kind: "equity",
+  },
+  AAPL: {
+    token: "0xb200000000000000000000C2e324d24d7eEcd1fb",
+    decimals: 8,
+    pool: "0xa3b1e3f9747065e2073722ff4c9027d3ea4994f0",
+    gauge: "0x43021fBbD01b967704aB2379F6e90E2d367042F3",
+    tickSpacing: 10,
+    fee: 0.0005,
+    npm: NPM_EQUITY,
+    router: ROUTER_EQUITY,
+    kind: "equity",
+  },
+  GOOGL: {
+    token: "0xb2000000000000000000002D0BA3164cc74f58B7",
+    decimals: 8,
+    pool: "0xb1987cad1682841b4b641d50e520777ec5ab5542",
+    gauge: "0x225fc4369972420683dA720F6cb39C5547C4a74e",
+    tickSpacing: 10,
+    fee: 0.0005,
+    npm: NPM_EQUITY,
+    router: ROUTER_EQUITY,
+    kind: "equity",
+  },
+  META: {
+    token: "0xb2000000000000000000008bC8786B856E61707C",
+    decimals: 8,
+    pool: "0xeaf57753bc382e0324a1d43f72e7027705a2273e",
+    gauge: "0x536DF7362915337ddc86C9b57D322905CA819d65",
+    tickSpacing: 10,
+    fee: 0.0005,
+    npm: NPM_EQUITY,
+    router: ROUTER_EQUITY,
+    kind: "equity",
+  },
+  AERO: {
+    token: AERO,
+    decimals: 18,
+    pool: "0xCCd9cC53b63662088c738B8BC06E9078Fb8D9ad4",
+    gauge: "0x491300eC768Cf28B13A8d3BbFd87713dD728b0AD",
+    tickSpacing: 200,
+    fee: 0.003,
+    npm: NPM_AERO,
+    router: ROUTER_MAIN,
+    kind: "crypto",
+  },
+};
+
+export const SEL = {
+  // pool
+  slot0: "0x3850c7bd",
+  liquidity: "0x1a686502",
+  stakedLiquidity: "0x3ab04b20",
+  unstakedFee: "0xb64cc67b",
+  gauge: "0xa6f19c84",
+  tickSpacingCall: "0xd0c93a7c",
+  // gauge
+  rewardRate: "0x7b0a47ee",
+  earned: "0x3e491d47", // earned(address,uint256)
+  stakedValues: "0x4b937763", // stakedValues(address) -> uint256[]
+  rewardToken: "0xf7c618c1",
+  gaugeDeposit: "0xb6b55f25", // deposit(uint256 tokenId)
+  gaugeWithdraw: "0x2e1a7d4d", // withdraw(uint256 tokenId)
+  getReward: "0x1c4b774b", // getReward(uint256 tokenId)
+  // gauge factory
+  minStakeTimes: "0xe782453b", // minStakeTimes(address pool)
+  // NPM
+  positions: "0x99fbab88",
+  ownerOf: "0x6352211e",
+  tokenOfOwnerByIndex: "0x2f745c59",
+  mint: "0xb5007d1f", // 12-word static tuple (Slipstream: tickSpacing + trailing sqrtPriceX96)
+  decreaseLiquidity: "0x0c49ccbe",
+  collect: "0xfc6f7865",
+  burn: "0x42966c68",
+  // router
+  exactInputSingle: "0xa026383e", // 8-word static tuple (tickSpacing, not fee)
+  // ERC20 / ERC721
+  balanceOf: "0x70a08231",
+  allowance: "0xdd62ed3e",
+  approve: "0x095ea7b3",
+  // factory
+  getPool: "0x28af8d0b", // getPool(address,address,int24)
+};
+
+export const ERC721_TRANSFER_TOPIC =
+  "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef";
+
+export const MAX_UINT256 = (1n << 256n) - 1n;
+export const MAX_UINT128 = (1n << 128n) - 1n;
+
+export function getMarket(name) {
+  const m = MARKETS[String(name || "").toUpperCase()];
+  if (!m) {
+    throw new Error(
+      `unknown market "${name}" — known: ${Object.keys(MARKETS).join(", ")}`
+    );
+  }
+  return m;
+}

--- a/aero-stock-lp/scripts/lib/math.mjs
+++ b/aero-stock-lp/scripts/lib/math.mjs
@@ -1,0 +1,99 @@
+// aero-stock-lp: price/tick/band math.
+// USDC is token0 in every pool, so tick and human price move in OPPOSITE
+// directions: the band's LOW price maps to the UPPER tick and vice versa.
+// That inversion lives HERE, once, and nowhere else.
+
+const Q96 = 2 ** 96;
+
+// human USD price of 1 token1, from sqrtPriceX96 (token dec = 8 or 18)
+export function priceFromSqrtX96(sqrtPriceX96, decimals) {
+  const r = Number(sqrtPriceX96) / Q96;
+  return 10 ** (decimals - 6) / (r * r);
+}
+
+export function tickFromPrice(price, decimals) {
+  return Math.log(10 ** (decimals - 6) / price) / Math.log(1.0001);
+}
+
+export function priceFromTick(tick, decimals) {
+  return 10 ** (decimals - 6) / 1.0001 ** tick;
+}
+
+function snapDown(tick, spacing) {
+  return Math.floor(tick / spacing) * spacing;
+}
+
+function snapUp(tick, spacing) {
+  return Math.ceil(tick / spacing) * spacing;
+}
+
+// band prices -> ticks (inversion + snapping handled here)
+export function ticksForBand(bandLow, bandHigh, decimals, spacing) {
+  let tickLower = snapDown(tickFromPrice(bandHigh, decimals), spacing);
+  let tickUpper = snapUp(tickFromPrice(bandLow, decimals), spacing);
+  if (tickUpper <= tickLower) tickUpper = tickLower + spacing; // 1-spacing floor
+  return {
+    tickLower,
+    tickUpper,
+    // actual prices after snapping (low <-> upper tick, high <-> lower tick)
+    bandLow: priceFromTick(tickUpper, decimals),
+    bandHigh: priceFromTick(tickLower, decimals),
+  };
+}
+
+export function inRange(currentTick, tickLower, tickUpper) {
+  return tickLower <= currentTick && currentTick < tickUpper;
+}
+
+// Band construction (§4): center = midpoint of pool price and real quote,
+// half-width = w (5-session expected move) x width factor, capped at 35%.
+export const WIDTH_FACTOR = { wide: 2, standard: 1, tight: 0.5 };
+
+export function buildBand(poolPrice, quote, w, width, decimals, spacing) {
+  const factor = WIDTH_FACTOR[width];
+  if (!factor) throw new Error(`width must be one of ${Object.keys(WIDTH_FACTOR)}`);
+  if (!(w > 0)) throw new Error("no honest vol input -> no band -> no entry");
+  const center = (poolPrice + quote) / 2;
+  const half = Math.min(w * factor, 0.35);
+  return ticksForBand(center * (1 - half), center * (1 + half), decimals, spacing);
+}
+
+// Stock-value share of a band [pl, pu] at price P (all human USD prices).
+// share = (sqrtP - P/sqrt(pu)) / ((sqrtP - P/sqrt(pu)) + (sqrtP - sqrt(pl)))
+export function stockShare(P, pl, pu) {
+  if (P <= pl) return 1; // below band: all stock
+  if (P >= pu) return 0; // above band: all USDC
+  const a = Math.sqrt(P) - P / Math.sqrt(pu);
+  const b = Math.sqrt(P) - Math.sqrt(pl);
+  return a / (a + b);
+}
+
+// Annualized w from IV: w = IV x sqrt(5/252)
+export function wFromIV(iv) {
+  return iv * Math.sqrt(5 / 252);
+}
+
+// w for AERO from hourly candles ([time, low, high, open, close, vol] newest first):
+// sigma_hourly of log returns x sqrt(24) x sqrt(5)
+export function wFromHourlyCandles(candles) {
+  const closes = candles
+    .slice(0, 24 * 7)
+    .map((c) => Number(c[4]))
+    .filter((x) => x > 0)
+    .reverse();
+  if (closes.length < 24) throw new Error("not enough candles for vol");
+  const rets = [];
+  for (let i = 1; i < closes.length; i++) rets.push(Math.log(closes[i] / closes[i - 1]));
+  const mean = rets.reduce((s, x) => s + x, 0) / rets.length;
+  const varr = rets.reduce((s, x) => s + (x - mean) ** 2, 0) / (rets.length - 1);
+  return Math.sqrt(varr) * Math.sqrt(24) * Math.sqrt(5);
+}
+
+// token amount (raw units) -> USD, given human price and decimals
+export function tokenUsd(rawAmount, price, decimals) {
+  return (Number(rawAmount) / 10 ** decimals) * price;
+}
+
+export function usdcUsd(rawAmount) {
+  return Number(rawAmount) / 1e6;
+}

--- a/aero-stock-lp/scripts/lib/positions.mjs
+++ b/aero-stock-lp/scripts/lib/positions.mjs
@@ -1,0 +1,246 @@
+// aero-stock-lp: position discovery, valuation, and the state file.
+// The chain is the memory; the file is a cache holding the only two
+// unrecoverable fields (entryUsd, enteredAt) plus preferences.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  MARKETS,
+  USDC,
+  AERO,
+  SEL,
+  MAX_UINT128,
+  NPM_EQUITY,
+  NPM_AERO,
+} from "./markets.mjs";
+import {
+  addrWord,
+  uintWord,
+  ethCall,
+  multicall,
+  wordAt,
+  toBigInt,
+  toInt,
+  toAddr,
+  decodeUintArray,
+} from "./chain.mjs";
+import { priceFromSqrtX96, tokenUsd, usdcUsd, inRange } from "./math.mjs";
+
+// ---------- state file ----------
+
+export function statePath(override) {
+  return override || path.join(os.homedir(), ".aero-stock-lp", "state.json");
+}
+
+export function loadState(override) {
+  const p = statePath(override);
+  try {
+    return JSON.parse(fs.readFileSync(p, "utf8"));
+  } catch {
+    return { compound: null, positions: [] };
+  }
+}
+
+export function saveState(state, override) {
+  const p = statePath(override);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(state, null, 2) + "\n");
+}
+
+// ---------- discovery ----------
+// Staked: gauge.stakedValues(wallet) per market.
+// Unstaked: NPM balanceOf + tokenOfOwnerByIndex, filtered by tickSpacing.
+// knownIds ({tokenId -> market}, e.g. from the state file) are always
+// checked directly; enumeration is capped at the most recent ENUM_CAP NFTs
+// so a pathological wallet can't stall the pass.
+
+const ENUM_CAP = 400;
+
+export async function discoverPositions(wallet, knownIds = {}) {
+  const marketNames = Object.keys(MARKETS);
+
+  const stakedCalls = marketNames.map((m) => ({
+    to: MARKETS[m].gauge,
+    data: SEL.stakedValues + addrWord(wallet),
+  }));
+  const balCalls = [NPM_EQUITY, NPM_AERO].map((npm) => ({
+    to: npm,
+    data: SEL.balanceOf + addrWord(wallet),
+  }));
+  const first = await multicall([...stakedCalls, ...balCalls]);
+
+  const found = []; // {market, tokenId, staked}
+  marketNames.forEach((m, i) => {
+    if (!first[i].ok) return;
+    for (const id of decodeUintArray(first[i].data)) {
+      found.push({ market: m, tokenId: id, staked: true });
+    }
+  });
+
+  // enumerate unstaked NFTs per NPM (most recent first, capped)
+  const npms = [NPM_EQUITY, NPM_AERO];
+  const enumCalls = [];
+  let enumTruncated = false;
+  npms.forEach((npm, j) => {
+    const bal = first[marketNames.length + j].ok
+      ? Number(toBigInt(wordAt(first[marketNames.length + j].data, 0)))
+      : 0;
+    const start = Math.max(0, bal - ENUM_CAP);
+    if (start > 0) enumTruncated = true;
+    for (let k = bal - 1; k >= start; k--) {
+      enumCalls.push({
+        npm,
+        call: { to: npm, data: SEL.tokenOfOwnerByIndex + addrWord(wallet) + uintWord(k) },
+      });
+    }
+  });
+  if (enumCalls.length) {
+    const ids = await multicall(enumCalls.map((e) => e.call));
+    const posCalls = ids
+      .map((r, i) => ({
+        npm: enumCalls[i].npm,
+        tokenId: r.ok ? toBigInt(wordAt(r.data, 0)) : null,
+      }))
+      .filter((x) => x.tokenId !== null);
+    // state-file positions are always checked, even past the cap
+    // (skip ones already found staked — the gauge holds those NFTs)
+    for (const [id, market] of Object.entries(knownIds)) {
+      if (
+        !posCalls.some((p) => String(p.tokenId) === String(id)) &&
+        !found.some((f) => String(f.tokenId) === String(id))
+      ) {
+        posCalls.push({ npm: MARKETS[market]?.npm || NPM_EQUITY, tokenId: BigInt(id) });
+      }
+    }
+    const details = await multicall(
+      posCalls.map((p) => ({ to: p.npm, data: SEL.positions + uintWord(p.tokenId) }))
+    );
+    posCalls.forEach((p, i) => {
+      if (!details[i].ok) return;
+      const d = details[i].data;
+      const spacing = Number(toInt(wordAt(d, 4)));
+      const liq = toBigInt(wordAt(d, 7));
+      if (liq === 0n) return; // dust/burned
+      const token1 = toAddr(wordAt(d, 3));
+      const market = Object.keys(MARKETS).find(
+        (m) =>
+          MARKETS[m].tickSpacing === spacing &&
+          MARKETS[m].token.toLowerCase() === token1.toLowerCase() &&
+          MARKETS[m].npm === p.npm
+      );
+      if (market) found.push({ market, tokenId: p.tokenId, staked: false });
+    });
+  }
+  found.truncated = enumTruncated;
+  return found;
+}
+
+// ---------- valuation ----------
+// One position: batched plain reads + two owner-simulated calls.
+// Returns raw facts; P&L composition happens in the caller.
+
+export async function readPosition(wallet, market, tokenId) {
+  const M = MARKETS[market];
+  const idW = uintWord(tokenId);
+
+  const batch = await multicall([
+    { to: M.pool, data: SEL.slot0 },
+    { to: M.npm, data: SEL.positions + idW },
+    { to: M.npm, data: SEL.ownerOf + idW },
+    { to: M.gauge, data: SEL.earned + addrWord(wallet) + idW },
+    { to: M.pool, data: SEL.liquidity },
+    { to: M.pool, data: SEL.stakedLiquidity },
+    { to: M.pool, data: SEL.unstakedFee },
+    { to: M.gauge, data: SEL.rewardRate },
+  ]);
+  const [slot0, pos, owner, earned, poolLiq, poolStakedLiq, unstakedFee, rewardRate] =
+    batch;
+
+  if (!slot0.ok || !pos.ok || !owner.ok) {
+    throw new Error(`core reads failed for ${market} #${tokenId}`);
+  }
+
+  const sqrtPriceX96 = toBigInt(wordAt(slot0.data, 0));
+  const currentTick = Number(toInt(wordAt(slot0.data, 1)));
+  const tickLower = Number(toInt(wordAt(pos.data, 5)));
+  const tickUpper = Number(toInt(wordAt(pos.data, 6)));
+  const liquidity = toBigInt(wordAt(pos.data, 7));
+  const holder = toAddr(wordAt(owner.data, 0));
+  const staked = holder.toLowerCase() === M.gauge.toLowerCase();
+
+  // owner-only simulations (eth_call with spoofed from = current NFT holder)
+  const simFrom = staked ? M.gauge : holder;
+  const deadline = Math.floor(Date.now() / 1000) + 600;
+  let principal0 = 0n,
+    principal1 = 0n;
+  if (liquidity > 0n) {
+    const dec = await ethCall(
+      M.npm,
+      SEL.decreaseLiquidity +
+        idW +
+        uintWord(liquidity) +
+        uintWord(0) +
+        uintWord(0) +
+        uintWord(deadline),
+      simFrom
+    );
+    principal0 = toBigInt(wordAt(dec, 0));
+    principal1 = toBigInt(wordAt(dec, 1));
+  }
+  let fees0 = 0n,
+    fees1 = 0n;
+  try {
+    const col = await ethCall(
+      M.npm,
+      SEL.collect + idW + addrWord(simFrom) + uintWord(MAX_UINT128) + uintWord(MAX_UINT128),
+      simFrom
+    );
+    fees0 = toBigInt(wordAt(col, 0));
+    fees1 = toBigInt(wordAt(col, 1));
+  } catch {
+    // collect sim can revert on zero-fee positions; fees stay 0
+  }
+
+  const price = priceFromSqrtX96(sqrtPriceX96, M.decimals);
+  return {
+    market,
+    tokenId: String(tokenId),
+    staked,
+    holder,
+    currentTick,
+    tickLower,
+    tickUpper,
+    inRange: inRange(currentTick, tickLower, tickUpper),
+    liquidity,
+    poolPrice: price,
+    sqrtPriceX96,
+    principalUsd: usdcUsd(principal0) + tokenUsd(principal1, price, M.decimals),
+    feesUsd: usdcUsd(fees0) + tokenUsd(fees1, price, M.decimals),
+    earnedAero: earned.ok ? Number(toBigInt(wordAt(earned.data, 0))) / 1e18 : 0,
+    poolLiquidity: poolLiq.ok ? toBigInt(wordAt(poolLiq.data, 0)) : 0n,
+    poolStakedLiquidity: poolStakedLiq.ok ? toBigInt(wordAt(poolStakedLiq.data, 0)) : 0n,
+    unstakedFeePips: unstakedFee.ok ? Number(toBigInt(wordAt(unstakedFee.data, 0))) : 0,
+    rewardRatePerSec: rewardRate.ok ? Number(toBigInt(wordAt(rewardRate.data, 0))) / 1e18 : 0,
+  };
+}
+
+// Loose wallet balances (USDC + every market token + AERO) — real book money.
+export async function looseBalances(wallet) {
+  const tokens = [
+    { key: "USDC", addr: USDC, decimals: 6 },
+    ...Object.entries(MARKETS)
+      .filter(([k]) => k !== "AERO")
+      .map(([k, m]) => ({ key: k, addr: m.token, decimals: m.decimals })),
+    { key: "AERO", addr: AERO, decimals: 18 },
+  ];
+  const res = await multicall(
+    tokens.map((t) => ({ to: t.addr, data: SEL.balanceOf + addrWord(wallet) }))
+  );
+  const out = {};
+  tokens.forEach((t, i) => {
+    out[t.key] = res[i].ok ? Number(toBigInt(wordAt(res[i].data, 0))) / 10 ** t.decimals : 0;
+  });
+  return out;
+}

--- a/aero-stock-lp/scripts/manage.mjs
+++ b/aero-stock-lp/scripts/manage.mjs
@@ -1,0 +1,280 @@
+#!/usr/bin/env node
+// aero-stock-lp manage pass: ONE call reads everything, decides everything,
+// executes NOTHING. Output is one JSON object: {ok, positions[], txs[], report[]}.
+// Proposed txs are labeled with why; the agent confirms with the user where
+// the skill requires it and submits via Bankr one at a time.
+//
+//   manage.mjs --wallet 0x… [--state-path p] [--quote-NVDA 182.10 --quote-AAPL 311.20 …]
+//
+// Real equity quotes are the AGENT's job (market data / web search at pass
+// time); pass them as --quote-<MARKET>. Without a quote a market's recenter
+// is BLOCKED (fail closed) but valuation/reporting still runs at pool price.
+
+import {
+  MARKETS,
+  SEL,
+  CL_GAUGE_FACTORY,
+  MAX_UINT128,
+} from "./lib/markets.mjs";
+import {
+  addrWord,
+  uintWord,
+  multicall,
+  wordAt,
+  toBigInt,
+  geckoPool,
+  aeroSpot,
+  tx,
+} from "./lib/chain.mjs";
+import {
+  discoverPositions,
+  readPosition,
+  looseBalances,
+  loadState,
+} from "./lib/positions.mjs";
+
+const rest = process.argv.slice(2);
+const args = {};
+for (let i = 0; i < rest.length; i++) {
+  if (rest[i].startsWith("--")) {
+    const key = rest[i].slice(2);
+    const next = rest[i + 1];
+    if (next !== undefined && !next.startsWith("--")) {
+      args[key] = next;
+      i++;
+    } else args[key] = true;
+  }
+}
+
+function out(obj, code = 0) {
+  console.log(JSON.stringify(obj, null, 2));
+  process.exit(code);
+}
+
+const wallet = args.wallet;
+if (!wallet || wallet === true) out({ ok: false, gate: "args", detail: "--wallet required" }, 1);
+
+const HYSTERESIS = 1.3; // other route must pay >= 1.3x current or hold
+
+async function main() {
+  const state = loadState(args["state-path"]);
+  const knownIds = Object.fromEntries(
+    (state.positions || []).map((p) => [p.tokenId, p.market])
+  );
+  const [found, loose, spot] = await Promise.all([
+    discoverPositions(wallet, knownIds),
+    looseBalances(wallet),
+    aeroSpot().catch(() => null),
+  ]);
+
+  // gecko + minStakeTimes once per market that has a position
+  const marketsInBook = [...new Set(found.map((f) => f.market))];
+  const gecko = {};
+  await Promise.all(
+    marketsInBook.map(async (m) => {
+      gecko[m] = await geckoPool(MARKETS[m].pool).catch(() => null);
+    })
+  );
+  const minStakeRes = await multicall(
+    marketsInBook.map((m) => ({
+      to: CL_GAUGE_FACTORY,
+      data: SEL.minStakeTimes + addrWord(MARKETS[m].pool),
+    }))
+  );
+  const minStake = {};
+  marketsInBook.forEach((m, i) => {
+    minStake[m] = minStakeRes[i].ok ? Number(toBigInt(wordAt(minStakeRes[i].data, 0))) : 300;
+  });
+
+  const positions = [];
+  const txs = [];
+  const report = [];
+  let totalUsd = 0;
+  let totalPnl = 0;
+  let pnlKnown = true;
+
+  const reads = await Promise.all(
+    found.map((f) => readPosition(wallet, f.market, f.tokenId))
+  );
+
+  for (let fi = 0; fi < found.length; fi++) {
+    const f = found[fi];
+    const M = MARKETS[f.market];
+    const p = reads[fi];
+    const rec = (state.positions || []).find((s) => s.tokenId === String(f.tokenId));
+    const g = gecko[f.market];
+
+    const earnedUsd = spot ? p.earnedAero * spot : 0;
+    const value = p.principalUsd + p.feesUsd + earnedUsd;
+    totalUsd += value;
+
+    const basis = rec?.entryUsd ?? null;
+    const pnl = basis !== null ? value - basis : null;
+    if (pnl !== null) totalPnl += pnl;
+    else pnlKnown = false;
+
+    // projected APR (gross, in-range-conditional, "at this epoch's rate")
+    let apr = null;
+    if (p.inRange && value > 0) {
+      if (rec?.enteredAt) {
+        const days = Math.max((Date.now() - Date.parse(rec.enteredAt)) / 8.64e7, 0.04);
+        const measured = ((p.feesUsd + earnedUsd) / days) * 365;
+        apr = (measured / value) * 100;
+      }
+      if (apr === null || apr === 0) {
+        const potShare = p.staked
+          ? spot && p.poolStakedLiquidity > 0n
+            ? ((Number(p.liquidity) / Number(p.poolStakedLiquidity)) *
+                p.rewardRatePerSec *
+                31536000 *
+                spot *
+                100) /
+              value
+            : null
+          : g && p.poolLiquidity > 0n
+            ? ((g.vol24hUsd * M.fee * (Number(p.liquidity) / Number(p.poolLiquidity)) *
+                (1 - p.unstakedFeePips / 1e6) *
+                365) /
+                value) *
+              100
+            : null;
+        apr = potShare;
+      }
+    }
+
+    const bandLow = 10 ** (M.decimals - 6) / 1.0001 ** p.tickUpper;
+    const bandHigh = 10 ** (M.decimals - 6) / 1.0001 ** p.tickLower;
+
+    const entry = {
+      market: f.market,
+      tokenId: String(f.tokenId),
+      route: p.staked ? "staked (earning AERO)" : "unstaked (earning fees)",
+      inRange: p.inRange,
+      valueUsd: +value.toFixed(2),
+      principalUsd: +p.principalUsd.toFixed(2),
+      feesUsd: +p.feesUsd.toFixed(2),
+      earnedAero: +p.earnedAero.toFixed(4),
+      earnedAeroUsd: +earnedUsd.toFixed(2),
+      band: { low: +bandLow.toFixed(2), high: +bandHigh.toFixed(2) },
+      poolPrice: +p.poolPrice.toFixed(2),
+      basisUsd: basis,
+      basisEstimated: rec ? rec.entryUsd === null : true,
+      pnlUsd: pnl !== null ? +pnl.toFixed(2) : null,
+      projectedAprPct: apr !== null ? +apr.toFixed(1) : null,
+    };
+
+    if (p.inRange) {
+      // route comparison with 1.3x hysteresis
+      if (g && spot) {
+        const skim = 1 - p.unstakedFeePips / 1e6;
+        const feePerL =
+          p.poolLiquidity > 0n ? (g.vol24hUsd * M.fee * 365 * skim) / Number(p.poolLiquidity) : 0;
+        const emisDen = p.staked ? p.poolStakedLiquidity : p.poolStakedLiquidity + p.liquidity;
+        const emisPerL =
+          emisDen > 0n ? (p.rewardRatePerSec * 31536000 * spot) / Number(emisDen) : 0;
+        const current = p.staked ? emisPerL : feePerL;
+        const other = p.staked ? feePerL : emisPerL;
+        if (current > 0 && other >= HYSTERESIS * current) {
+          entry.routeSwitchProposed = p.staked ? "unstake -> collect fees" : "stake -> earn AERO";
+          if (p.staked) {
+            txs.push(
+              tx(M.gauge, SEL.gaugeWithdraw + uintWord(f.tokenId), `#${f.tokenId} unstake (route switch, ${(other / current).toFixed(2)}x; withdraw also claims AERO)`)
+            );
+          } else {
+            txs.push(
+              tx(M.npm, SEL.collect + uintWord(f.tokenId) + addrWord(wallet) + uintWord(MAX_UINT128) + uintWord(MAX_UINT128), `#${f.tokenId} collect fees BEFORE staking (they stop being claimable in the gauge)`),
+              tx(M.npm, SEL.approve + addrWord(M.gauge) + uintWord(f.tokenId), `#${f.tokenId} approve NFT -> gauge`),
+              tx(M.gauge, SEL.gaugeDeposit + uintWord(f.tokenId), `#${f.tokenId} stake (route switch, ${(other / current).toFixed(2)}x)`)
+            );
+          }
+        }
+      }
+      // compound: only per recorded consent
+      if (
+        state.compound === "sell" &&
+        p.staked &&
+        spot &&
+        earnedUsd >= 10 &&
+        rec?.enteredAt &&
+        Date.now() - Date.parse(rec.enteredAt) > (minStake[f.market] || 300) * 1000
+      ) {
+        entry.compoundProposed = `claim + sell ${p.earnedAero.toFixed(2)} AERO (~$${earnedUsd.toFixed(2)})`;
+        txs.push(
+          tx(M.gauge, SEL.getReward + uintWord(f.tokenId), `#${f.tokenId} claim ${p.earnedAero.toFixed(2)} AERO`)
+          // the AERO -> USDC sell is built by exit.mjs sell-aero after the claim mines
+        );
+      }
+      report.push(
+        `${f.market}: $${value.toFixed(2)}${pnl !== null ? ` (${pnl >= 0 ? "+" : ""}$${pnl.toFixed(2)})` : ""}, in range $${bandLow.toFixed(2)} – $${bandHigh.toFixed(2)} (now $${p.poolPrice.toFixed(2)}), ${entry.route}${apr ? ` — ~${apr.toFixed(0)}% APR at this epoch's rate` : ""}.`
+      );
+    } else {
+      // out of range: earns zero on either route. Exit/re-enter through BOTH brakes.
+      const earningsSinceMint = p.feesUsd + earnedUsd;
+      const reentryCost = value * (M.fee * 0.5 + 0.005) + 0.05;
+      const hurdleMet = earningsSinceMint >= 2 * reentryCost;
+      const recents = (rec?.recenters || []).filter(
+        (r) => Date.now() - Date.parse(r.at) < 7 * 8.64e7
+      );
+      const direction = p.currentTick >= p.tickUpper ? "down" : "up"; // price direction (tick inverse)
+      const trendBrake =
+        recents.length >= 2 && recents.slice(-2).every((r) => r.direction === direction);
+      const quote = args[`quote-${f.market}`] ? Number(args[`quote-${f.market}`]) : null;
+
+      entry.outOfRange = {
+        earningsSinceMintUsd: +earningsSinceMint.toFixed(2),
+        reentryCostEstUsd: +reentryCost.toFixed(2),
+        costHurdleMet: hurdleMet,
+        trendBrake,
+        quoteProvided: quote !== null || f.market === "AERO",
+        action: !hurdleMet
+          ? "hold — waiting out the cost hurdle"
+          : trendBrake
+            ? "stand aside in cash — trend brake (2+ same-direction recenters)"
+            : quote === null && f.market !== "AERO"
+              ? "exit-ready, but re-entry BLOCKED: no fresh quote passed (--quote-" + f.market + ")"
+              : "exit and re-enter: run exit.mjs begin, then entry.mjs plan",
+      };
+      report.push(
+        `${f.market}: $${value.toFixed(2)}, OUT of range ($${bandLow.toFixed(2)} – $${bandHigh.toFixed(2)}, now $${p.poolPrice.toFixed(2)}), earning nothing — ${entry.outOfRange.action}.`
+      );
+    }
+    positions.push(entry);
+  }
+
+  // loose balances are real book money
+  const looseUsd =
+    loose.USDC +
+    (spot ? loose.AERO * spot : 0) +
+    Object.keys(MARKETS)
+      .filter((m) => m !== "AERO" && loose[m] > 0)
+      .reduce((s, m) => {
+        const pos = positions.find((p) => p.market === m);
+        return s + loose[m] * (pos ? pos.poolPrice : 0);
+      }, 0);
+
+  report.push(
+    `Total: $${(totalUsd).toFixed(2)} in positions${pnlKnown && positions.length ? `, ${totalPnl >= 0 ? "+" : ""}$${totalPnl.toFixed(2)} net` : ""}; loose wallet balances ~$${looseUsd.toFixed(2)}. Emissions reset Thursday.`
+  );
+
+  out({
+    ok: true,
+    wallet,
+    positions,
+    loose,
+    aeroSpot: spot,
+    txs,
+    report,
+    notes: [
+      positions.length === 0 ? "No LP positions found on-chain for this wallet." : null,
+      found.truncated
+        ? "wallet holds many position NFTs — enumeration capped at the most recent 400; state-file positions were checked directly regardless"
+        : null,
+      state.compound == null
+        ? "compound preference unset — ask the user once before any auto-sell (record compound: sell|hold in the state file)"
+        : `compound: ${state.compound}`,
+      "APR figures are gross, in-range-conditional, at this epoch's rate (resets Thursday) — never promise them.",
+    ].filter(Boolean),
+  });
+}
+
+main().catch((e) => out({ ok: false, gate: "error", detail: String(e?.message || e) }, 1));

--- a/aero-stock-lp/scripts/selftest.mjs
+++ b/aero-stock-lp/scripts/selftest.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+// aero-stock-lp selftest: offline math/encoding vectors, plus --live for
+// read-only checks against Base mainnet (no keys, no writes, no cost).
+// Exit 0 = all pass; any failure exits 1 with the failing check named.
+
+import { MARKETS, SEL } from "./lib/markets.mjs";
+import { intWord, uintWord, addrWord, toInt, multicall, wordAt, toBigInt } from "./lib/chain.mjs";
+import {
+  priceFromSqrtX96,
+  tickFromPrice,
+  priceFromTick,
+  ticksForBand,
+  buildBand,
+  stockShare,
+  wFromIV,
+} from "./lib/math.mjs";
+
+const results = [];
+function check(name, cond, detail = "") {
+  results.push({ name, pass: !!cond, detail });
+}
+function approx(a, b, tolPct = 0.01) {
+  return Math.abs(a / b - 1) < tolPct;
+}
+
+// --- encoding ---
+check("int24 -100 two's complement", intWord(-100).endsWith("ff9c") && /^f+/.test(intWord(-100)));
+check("int24 +10 plain", intWord(10) === uintWord(10));
+check("sign-extend decode", toInt("f".repeat(62) + "9c") === -100n);
+check("addr padding", addrWord("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913").length === 64);
+
+// --- price math (dec 8 equities: USD/share = 100 / (sqrtP/2^96)^2) ---
+// vector: price $300 -> sqrtP = 2^96 * sqrt(100/300)
+const sqrtP300 = BigInt(Math.round(2 ** 96 * Math.sqrt(100 / 300)));
+check("price from sqrtX96 (equity $300)", approx(priceFromSqrtX96(sqrtP300, 8), 300, 0.001));
+// AERO (dec 18): USD/AERO = 1e12 / (sqrtP/2^96)^2 ; $1.20
+const sqrtAero = BigInt(Math.round(2 ** 96 * Math.sqrt(1e12 / 1.2)));
+check("price from sqrtX96 (AERO $1.20)", approx(priceFromSqrtX96(sqrtAero, 18), 1.2, 0.001));
+
+// --- tick <-> price round trips ---
+for (const [p, dec] of [[300, 8], [311.2, 8], [1.2, 18], [0.85, 18]]) {
+  const t = Math.round(tickFromPrice(p, dec));
+  check(`tick/price roundtrip ${p} (dec ${dec})`, approx(priceFromTick(t, dec), p, 0.001));
+}
+
+// --- band inversion + snapping ---
+// tick and human price move in OPPOSITE directions: low price -> upper tick.
+const band = ticksForBand(300, 322, 8, 10);
+check("band tickLower < tickUpper", band.tickLower < band.tickUpper);
+check("band ticks snapped to spacing", band.tickLower % 10 === 0 && band.tickUpper % 10 === 0);
+check("band prices preserved-ish", band.bandLow <= 300.5 && band.bandHigh >= 321.4);
+check(
+  "inversion: high price -> lower tick",
+  approx(priceFromTick(band.tickLower, 8), band.bandHigh, 0.001) &&
+    approx(priceFromTick(band.tickUpper, 8), band.bandLow, 0.001)
+);
+// degenerate band gets the 1-spacing floor
+const tiny = ticksForBand(310.0, 310.01, 8, 10);
+check("1-spacing floor", tiny.tickUpper - tiny.tickLower === 10);
+
+// --- band construction ---
+const b2 = buildBand(310, 312, 0.035, "standard", 8, 10);
+check("buildBand centers between pool and quote", b2.bandLow < 311 && b2.bandHigh > 311);
+const b3 = buildBand(310, 312, 5.0, "wide", 8, 10); // absurd vol -> capped
+check("buildBand caps at ±35%", b3.bandHigh / 311 < 1.36);
+let threw = false;
+try {
+  buildBand(310, 312, 0, "standard", 8, 10);
+} catch {
+  threw = true;
+}
+check("no vol input -> throws (fail closed)", threw);
+
+// --- stock share ---
+check("share at center ~0.4-0.6", stockShare(311, 300, 322) > 0.4 && stockShare(311, 300, 322) < 0.6);
+check("share below band = 1", stockShare(290, 300, 322) === 1);
+check("share above band = 0", stockShare(330, 300, 322) === 0);
+check("wFromIV(0.28) ~ 3.9%", approx(wFromIV(0.28), 0.0394, 0.02));
+
+// --- calldata shape (static tuples: selector + N words) ---
+const mintData =
+  SEL.mint +
+  addrWord("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913") +
+  addrWord(MARKETS.AAPL.token) +
+  intWord(10) +
+  intWord(-115000) +
+  intWord(-114000) +
+  uintWord(50000000n) +
+  uintWord(16000000n) +
+  uintWord(0) +
+  uintWord(0) +
+  addrWord("0x" + "11".repeat(20)) +
+  uintWord(1755800000) +
+  uintWord(0);
+check("mint calldata = 4 + 12*32 bytes", mintData.length === 2 + (4 + 12 * 32) * 2);
+const swapData =
+  SEL.exactInputSingle +
+  addrWord("0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913") +
+  addrWord(MARKETS.AAPL.token) +
+  intWord(10) +
+  addrWord("0x" + "11".repeat(20)) +
+  uintWord(1755800000) +
+  uintWord(11000000n) +
+  uintWord(3400000n) +
+  uintWord(0);
+check("exactInputSingle calldata = 4 + 8*32 bytes", swapData.length === 2 + (4 + 8 * 32) * 2);
+
+// --- live (read-only) ---
+if (process.argv.includes("--live")) {
+  const names = Object.keys(MARKETS);
+  const res = await multicall(
+    names.flatMap((m) => [
+      { to: MARKETS[m].pool, data: SEL.slot0 },
+      { to: MARKETS[m].pool, data: SEL.gauge },
+      { to: MARKETS[m].pool, data: SEL.tickSpacingCall },
+      { to: MARKETS[m].gauge, data: SEL.rewardToken },
+    ])
+  );
+  names.forEach((m, i) => {
+    const [slot0, gauge, spacing, rewardToken] = res.slice(i * 4, i * 4 + 4);
+    const price = slot0.ok ? priceFromSqrtX96(toBigInt(wordAt(slot0.data, 0)), MARKETS[m].decimals) : 0;
+    const tick = slot0.ok ? Number(toInt(wordAt(slot0.data, 1))) : null;
+    check(`live ${m} slot0 sane price`, price > 0 && price < 100000, `$${price.toFixed(2)}`);
+    check(
+      `live ${m} tick matches price`,
+      tick !== null && approx(priceFromTick(tick, MARKETS[m].decimals), price, 0.001)
+    );
+    check(
+      `live ${m} pool.gauge() matches table`,
+      gauge.ok && ("0x" + gauge.data.slice(24)).toLowerCase() === MARKETS[m].gauge.toLowerCase()
+    );
+    check(
+      `live ${m} tickSpacing matches table`,
+      spacing.ok && Number(toInt(wordAt(spacing.data, 0))) === MARKETS[m].tickSpacing
+    );
+    check(
+      `live ${m} gauge pays AERO`,
+      rewardToken.ok &&
+        ("0x" + rewardToken.data.slice(24)).toLowerCase() ===
+          "0x940181a94a35a4569e4529a3cdfb74e38fd98631"
+    );
+  });
+}
+
+// --- report ---
+const failed = results.filter((r) => !r.pass);
+for (const r of results) {
+  console.error(`${r.pass ? "PASS" : "FAIL"}  ${r.name}${r.detail ? `  (${r.detail})` : ""}`);
+}
+console.log(JSON.stringify({ ok: failed.length === 0, checks: results.length, failed: failed.map((f) => f.name) }));
+process.exit(failed.length === 0 ? 0 : 1);


### PR DESCRIPTION
Follow-up to #653, implementing the review feedback: move everything deterministic out of prose and into bundled scripts, so the model stops re-authoring RPC calls, hex calldata, and tick math by hand on every pass.

## What's in scripts/ (plain node ≥ 18, zero dependencies, no npm install)

| file | job |
|---|---|
| `entry.mjs plan\|size\|settle` | one phase per **transaction boundary** (your own swap moves the pool, so the mint sizes after the swap mines). `plan` runs every entry gate; `settle` pulls the tokenId from the mint receipt and does the staked-vs-unstaked pot math |
| `manage.mjs` | the whole manage pass in one call: chain discovery, honest valuation (loose balances included), route hysteresis, cost-hurdle / trend-brake verdicts, proposed txs |
| `exit.mjs begin\|finish\|sell-aero` | phased exit (sell amounts exist only after the collect mines) |
| `selftest.mjs [--live]` | 24 offline math/encoding vectors; `--live` adds 25 on-chain checks of the market table (gauge, tickSpacing, reward token per pool) |
| `lib/` | markets table (canonical), 3-RPC fallback + auto-chunked Multicall3 batching, tick/price math (the USDC-is-token0 inversion lives in exactly one place) |

## The two rules that carry the value

1. **Scripts never sign.** No keys in the sandbox. They emit unsigned `{to, data, value, chainId}`; the agent submits via Bankr one at a time with receipt checks — custody model unchanged.
2. **Gates fail closed via exit code.** Missing or stale quote → non-zero exit with `{"ok":false,"gate":"quote-fresh"}`. Prose the model could rationalize skipping is now a mechanic it can't.

Left to the model: which market, how much, fetching the real quote, talking to the user. Output is one JSON object per call — `report` fields are written to be relayed to the user nearly verbatim.

## Validation (all against Base mainnet, read-only)

- `selftest.mjs --live`: **49/49 pass** — all five pools answer with sane prices, gauges/tickSpacing/reward tokens match the table
- **Mint calldata byte-identical** to a real historical Slipstream mint tx (decoded a live NPM mint, re-encoded its fields with our encoder: exact input match)
- `settle` run against that same real mint tx extracts the correct tokenId from the receipt logs and produces sensible live route math (GOOGL: emissions pot ≈$283k/yr vs fee pot ≈$173k/yr → stake)
- `manage.mjs` valued a live wallet holding two staked positions in **~1.5s** (the equivalent paced sequential prose flow measured ~70s); an adversarial wallet holding **18,250 position NFTs** is handled via capped enumeration with the cap surfaced in the output
- `entry.mjs plan` live: all 9 gates with real numbers; stale quote correctly exits 1 with the failing gate named
- Budget-cap fix found during testing: a wallet holding loose stock beyond the entry's $usd is no longer swept into the mint

SKILL.md drops the hex/procedure internals (497 → 230 lines); what remains is judgment, comms rules, and the script wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)