### PR TITLE
feat: add WOLF airdrop claim skill

### DIFF
--- a/wolf-airdrop-claim/SKILL.md
+++ b/wolf-airdrop-claim/SKILL.md
@@ -36,9 +36,9 @@ Use `read_contract` on Base before fetching or submitting a proof. Read:
 - Airdrop `claimDeadline() view returns (uint64)`; require `1795397419` and ensure it has not passed.
 - Airdrop `hasClaimed(address) view returns (bool)` for the connected wallet; stop if `true`.
 - Airdrop `claimedCount() view returns (uint256)`.
-- WOLF `balanceOf(address) view returns (uint256)` for the airdrop address; require it to equal `(500 - claimedCount) * 6000000000000000000000000` exactly.
+- WOLF `balanceOf(address) view returns (uint256)` for the airdrop address; require it to be at least `(500 - claimedCount) * 6000000000000000000000000`.
 
-If the WOLF balance differs from the exact outstanding liability, tell the user the airdrop is not fully funded or is awaiting reconciliation. Do not call `claim` and do not retry blindly. Before the first claim, the required balance is exactly `3000000000000000000000000000` raw WOLF.
+If the WOLF balance is below the outstanding liability, tell the user the airdrop is not fully funded or is awaiting reconciliation. Do not call `claim` and do not retry blindly. A surplus does not block claims; anyone can transfer extra WOLF to the distributor. Before the first claim, the minimum required balance is `3000000000000000000000000000` raw WOLF.
 
 ### 2. Fetch the connected wallet's proof
 

