### PR TITLE
aero-stock-lp: send the wait message before any work starts, not after confirmation

### DIFF
--- a/aero-stock-lp/SKILL.md
+++ b/aero-stock-lp/SKILL.md
@@ -40,11 +40,13 @@ outcome. Rules:
   at $298 – $322? yes/no" — `plan` emits exactly this line), then execute
   the whole sequence without narrating each step. Report one final line
   with the position and a single tx link.
-- Set the time expectation once, right after the user confirms: opening
-  (or exiting) a position takes several onchain transactions submitted
-  one at a time, so it usually takes 2–3 minutes end to end. One line —
-  "Opening your position now — this takes a few onchain steps, usually
-  2–3 minutes" — so the quiet stretch reads as normal, not stuck.
+- Set the time expectation FIRST. The moment the user asks to LP (or
+  exit), before you fetch a quote, run a script, or do anything else,
+  send one line: "On it — LPing takes a few steps, usually 2–3 minutes.
+  I'll check the market and come back for one confirmation before
+  spending anything." Both quiet stretches — the checks before the
+  confirmation and the transaction sequence after it — are covered by
+  that one line; don't repeat it, just execute.
 - Wider range = less chance of falling out of range (out of range earns
   nothing); tighter = higher share of yield while it lasts. Default to
   `standard` width without asking; explain only if the user asks about


### PR DESCRIPTION
Follow-up to #662, which merged with only the first commit — the second commit (this change) failed to push before the merge. #662 as merged has the agent say the 2–3 minute line only after the user confirms, but the first silent stretch (quote fetch, entry gates) happens before that, so the user still stares at a bare "thinking" indicator.

This moves the rule: the moment the user asks to LP or exit — before any quote fetch or script run — send one line ("On it — LPing takes a few steps, usually 2–3 minutes. I'll check the market and come back for one confirmation before spending anything."). That one line covers both quiet stretches; the agent doesn't repeat it after confirmation.