### PR TITLE
aero-stock-lp: auto-routing in description + optional position-app offer after entry

### DIFF
--- a/aero-stock-lp/SKILL.md
+++ b/aero-stock-lp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aero-stock-lp
-description: LP tokenized stocks onchain — range-LP Coinbase tokenized equities (NVDA, AAPL, GOOGL, META) and AERO/USDC on Aerodrome Slipstream (Base) for trading-fee + AERO emission yield. Use when the user wants to LP stocks or Aerodrome pools on Base, open/recenter/exit a Slipstream position, check pool status, NAV, or yields, get a portfolio overview ("how are my LP positions doing?") with P&L and projected APR, compare the staked (emissions) vs unstaked (fees) route, or run a manage pass on request. Bundled node scripts do the chain reads, gate checks, and calldata; writes go via the Bankr arbitrary-transaction flow. NOT for perps, spot trading, or Uniswap.
+description: LP tokenized stocks onchain — range-LP Coinbase tokenized equities (NVDA, AAPL, GOOGL, META) and AERO/USDC on Aerodrome Slipstream (Base) for trading-fee + AERO emission yield. Use when the user wants to LP stocks or Aerodrome pools on Base, open/recenter/exit a Slipstream position, check pool status, NAV, or yields, get a portfolio overview ("how are my LP positions doing?") with P&L and projected APR, or run a manage pass on request. Auto-routes every position to the higher-yielding side — staked (AERO emissions) vs unstaked (trading fees) — at entry and re-checks on every manage pass. Bundled node scripts do the chain reads, gate checks, and calldata; writes go via the Bankr arbitrary-transaction flow. NOT for perps, spot trading, or Uniswap.
 ---
 
 # aero-stock-lp — LP onchain equities on Aerodrome (Base)
@@ -103,6 +103,11 @@ YOU submit the txs via Bankr and check receipts.
 5. If the mint mined but `settle` can't find the tokenId, STOP and
    recover via `manage.mjs` (it discovers from chain) — never re-mint
    blind.
+6. Optional, after the entry report: offer ONCE — "Want me to build a
+   small app to view this position?" If yes, build a simple read-only
+   dashboard fed by `manage.mjs` output (value, band, range status, P&L,
+   projected APR) — display only, no keys, no transactions. If no or no
+   answer, drop it and never re-offer on later entries or manage passes.
 
 ## 3. Manage pass (run on request)
 


### PR DESCRIPTION
Two small additions:

**Description now states the auto-routing.** The skill already routes every position to the higher-yielding side automatically — `entry.mjs settle` compares the fee pot vs the AERO emissions pot per unit of in-range liquidity (including your own dilution) and picks staked vs unstaked at entry, and `manage.mjs` re-checks on every pass with a 1.3x hysteresis before proposing a switch. The frontmatter description now says so, since it's a headline behavior users should discover the skill by.

**Optional position app, offered once.** After a successful entry report, the agent offers once: "Want me to build a small app to view this position?" If yes — a simple read-only dashboard fed by `manage.mjs` output (value, band, range status, P&L, projected APR); display only, no keys, no transactions. If no, it never re-offers. Keeps the skill itself no more complicated than it is — it's a one-line prompt, not a feature.