--- a/wolf-airdrop-claim/SKILL.md
+++ b/wolf-airdrop-claim/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: wolf-airdrop-claim
+description: Claim from The White Wolf (WOLF) Bankr Club Top-500 airdrop on Base. Each eligible wallet can claim 6,000,000 WOLF once with a Merkle proof. Use when a user asks to claim WOLF, check WOLF airdrop eligibility or claim status, or mentions the WOLF Top-500 Bankr Club distribution.
+---
+
+# WOLF airdrop claim
+
+Claim an equal share from the verified WOLF `BankrAirdrop` on Base. The Merkle leaf binds to `msg.sender`, so the eligible wallet must submit its own claim. Never request or handle the user's private key.
+
+## Constants
+
+| Field | Value |
+|---|---|
+| Chain | `base` (chain ID `8453`) |
+| Airdrop | `0xA9C8829c74618b8B245AD8140658A75Aa19043de` |
+| WOLF token | `0x73AC2806C40AB4741ea7a35B7328ACA957755ba3` |
+| Merkle root | `0x98e14446c511330a5ba7dfefc8159dc2e29ed0682e8e2d5dc1464166752760b3` |
+| Share | `6000000000000000000000000` raw units = 6,000,000 WOLF |
+| Total claimers | `500` |
+| Total distribution | `3000000000000000000000000000` raw units = 3,000,000,000 WOLF |
+| Deadline | Unix `1795397419` = `2026-11-23T01:30:19Z` |
+| Owner | `0x71a3A6dEF933Faed976BCB8eF39854f02fD69A0f` |
+| Proofs | `https://gist.githubusercontent.com/0xdeployer/c7b78c9b3d311685f8987127808b3615/raw/f5ba3d7eb9c00cf5c1840218ab72349a933635ce/wolf-proofs.json` |
+| Proof SHA-256 | `2156b1d4a9eeea61c571cbaf459ee579a2c429b33be305b3e048a057068d8006` |
+
+## Claim workflow
+
+### 1. Read and validate on-chain state
+
+Use `read_contract` on Base before fetching or submitting a proof. Read:
+
+- Airdrop `token() view returns (address)`; require the WOLF token above.
+- Airdrop `merkleRoot() view returns (bytes32)`; require the root above.
+- Airdrop `share() view returns (uint256)`; require the share above.
+- Airdrop `totalClaimers() view returns (uint256)`; require `500`.
+- Airdrop `claimDeadline() view returns (uint64)`; require `1795397419` and ensure it has not passed.
+- Airdrop `hasClaimed(address) view returns (bool)` for the connected wallet; stop if `true`.
+- Airdrop `claimedCount() view returns (uint256)`.
+- WOLF `balanceOf(address) view returns (uint256)` for the airdrop address; require it to equal `(500 - claimedCount) * 6000000000000000000000000` exactly.
+
+If the WOLF balance differs from the exact outstanding liability, tell the user the airdrop is not fully funded or is awaiting reconciliation. Do not call `claim` and do not retry blindly. Before the first claim, the required balance is exactly `3000000000000000000000000000` raw WOLF.
+
+### 2. Fetch the connected wallet's proof
+
+Use `execute_cli` with the connected wallet address. The script must validate the exact downloaded bytes, embedded campaign constants, and case-insensitive wallet lookup:
+
+```
+execute_cli(
+  files='{"getProof.ts":"import { createHash } from \"node:crypto\";\nconst url = \"https://gist.githubusercontent.com/0xdeployer/c7b78c9b3d311685f8987127808b3615/raw/f5ba3d7eb9c00cf5c1840218ab72349a933635ce/wolf-proofs.json\";\nconst expectedSha = \"2156b1d4a9eeea61c571cbaf459ee579a2c429b33be305b3e048a057068d8006\";\nconst expectedRoot = \"0x98e14446c511330a5ba7dfefc8159dc2e29ed0682e8e2d5dc1464166752760b3\";\nconst expectedShare = \"6000000000000000000000000\";\nconst target = (process.argv[2] ?? \"\").trim().toLowerCase();\nif (!/^0x[a-f0-9]{40}$/.test(target)) { console.error(\"usage: bun getProof.ts <0x...wallet>\"); process.exit(2); }\nconst response = await fetch(url);\nif (!response.ok) { console.error(`proof download failed: HTTP ${response.status}`); process.exit(3); }\nconst bytes = new Uint8Array(await response.arrayBuffer());\nconst actualSha = createHash(\"sha256\").update(bytes).digest(\"hex\");\nif (actualSha !== expectedSha) { console.error(\"proof file hash mismatch — refusing to proceed\"); process.exit(4); }\nconst data = JSON.parse(new TextDecoder().decode(bytes));\nif (String(data.merkleRoot).toLowerCase() !== expectedRoot || String(data.share) !== expectedShare || data.totalClaimers !== 500) { console.error(\"proof campaign constants mismatch — refusing to proceed\"); process.exit(5); }\nconst entry = Object.entries(data.proofs).find(([address]) => address.toLowerCase() === target);\nif (!entry) { console.error(`NOT_ELIGIBLE: ${target} is not in the WOLF airdrop list`); process.exit(1); }\nconsole.log(JSON.stringify(entry[1]));\n"}',
+  commands=["bun getProof.ts <CONNECTED_WALLET>"]
+)
+```
+
+An exit with `NOT_ELIGIBLE` is final for that wallet. Do not call `write_contract`. A successful run prints one JSON-encoded `bytes32[]` containing 8 or 9 hashes.
+
+### 3. Submit the claim
+
+Call `write_contract` only after every preflight above passes:
+
+```
+write_contract(
+  to="0xA9C8829c74618b8B245AD8140658A75Aa19043de",
+  functionSignature="claim(bytes32[] proof)",
+  args=['<JSON proof array printed by getProof.ts>'],
+  value="0",
+  chain="base"
+)
+```
+
+Pass the complete JSON proof array as the single string in `args`. Do not add a recipient argument; the contract verifies `msg.sender`.
+
+### 4. Verify the result
+
+After a successful transaction:
+
+1. Read `hasClaimed(address) view returns (bool)` for the connected wallet and require `true`.
+2. Read WOLF `balanceOf(address) view returns (uint256)` for the connected wallet.
+3. Report the transaction hash and current WOLF balance.
+
+## Revert handling
+
+| Error | Selector | Response |
+|---|---|---|
+| `InvalidProof()` | `0x09bde339` | The connected wallet or proof is not eligible. Stop. |
+| `AlreadyClaimed()` | `0x646cf558` | The wallet already claimed. Read `hasClaimed` and stop. |
+| `ClaimWindowClosed()` | `0xf0f25a33` | The deadline has passed. Stop. |
+| `InsufficientBalance()` | `0xf4d678b8` | The distributor lacks one full share. Tell the user it is not funded or has insufficient claim liquidity. |
+
+## Owner-only operations
+
+Never call owner functions unless the connected wallet is exactly `0x71a3A6dEF933Faed976BCB8eF39854f02fD69A0f` and the user explicitly requests the operation.
+
+- `sweep(address to)` transfers all remaining WOLF out of the airdrop and is callable at any time.
+- `rescueERC20(address token,address to)` recovers a non-WOLF ERC-20 sent accidentally.
+- `setToken(address)` is unavailable because WOLF was fixed in the constructor; it will revert with `TokenAlreadySet()`.

