### PR TITLE
aero-stock-lp: tell the user LPing takes a few minutes

### DIFF
--- a/aero-stock-lp/SKILL.md
+++ b/aero-stock-lp/SKILL.md
@@ -40,6 +40,11 @@ outcome. Rules:
   at $298 – $322? yes/no" — `plan` emits exactly this line), then execute
   the whole sequence without narrating each step. Report one final line
   with the position and a single tx link.
+- Set the time expectation once, right after the user confirms: opening
+  (or exiting) a position takes several onchain transactions submitted
+  one at a time, so it usually takes 2–3 minutes end to end. One line —
+  "Opening your position now — this takes a few onchain steps, usually
+  2–3 minutes" — so the quiet stretch reads as normal, not stuck.
 - Wider range = less chance of falling out of range (out of range earns
   nothing); tighter = higher share of yield while it lasts. Default to
   `standard` width without asking; explain only if the user asks about


### PR DESCRIPTION
An LP request has two quiet stretches: the pre-confirmation checks (quote fetch, entry gates) and the post-confirmation transaction sequence. Adds one rule to the "Talking to the user" section: the moment the user asks to LP or exit — before any quote fetch or script run — send one line setting expectations ("On it — LPing takes a few steps, usually 2–3 minutes. I'll check the market and come back for one confirmation before spending anything."), so neither wait reads as stuck.