### PR TITLE
bankr: weekly sync — credit transfers, degen mode, /runs, Gemini 3.7 Flash default

### DIFF
--- a/bankr/SKILL.md
+++ b/bankr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bankr
-description: AI-powered crypto trading agent, wallet API, and LLM gateway via natural language. Use when the user wants to trade crypto, trade tokenized stocks and ETFs (spot or leveraged), check portfolio balances (with PnL and NFTs), view token prices, search tokens, research token holders, transfer crypto, manage NFTs, use leverage (Hyperliquid or Avantis), bet on Polymarket, deploy tokens, set up automated trading, sign and submit raw transactions, call or deploy x402 paid API endpoints, browse the web, store and query files on their wallet's filesystem, or access LLM models through the Bankr LLM gateway funded by your Bankr wallet — including zero-data-retention and TEE-private inference tiers. Supports Base, Ethereum, Polygon, Solana, Unichain, World Chain, Arbitrum, BNB Chain, and Robinhood Chain.
+description: AI-powered crypto trading agent, wallet API, and LLM gateway via natural language. Use when the user wants to trade crypto, trade tokenized stocks and ETFs (spot or leveraged), check portfolio balances (with PnL and NFTs), view token prices, search tokens, research token holders, transfer crypto, manage NFTs, use leverage (Hyperliquid or Avantis), bet on Polymarket, deploy tokens, set up automated trading, sign and submit raw transactions, call or deploy x402 paid API endpoints, browse the web, store and query files on their wallet's filesystem, or access LLM models through the Bankr LLM gateway funded by your Bankr wallet — including zero-data-retention and TEE-private inference tiers, plus topping up and sending LLM credits to another Bankr user. Supports Base, Ethereum, Polygon, Solana, Unichain, World Chain, Arbitrum, BNB Chain, and Robinhood Chain.
 metadata:
   {
     "clawdbot":
@@ -623,6 +623,10 @@ bankr agent prompt "How many LLM credits do I have left?"
 
 The agent can also report your current LLM credit balance in conversation — including any expiring grants and when they lapse — without needing the `bankr llm credits` command.
 
+**Sending credits to another Bankr user.** Purchased credit is transferable peer-to-peer — ask the agent ("send $20 of LLM credits to @alice") or `POST /llm/credits/transfer`. The recipient must already be a Bankr user (X username or `0x` address; no ENS on this path), only purchased credit moves (grants are not transferable), the minimum is $1, and a wallet may send at most **$500 per trailing 24 hours**. Read-only API keys are refused; pass your own `transferId` so a retry can't double-send.
+
+**Daily spend budget.** You can cap what the gateway spends on your behalf, independently of your balance. The window is a **trailing 24 hours**, not a calendar day — nothing resets at midnight, capacity returns as charges age out. Over budget, spending requests return `402` with `type: daily_budget_exceeded` (distinct from `insufficient_credits`), while read-only `GET` endpoints keep working so you can poll for when you're unblocked. The same budget also ends Max Mode agent runs early.
+
 1 credit = $1 USD. Multi-chain: pay with USDC or USDT directly on Base, Polygon, Ethereum, Arbitrum, or BNB Chain, or with any other ERC-20 (auto-swapped to the chain's preferred stablecoin — USDC on most chains, USDT on BNB). When using `--token`, the CLI picks the chain with the highest USD balance of that token. Maximum $1,000 per top-up.
 
 ### Model Deprecation
@@ -732,9 +736,10 @@ Spot stocks work with swaps, transfers, limit orders, and DCA. Only issuer-token
 
 ### Token Deployment
 
-- **EVM (Base default, or Robinhood Chain)**: Launch ERC20 tokens via Doppler on a Uniswap V4 pool with customizable metadata and social links. Fixed **100 billion** supply. Every trade pays a **0.7% swap fee on the pool and 95% of it goes to you** (0.665% of volume, claimable anytime); the hook adds the Bankr protocol fee + BNKR buyback and LP fee on top, for **1.75% all-in**. The **0.285% LP fee is creator-side too** — it compounds as locked liquidity in your own pool, strengthening your token's liquidity on every swap, so the creator side totals **0.95% of volume**. Tokens deploy to Base by default; pass a chain (`bankr launch --chain robinhood`) to launch on Robinhood Chain instead. Legacy Clanker tokens remain claimable (claims auto-detect Doppler vs Clanker).
+- **EVM (Base or Robinhood Chain)**: Launch ERC20 tokens via Doppler on a Uniswap V4 pool with customizable metadata and social links. Fixed **100 billion** supply. Every trade pays a **0.7% swap fee on the pool and 95% of it goes to you** (0.665% of volume, claimable anytime); the hook adds the Bankr protocol fee + BNKR buyback and LP fee on top, for **1.75% all-in**. The **0.285% LP fee is creator-side too** — it compounds as locked liquidity in your own pool, strengthening your token's liquidity on every swap, so the creator side totals **0.95% of volume**. **The default chain depends on the surface**: the CLI (`bankr launch`) and the web launch form preselect **Base**, while the AI agent and the deploy API fall back to **Robinhood Chain** when no chain is named. Name the chain explicitly (`bankr launch --chain robinhood`, `"chain": "base"`, or "launch it on Base") whenever it matters. Legacy Clanker tokens remain claimable (claims auto-detect Doppler vs Clanker).
 - **Stock-paired launches** (EVM, optional): pair the new token's pool with a registry tokenized stock instead of WETH, so the token trades against equity exposure. Available on Base (B20 equities) and Robinhood Chain — pass `pairedStockAddress` to the deploy API, or ask the agent to pair the launch with a ticker. Only stocks Bankr can price are offered, since launch-curve math needs a USD price.
 - **Quote-only fees** (EVM, optional): opt in at launch to collect all creator fees in the quote token (e.g. WETH) instead of a mix of the launched token and quote token — your total take is identical either way. Ask for "quote-only fees", pass `quoteOnlyFees: true` to the deploy API, or use `bankr launch --quote-only-fees`. Fixed at launch, like the fee schedule itself.
+- **Degen mode** (EVM, optional): start the token at a **$2,500 market cap** instead of the standard starting cap, for maximum early volatility. Explicit opt-in only — ask for "degen mode" by name, or pass `degenMode: true` to the deploy API. The figure is fixed; there is no custom starting market cap, a token *named* DEGEN does not opt you in, and the mode is unavailable on partner deploys.
 - **Solana**: Launch SPL tokens via Raydium LaunchLab with bonding curve and auto-migration to CPMM
 - Creator fee claiming on both chains
 - Fee Key NFTs for Solana (50% LP trading fees post-migration)
@@ -790,6 +795,7 @@ Every Bankr wallet has a persistent filesystem, shared across the CLI, web termi
 - Create, read, edit, search, move, rename, and delete files by asking the agent — a path (`/research/notes.md`) works anywhere a file ID does
 - `bankr files ls|upload|download|cat|edit|write|search|mkdir|rm|storage` from the CLI; `/user/files/*` over REST
 - **Ask questions about a file without loading it** — the agent runs a read-only `jq`/`grep`/`awk`-style pipeline in a sandbox and returns only the answer, so a 4 MB CSV never enters the conversation. Available on every wallet, no Club subscription needed
+- **Run outputs (`/runs`)** — a separate, conversation-scoped scratch namespace. Deliverables a sandboxed run writes to `./output/` persist there automatically and stay readable by path in later turns, and oversized tool results are stored there instead of crowding the conversation. Text only, ~14 days, 10 MB per file / 100 MB per conversation. Save anything that matters longer into your own filesystem
 - Quotas: 1 GB / 10 MB per file / 10 GB monthly downloads on the free tier; 10 GB / 50 MB / 100 GB on Bankr Club. Checked at write time, resolved live from your current Club status
 - Deletion is soft — files are recoverable via support for 24 hours, then permanently gone
 
@@ -853,6 +859,12 @@ One side effect worth knowing: the price-impact limit also fails closed on venue
 ### Protected-Token Swap Guard
 
 Bankr blocks **swaps** of a small set of protected tokens where swapping is almost always a costly mistake — for example staked positions that should be unwound through their own redeem flow. The block is swap-only: the token stays visible in your portfolio, transferable, and usable with the relevant staking/redeem tools. When a swap is blocked, the agent returns a clear reason pointing you to the correct exit path. This guard applies across the swap/limit/stop/DCA/TWAP tools on the EVM swap paths.
+
+### Impostor-Token Screening
+
+A common attack is to airdrop dust that reports a **canonical currency's ticker** — `USDG`, `USDC`, `USDT`, `EURC`, a chain's native or wrapped symbol — from an address that isn't the real one, hoping an agent copies the address straight out of a balance listing and trades into it. Bankr treats a negative security verdict on that shape as decisive: the token drops out of your portfolio listing rather than reaching the agent as a clean-looking `symbol: "USDG"` entry.
+
+The screen is narrow on purpose. Genuine canonical tokens match on address and are unaffected, fresh launches with real liquidity keep the more forgiving classification they need, and **a token you actually bought through Bankr is never hidden by a spam verdict** — only unsolicited dust drops. When you mean a specific asset, naming the ticker (not an address pasted from a balance list) lets Bankr resolve it to the vetted contract.
 
 ### BNKR Staking Is Withdraw-Only
 
@@ -1157,6 +1169,7 @@ See [references/safety.md](references/safety.md) for comprehensive safety guidan
 
 - "Deploy a token called BankrFan with symbol BFAN on Base"
 - "Launch a token with quote-only fees" (all creator fees collected in the quote token)
+- "Launch MOON in degen mode" (starts at a $2,500 market cap)
 - "Claim fees for my token MTK"
 
 ### LLM Credits
@@ -1167,6 +1180,8 @@ See [references/safety.md](references/safety.md) for comprehensive safety guidan
 - "Top up LLM credits using my ETH"
 - "Top up my LLM credits with $25 using USDT on Polygon"
 - "Add $10 of LLM credits paid in USDT on BNB"
+- "Send $20 of LLM credits to @alice"
+- "Transfer 5 dollars of my LLM credits to 0xRecipient"
 
 ### x402 Paid API Calls
 
@@ -1213,8 +1228,9 @@ Venue selection is automatic and the Wallet API now covers the same edge cases t
 
 - **Same-chain EVM** goes through the DEX aggregator, with a direct-pool venue preferred on thin-liquidity chains; **cross-chain and any Solana leg** goes through the bridge/swap aggregator
 - **Brand-new Solana tokens** still on their Raydium LaunchLab bonding curve fall back to the curve when no aggregator route exists yet, instead of failing with "no route". The fallback is narrow: both legs on Solana, a SOL ↔ token pair with an un-migrated curve, a genuine no-route from the aggregator, and **no price-impact limit set on the wallet** — the curve exposes no impact figure to check, so Bankr fails closed rather than fill an unguardable venue. With price-impact protection on, these swaps are rejected by design (the `minBuyAmount` floor still applies inside the fill)
-- **Polygon `pUSD` → `USDC.e`** uses the 1:1 on-chain Offramp unwrap rather than a DEX quote: no fee, no slippage, no price impact. The reverse direction (`USDC.e` → `pUSD`) is quoted like any ordinary pair. The unwrap settles to your own wallet, so a **swap-and-send** naming a different recipient routes through the normal venues instead — it never silently settles to you
+- **Polygon `pUSD` → `USDC.e`** uses the 1:1 on-chain Offramp unwrap rather than a DEX quote: no fee, no slippage, no price impact. Asking the agent to convert pUSD to plain "USDC" on Polygon resolves to `USDC.e` and takes this path — the request is read as the one routable thing it can mean, so the quote, the signing card, and the confirmation all name `USDC.e` rather than the pair failing to route. The reverse direction (`USDC.e` → `pUSD`) is quoted like any ordinary pair, and **buying** pUSD is untouched — the Offramp can only unwrap. The unwrap settles to your own wallet, so a **swap-and-send** naming a different recipient routes through the normal venues instead — it never silently settles to you
 - **Robinhood Chain tokenized stocks** are quoted and filled through the aggregator's RFQ makers, settling against USDG, while ordinary Robinhood Chain pairs keep their thin-pool protection
+- **Wallet-mode swaps** — where you sign from an external/connected wallet rather than a Bankr-custodied one — now walk the same venue order as every other swap, so a thin-liquidity pair reaches its direct-pool venue instead of being diverted to the bridge aggregator. Practical effects: a route that used to need an approval plus a router call can now come back as a single transaction to sign, and a leg whose build fails is reported as **failed** rather than handed to you as something to sign under a success message
 
 ```bash
 # CLI — quote only (no execution)

--- a/bankr/references/files.md
+++ b/bankr/references/files.md
@@ -17,11 +17,15 @@ Quotas are checked at the moment of write and resolved from your current Club st
 ## Layout
 
 ```
-/                    ← your root
+/                    ← your root (permanent, wallet-scoped)
 ├─ .memory/          ← auto-managed agent memory
 ├─ cli/              ← installed CLI skills and manifests
 └─ (your folders)
+
+/runs/               ← run outputs (conversation-scoped, expiring) — see below
 ```
+
+`/runs` is a reserved namespace: you can't create a folder of your own by that name.
 
 ## Using Files From Chat
 
@@ -36,6 +40,25 @@ delete the draft from yesterday
 ```
 
 A **path** (`/research/notes.md`) works anywhere a file ID does, on every file tool. When the agent generates a document you get a clickable link in the chat that opens the built-in preview/editor.
+
+## Run Outputs (`/runs`)
+
+Your permanent files are one half of what the agent can see. The other is `/runs` — a scratch namespace holding what a run produced: deliverables a sandboxed skill wrote, and tool results too large to sit in the conversation.
+
+- **Anything a sandboxed run writes to `./output/` is persisted automatically** to a `/runs/…` path when the call ends, and the run's summary lists those paths. You can ask the agent to read them back by path in a later turn, without re-running anything.
+- **Oversized tool results are stored rather than pasted.** A large result is written to `/runs` with a short preview kept inline, so a big fetch doesn't crowd out the rest of the conversation — the agent re-reads the full file by path when it needs it.
+- Ask for `/runs` listings the same way you ask for any other folder: *"list my run files"*, *"read /runs/… back to me"*.
+
+| | Limit |
+|---|---|
+| Scope | Your wallet **and** the conversation — run files aren't visible from another thread |
+| Retention | ~14 days, refreshed on each read or write, so an active conversation's files don't lapse |
+| Per file | 10 MB |
+| Per conversation | 100 MB across all run files |
+| Per sandbox call | 25 files / 10 MB synced out of `./output/` |
+| Content | **Text only.** Binary output (images, archives, PDFs) is refused — a run publishes those as artifacts instead |
+
+Run outputs are deliberately not durable storage. When something matters beyond the conversation, have the agent save it into your own filesystem (`/reports/…`), which is permanent and wallet-wide.
 
 ## Asking Questions About a File
 

--- a/bankr/references/llm-gateway.md
+++ b/bankr/references/llm-gateway.md
@@ -50,7 +50,8 @@ bankr config get llmKey
 | `claude-sonnet-4.6` | Anthropic | Previous generation Sonnet (1M context) |
 | `claude-sonnet-4.5` | Anthropic | Earlier Sonnet (1M context) |
 | `claude-haiku-4.5` | Anthropic | Fast, cost-effective (200K context) |
-| `gemini-3.6-flash` | Google | Latest Flash — the Bankr agent's default model (1M, image input) |
+| `gemini-3.7-flash` | Google | Latest Flash — the Bankr agent's default model (1M, image input) |
+| `gemini-3.6-flash` | Google | Previous Flash, coding and agents (1M, image input) |
 | `gemini-3.5-flash` | Google | Fast general-purpose (1M) |
 | `gemini-3.5-flash-lite` | Google | Ultra-fast, lowest cost (1M) |
 | `gemini-3.1-pro` | Google | Long context, reasoning (1M) |
@@ -177,7 +178,7 @@ Only a **trailing** tier token counts as the opt-in, so unrelated model IDs cont
 
 ### Max Mode — Choose the Agent's Model
 
-Max Mode replaces the Bankr agent's default model (`gemini-3.6-flash`) with any gateway model, billed per token from your **LLM credit balance**. It's the pay-per-use alternative to a Bankr Club subscription for unlimited terminal messages, and unlike Club checkout it works with external/connected wallets.
+Max Mode replaces the Bankr agent's default model (`gemini-3.7-flash`) with any gateway model, billed per token from your **LLM credit balance**. It's the pay-per-use alternative to a Bankr Club subscription for unlimited terminal messages, and unlike Club checkout it works with external/connected wallets.
 
 ```bash
 bankr agent "analyze my portfolio" --model claude-opus-5
@@ -243,6 +244,54 @@ spend order = expiring grants first (soonest-expiring), then the permanent pool
 ```
 
 Expired grants drop off automatically — there is no manual cleanup. The Credits page and `/llm/usage` show a breakdown of your permanent pool vs. each grant and its expiry, and your credit history labels grant rows.
+
+### Sending Credits to Another Bankr User
+
+Purchased credit is transferable peer-to-peer. Ask the agent, or call the API directly:
+
+```bash
+bankr agent prompt "Send $20 of LLM credits to @alice"
+bankr agent prompt "Transfer 5 dollars of my LLM credits to 0xRecipient"
+```
+
+```bash
+curl -X POST "https://api.bankr.bot/llm/credits/transfer" \
+  -H "X-API-Key: $BANKR_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"recipientAddress":"0xRecipient","amountUsd":20,"transferId":"my-unique-id"}'
+```
+
+The key needs **LLM Gateway** access enabled, like the top-up endpoint.
+
+The sender is debited and the recipient credited atomically — there is no pending state to reconcile.
+
+| Rule | Detail |
+|------|--------|
+| **Recipient** | Must already be a Bankr user. The agent accepts an X (Twitter) username or a `0x` address; the API takes the resolved EVM address. ENS names are not supported on this path. |
+| **Only purchased credit moves** | Grant credit (promotional, developer, partner) is **not** transferable — your sendable figure is the purchased slice of your pool, minus usage that's metered but not yet deducted. |
+| **Minimum** | $1 per transfer. |
+| **Rolling cap** | $500 gross sent per wallet per **trailing 24 hours** (shared with the same window the daily spend budget uses). Over it, the call returns `429`. |
+| **Write scope** | Read-only API keys are refused (`403`). If the key has an `--allowed-recipients` allowlist, the recipient must be on it. |
+| **Wallet controls apply** | A paused wallet can't send, and a wallet-level permitted-recipients list gates credit transfers exactly as it gates on-chain sends. |
+| **Idempotency** | Pass your own `transferId`; a retry with the same value never double-sends. |
+
+Failure codes are explicit rather than generic: `self-transfer` / `amount-too-small` (`400`), `insufficient-credit` (`402`), `wallet-paused` / `recipient-not-permitted` (`403`), `recipient-invalid` (`404`), `transfer-conflict` (`409`), `daily-cap-exceeded` / `daily-budget-exceeded` (`429`).
+
+`GET /llm/usage` returns `transferableUsd` — the sendable figure, already clamped by the remaining 24h cap and by any daily spend budget — so a client can offer a "Max" the transfer endpoint won't then reject.
+
+### Daily Spend Budget
+
+You can cap what the gateway may spend on your behalf, independently of your balance. The cap is measured over a **trailing 24 hours**, not a calendar day — nothing resets at midnight; capacity returns as individual charges age out of the window.
+
+```bash
+# Read or set from the web console at bankr.bot/llm
+GET  /llm/daily-budget      # { config: { limitUsd }, spentUsd }
+POST /llm/daily-budget      # { "limitUsd": 25 }   — null clears the cap
+```
+
+- Over budget, spending requests are rejected with `402 Payment Required` and error `type: daily_budget_exceeded` — distinct from `insufficient_credits`, which means the balance itself ran out.
+- **Only requests that spend are blocked.** Every read-only `GET` keeps working — `/v1/credits`, `/v1/usage`, `/v1/models` among them — so poll `exceeded` on `/v1/credits` to learn when you're unblocked, and `/v1/usage` for what consumed the budget. There is no reset time to schedule against.
+- The same budget also ends Max Mode agent runs early, so a capped wallet sees it on the agent surface too.
 
 ### Agent Credit Top-Up
 

--- a/bankr/references/llm-gateway.md
+++ b/bankr/references/llm-gateway.md
@@ -261,7 +261,7 @@ curl -X POST "https://api.bankr.bot/llm/credits/transfer" \
   -d '{"recipientAddress":"0xRecipient","amountUsd":20,"transferId":"my-unique-id"}'
 ```
 
-The key needs **LLM Gateway** access enabled, like the top-up endpoint.
+Auth matches the other credit endpoints: a Bankr API key — `X-API-Key`, or `Authorization: Bearer` — with **LLM Gateway** access enabled, or a signed-in web session. Whichever you use, the transfer is a write, so read-only keys are refused.
 
 The sender is debited and the recipient credited atomically — there is no pending state to reconcile.
 

--- a/bankr/references/safety.md
+++ b/bankr/references/safety.md
@@ -324,6 +324,7 @@ Blockchain transactions are **irreversible** once confirmed. Key safety rules:
 - **Wait for confirmation** — Use `waitForConfirmation: true` with `/agent/submit` to ensure transactions are confirmed before proceeding. See [sign-submit-api.md](sign-submit-api.md).
 - **Immediate execution** — `/agent/submit` executes transactions immediately with no confirmation prompt. For safety with the prompt API, the AI agent may ask for confirmation on large or unusual operations.
 - **Understand calldata** — When using arbitrary transactions, verify the calldata source is trusted. See [arbitrary-transaction.md](arbitrary-transaction.md).
+- **Never trade an address you copied out of a balance listing.** Airdropped dust that reports a canonical ticker (`USDG`, `USDC`, `USDT`, `EURC`, a native or wrapped symbol) from the wrong address is a standing attack against agents. Bankr keeps a negative security verdict decisive for that shape, so impostor dust drops out of the portfolio listing instead of reaching the agent as a clean-looking entry — but the durable habit is to name the **ticker** and let Bankr resolve it to the vetted contract. Genuine canonical tokens and tokens you bought through Bankr are never hidden.
 
 ## Key Management
 

--- a/bankr/references/token-deployment.md
+++ b/bankr/references/token-deployment.md
@@ -6,9 +6,11 @@ Deploy and manage tokens on Base and Robinhood Chain (via Doppler / Uniswap V4) 
 
 | Chain | Protocol | Token Standard | Best For |
 |-------|----------|----------------|----------|
-| **Base** (default) | Doppler (Uniswap V4) | ERC20 | Memecoins, social/agent tokens |
-| **Robinhood Chain** | Doppler (Uniswap V4) | ERC20 | Memecoins alongside tokenized stocks |
+| **Base** (CLI / web default) | Doppler (Uniswap V4) | ERC20 | Memecoins, social/agent tokens |
+| **Robinhood Chain** (agent / deploy-API default) | Doppler (Uniswap V4) | ERC20 | Memecoins alongside tokenized stocks |
 | **Solana** | Raydium LaunchLab | SPL | High-speed trading, bonding curves |
+
+> **The EVM default differs by surface.** `bankr launch` and the web launch form preselect **Base**; the AI agent and `POST /token-launches/deploy` fall back to **Robinhood Chain** when the request names no chain. Name the chain explicitly whenever it matters.
 
 > **Builder exits:** selling a token you earn creator fees on through Bankr's ordinary swap/limit/stop/DCA/TWAP tools is intentionally restricted (buying and transferring still work). To take profit, builders use a **Glidepath** — a capped, AI-paced gradual sell managed from the token page at [bankr.bot](https://bankr.bot). Glidepath is a web feature, not a CLI/API action. Details: https://docs.bankr.bot/token-launching/glidepath
 
@@ -189,7 +191,7 @@ Users can launch additional tokens beyond sponsored limits by paying ~0.01 SOL g
 
 ## EVM Token Launches (Base & Robinhood Chain, via Doppler)
 
-Launch ERC20 tokens on Base or Robinhood Chain. New launches create a Uniswap V4 pool via Doppler with a fixed supply and a single swap-fee tier shared between you and the protocol. Tokens deploy to **Base by default**; pass a chain to launch on Robinhood Chain instead (`bankr launch --chain robinhood`, or "launch a token on robinhood"). Robinhood Chain memecoin launches need no location verification — that gate only applies to Robinhood-issued tokenized stocks.
+Launch ERC20 tokens on Base or Robinhood Chain. New launches create a Uniswap V4 pool via Doppler with a fixed supply and a single swap-fee tier shared between you and the protocol. The default chain differs by surface (see [Supported Chains](#supported-chains)), so name it explicitly — `bankr launch --chain robinhood`, `"chain": "base"`, or "launch a token on robinhood". Robinhood Chain memecoin launches need no location verification — that gate only applies to Robinhood-issued tokenized stocks.
 
 ### Token Economics
 
@@ -232,6 +234,21 @@ Two knock-on effects for anyone integrating against a quote-only token:
 
 Like the fee schedule, this option cannot be changed after launch.
 
+### Degen Mode (optional, fixed at launch)
+
+Degen mode starts the token at a **$2,500 market cap** instead of the standard starting cap, so the curve's early range is far more volatile. Everything else about the launch — supply, fee schedule, curve shape, vesting — is unchanged.
+
+| How | Syntax |
+|-----|--------|
+| Natural language | "launch MOON in degen mode" |
+| Deploy API | `"degenMode": true` |
+| Web | toggle in the launch form |
+
+- **Explicit opt-in only.** You have to ask for the mode by name. A token *called* DEGEN, or generic "make it risky" phrasing, does not turn it on.
+- **The figure is fixed at $2,500.** There is no custom starting market cap to request.
+- **Not available on partner deploys** — those are rejected with a `400` rather than quietly launched at the standard cap.
+- No `bankr launch` flag yet; use the agent or the deploy API from the command line.
+
 ### Deployment Parameters
 
 | Parameter | Required | Description | Example |
@@ -245,6 +262,7 @@ Like the fee schedule, this option cannot be changed after launch.
 | **Telegram** | No | Telegram group | "@mytoken" |
 | **Fee Recipient** | No | Route creator fees to a wallet, ENS, or social handle | "@partner" |
 | **Quote-only fees** | No | Collect all creator fees in the quote token; fixed at launch | `quoteOnlyFees: true` |
+| **Degen mode** | No | Start at a $2,500 market cap; explicit opt-in, not on partner deploys | `degenMode: true` |
 
 ### Prompt Examples
 
@@ -253,6 +271,7 @@ Like the fee schedule, this option cannot be changed after launch.
 - "Create a memecoin: name=DogeKiller, symbol=DOGEK"
 - "Deploy token with website myproject.com and Twitter @myproject"
 - "Create a token on Base"
+- "Launch MOON in degen mode"
 - "Launch a token called CoolBot on robinhood"
 - "Launch a token called CoolBot and route fees to @partner"
 - "Launch a token with quote-only fees"
@@ -289,7 +308,7 @@ bankr agent prompt "Launch a token called Semis paired with NVDA on base"
 ```
 
 ```json
-POST /token/deploy
+POST /token-launches/deploy
 { "name": "Semis", "symbol": "SEMIS", "chain": "base", "pairedStockAddress": "0x..." }
 ```
 


### PR DESCRIPTION
Weekly sync of the `bankr` skill against what actually shipped, plus a few pre-existing inaccuracies the pass turned up.

## Shipped this week

**LLM credits are transferable peer-to-peer.** New section in `references/llm-gateway.md` plus a summary in `SKILL.md`: `POST /llm/credits/transfer`, the agent phrasings that reach it, and the rules that bound it — recipient must be an existing Bankr user (X username or `0x` address, no ENS on this path), only *purchased* credit moves (grants aren't transferable), $1 minimum, $500 gross per trailing 24h, read-only keys refused, caller-supplied `transferId` for idempotency, and wallet-level pause / permitted-recipients controls applying as they do to on-chain sends. Documents the explicit failure codes and `transferableUsd` on `GET /llm/usage` so a client can offer a "Max" the endpoint won't reject.

**Gemini 3.7 Flash is the agent's default model.** Added to the model table and marked as the default; 3.6 Flash demoted to a previous-generation row. The Max Mode section named the old default and now names the new one.

**Degen mode for token launches.** New section in `references/token-deployment.md`, a bullet in `SKILL.md`, a parameter-table row, and a prompt example: a fixed $2,500 starting market cap, explicit opt-in by name only (a token *called* DEGEN doesn't opt you in), no custom cap, unavailable on partner deploys, and no CLI flag yet.

**Polygon pUSD → USDC.** Asking to convert pUSD to plain "USDC" on Polygon now resolves to `USDC.e` and takes the 1:1 Offramp unwrap instead of failing to route; the swap-semantics bullet says so, and notes the buy direction is untouched.

**Wallet-mode swap routing.** Swaps signed from an external/connected wallet now walk the same venue order as custodied ones, so a thin-liquidity pair reaches its direct-pool venue rather than being diverted to the bridge aggregator — which can collapse an approve-plus-router pair into a single transaction to sign. Also: a leg whose build fails is now reported as failed rather than handed over to sign under a success message.

**Impostor-token screening.** New safety subsection plus a `references/safety.md` rule. Airdropped dust reporting a canonical ticker (`USDG`, `USDC`, `USDT`, `EURC`, a native or wrapped symbol) from a non-canonical address now keeps its negative verdict and drops out of the portfolio listing instead of reaching the agent as a clean-looking entry. Notes the narrowness — genuine canonical tokens and anything bought through Bankr are never hidden — and gives the durable habit: name the ticker, don't trade an address pasted from a balance list.

**Run outputs (`/runs`).** New section in `references/files.md` and a bullet in the file-storage capability list. Covers the `./output/` auto-persist channel, oversized tool results being stored rather than pasted inline, and the limits: conversation-scoped, ~14 days refreshed on access, 10 MB per file, 100 MB per conversation, 25 files / 10 MB per sandbox call, text only.

## Gaps caught while syncing

These were already wrong before this week's changes; fixed here since the same sections were being touched.

- **The EVM launch default differs by surface.** The skill claimed Base everywhere. The CLI and the web launch form preselect Base, but the agent and the deploy API fall back to Robinhood Chain when no chain is named. Corrected in three places, with an explicit "name the chain" instruction.
- **Wrong deploy endpoint.** The stock-paired launch example used `POST /token/deploy`; the endpoint is `POST /token-launches/deploy`.
- **The LLM daily spend budget was undocumented.** Added: the cap is measured over a trailing 24 hours rather than a calendar day (nothing resets at midnight — capacity returns as charges age out), over-budget spending requests return `402` with `type: daily_budget_exceeded` (distinct from `insufficient_credits`), read-only `GET` endpoints stay unblocked so you can poll for recovery, and the same budget ends Max Mode agent runs early. The rolling-window measurement and the blocked-caller semantics landed this week; the underlying cap predates the window.

## Verification

Every limit, endpoint path, error code, and default in this diff was read off current source rather than inferred — model default, transfer minimum/cap/permission gates, degen-mode market cap and partner-deploy rejection, `/runs` byte and count caps and TTL, and the per-surface launch-chain defaults.


---
_Generated by [Claude Code](https://claude.ai/code/session_01CTvGjcc8zq6Rgn71RDFdL2)_