--- a/wolf-airdrop-claim/catalog.json
+++ b/wolf-airdrop-claim/catalog.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": 1,
+  "slug": "wolf-airdrop-claim",
+  "provider": "Bankr",
+  "providerUrl": "https://bankr.bot",
+  "logo": null,
+  "demo": {
+    "title": "claim-wolf.sh",
+    "language": "bash",
+    "code": "# Check eligibility and funding without sending a transaction\nbankr prompt \"Check whether my wallet is eligible for the WOLF Top-500 airdrop\"\n\n# Claim after the distributor is fully funded\nbankr prompt \"Claim my WOLF airdrop\""
+  },
+  "setup": [
+    "Install: `install the wolf-airdrop-claim skill from https://github.com/BankrBot/skills/tree/main/wolf-airdrop-claim`",
+    "Base mainnet only — WOLF token: `0x73AC2806C40AB4741ea7a35B7328ACA957755ba3`",
+    "Verified distributor: `0xA9C8829c74618b8B245AD8140658A75Aa19043de`",
+    "Each eligible Bankr Club Top-500 wallet can claim 6,000,000 WOLF once",
+    "Claims remain blocked until the distributor holds the exact outstanding WOLF liability"
+  ],
+  "install": {
+    "type": "bankr",
+    "repoPath": "wolf-airdrop-claim",
+    "command": "install the wolf-airdrop-claim skill from https://github.com/BankrBot/skills/tree/main/wolf-airdrop-claim"
+  }
+}

--- a/wolf-airdrop-claim/catalog.json
+++ b/wolf-airdrop-claim/catalog.json
@@ -14,7 +14,7 @@
     "Base mainnet only — WOLF token: `0x73AC2806C40AB4741ea7a35B7328ACA957755ba3`",
     "Verified distributor: `0xA9C8829c74618b8B245AD8140658A75Aa19043de`",
     "Each eligible Bankr Club Top-500 wallet can claim 6,000,000 WOLF once",
-    "Claims remain blocked until the distributor holds the exact outstanding WOLF liability"
+    "Claims remain blocked until the distributor holds at least the outstanding WOLF liability"
   ],
   "install": {
     "type": "bankr",


### PR DESCRIPTION
## Summary
- add the WOLF Bankr Club Top-500 claim skill
- pin the 500-wallet proof bundle by Git revision and SHA-256
- require the distributor to hold at least its outstanding liability before submitting a claim
- tolerate harmless surplus WOLF so a permissionless dust transfer cannot block claims
- add catalog metadata for installation and discovery

## Production constants
- Base distributor: 0xA9C8829c74618b8B245AD8140658A75Aa19043de
- WOLF: 0x73AC2806C40AB4741ea7a35B7328ACA957755ba3
- Merkle root: 0x98e14446c511330a5ba7dfefc8159dc2e29ed0682e8e2d5dc1464166752760b3
- 500 recipients x 6,000,000 WOLF
- Deadline: 2026-11-23T01:30:19Z

## Validation
- manifest passes Bankr production parseManifest
- compact proof file SHA-256 and campaign constants validated
- eligible and ineligible proof lookup paths exercised
- live Base preflight correctly blocks while the intentionally unfunded balance is zero

The distributor is deployed and verified but intentionally awaits the WOLF team transfer of exactly 3,000,000,000 WOLF.