### PR TITLE
Add walcert skill — A–F wallet maturity certificates (x402)

### DIFF
--- a/walcert/SKILL.md
+++ b/walcert/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: walcert
+description: >-
+  Issue A–F wallet-maturity certificates (origins, activity, multichain, portfolio)
+  via Walcert’s public HTTP API. Use when the user or agent needs to judge a
+  wallet before paying, tipping, launching a token, or interacting with an
+  ERC-8004 agent. Free preview first; full signed certificate is x402 $0.05 USDC.
+metadata:
+  openclaw:
+    homepage: https://walcert.globalscoreagent.com
+---
+
+# Walcert
+
+Walcert (Global Score Agent) is a live ERC-8004 agent on **Celo** (agentId `9699`) that
+issues **A–F wallet-maturity certificates**. Scoring runs on the public API. This
+skill only teaches *when* and *how* to call that API. Do not reimplement scoring.
+Do not proxy the API through another host.
+
+## When to use
+
+Use this skill when someone asks whether a wallet looks mature/legitimate, wants
+an origins / activity / multichain / portfolio certificate, or wants to verify
+an existing Walcert on-chain receipt.
+
+Do **not** use this skill for token rug scans, HUMI/WAMI agent scores, or
+ERC-8004 registration.
+
+## Base URL
+
+`https://walcert.globalscoreagent.com`
+
+JSON body field is always `wallet_address` (checksum optional; 0x + 40 hex).
+
+## Flow
+
+1. **Preview** (free) for `origins` or `activity` unless the user already asked for
+   a signed / on-chain certificate.
+2. **Paid certificate** if they need signature + on-chain anchor, or the type is
+   `multichain` / `portfolio` (preview returns 403).
+3. **Verify** with the Celo `tx_hash` from `onchain` when they only have the receipt.
+
+### Preview (no payment)
+
+```http
+POST /v1/preview/{origins|activity}
+Content-Type: application/json
+
+{"wallet_address":"0x…"}
+```
+
+Returns grade A–F + labels only. Rate limit: **8 requests / 15 min / IP** → 429
+with `Retry-After`. `multichain` and `portfolio` preview → **403**.
+
+### Full certificate (x402)
+
+```http
+POST /v1/certificates/{origins|activity|multichain|portfolio}
+Content-Type: application/json
+
+{"wallet_address":"0x…"}
+```
+
+Unauthenticated call → **402**. Retry with a valid PAYMENT-SIGNATURE.
+
+- Price: **$0.05 USDC**
+- **Default rail: Base** (`eip155:8453`, native USDC, EIP-3009). Pick `accepts[0]`
+  unless the host cannot pay Base.
+- Celo (`eip155:42220`) is also listed (Track 2).
+- BNB (`eip155:56`, Permit2, Binance-Peg USDC) only if the host can sign Permit2 on
+  BSC **and** will `claim` the soulbound receipt NFT afterwards. See
+  `references/x402-rails.md`. Base/Celo payments do **not** mint an NFT.
+
+### Verify (free)
+
+```http
+POST /v1/verify
+Content-Type: application/json
+
+{"tx_hash":"0x…"}
+```
+
+`tx_hash` is the Celo `giveFeedback` transaction (66-char hex). Optional:
+`data_hash`, `certificate_id`.
+
+## Identity (do not mix)
+
+| Chain | agentId | Role |
+|-------|---------|------|
+| Celo | `9699` | Certificate issuer / on-chain anchor |
+| Base | ACP listing | Marketplace identity, **not** the cert issuer |
+| Ethereum | Agent City | Discovery only |
+
+`payTo` is the operational EOA on the 402. Never pay from Owner or Monitor keys.
+Never log private keys.
+
+## Forbidden
+
+- Wrapping or rehosting on `x402.bankr.bot` (or any x402 Cloud).
+- Internal marketplace bypass / shared secrets.
+- Paying preview endpoints.
+- Treating Bankr/OpenClaw as a seller catalog — they only load this skill.
+
+Details: `references/api.md`, `references/x402-rails.md`.

--- a/walcert/catalog.json
+++ b/walcert/catalog.json
@@ -16,7 +16,7 @@
   "install": {
     "type": "external",
     "provider": "Global Score Agent",
-    "command": "install the walcert skill from https://github.com/GlobalScoreAgent/walcert-skill/tree/main/skills/walcert",
+    "command": "install the walcert skill from https://github.com/GlobalScoreAgent/walcert-skill",
     "reference": null
   }
 }

--- a/walcert/catalog.json
+++ b/walcert/catalog.json
@@ -1,0 +1,22 @@
+{
+  "schemaVersion": 1,
+  "slug": "walcert",
+  "provider": "Global Score Agent",
+  "providerUrl": "https://globalscoreagent.com",
+  "demo": {
+    "title": "preview-origins.sh",
+    "language": "bash",
+    "code": "curl -sS -X POST https://walcert.globalscoreagent.com/v1/preview/origins \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"wallet_address\":\"0x0000000000000000000000000000000000000001\"}'"
+  },
+  "setup": [
+    "Install this skill from the Walcert GitHub folder (source of truth; Bankr Discover PR is optional).",
+    "For a signed certificate, the host wallet needs USDC on Base for x402 ($0.05).",
+    "Do not wrap Walcert on x402 Cloud. Call walcert.globalscoreagent.com directly."
+  ],
+  "install": {
+    "type": "external",
+    "provider": "Global Score Agent",
+    "command": "install the walcert skill from https://github.com/GlobalScoreAgent/walcert-agent/tree/main/skills/walcert",
+    "reference": null
+  }
+}

--- a/walcert/catalog.json
+++ b/walcert/catalog.json
@@ -3,20 +3,20 @@
   "slug": "walcert",
   "provider": "Global Score Agent",
   "providerUrl": "https://globalscoreagent.com",
+  "logo": null,
   "demo": {
     "title": "preview-origins.sh",
     "language": "bash",
     "code": "curl -sS -X POST https://walcert.globalscoreagent.com/v1/preview/origins \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"wallet_address\":\"0x0000000000000000000000000000000000000001\"}'"
   },
   "setup": [
-    "Install from the public repo GlobalScoreAgent/walcert-skill (this agent repo is private; Bankr cannot fetch it).",
-    "For a signed certificate, the host wallet needs USDC on Base for x402 ($0.05).",
-    "Do not wrap Walcert on x402 Cloud. Call walcert.globalscoreagent.com directly."
+    "Install: `install the walcert skill from https://github.com/BankrBot/skills/tree/main/walcert`",
+    "Paid certificates: host wallet needs USDC on Base for x402 ($0.05).",
+    "Call https://walcert.globalscoreagent.com directly. Do not wrap on Bankr x402 Cloud."
   ],
   "install": {
-    "type": "external",
-    "provider": "Global Score Agent",
-    "command": "install the walcert skill from https://github.com/GlobalScoreAgent/walcert-skill",
-    "reference": null
+    "type": "bankr",
+    "repoPath": "walcert",
+    "command": "install the walcert skill from https://github.com/BankrBot/skills/tree/main/walcert"
   }
 }

--- a/walcert/catalog.json
+++ b/walcert/catalog.json
@@ -9,14 +9,14 @@
     "code": "curl -sS -X POST https://walcert.globalscoreagent.com/v1/preview/origins \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"wallet_address\":\"0x0000000000000000000000000000000000000001\"}'"
   },
   "setup": [
-    "Install this skill from the Walcert GitHub folder (source of truth; Bankr Discover PR is optional).",
+    "Install from the public repo GlobalScoreAgent/walcert-skill (this agent repo is private; Bankr cannot fetch it).",
     "For a signed certificate, the host wallet needs USDC on Base for x402 ($0.05).",
     "Do not wrap Walcert on x402 Cloud. Call walcert.globalscoreagent.com directly."
   ],
   "install": {
     "type": "external",
     "provider": "Global Score Agent",
-    "command": "install the walcert skill from https://github.com/GlobalScoreAgent/walcert-agent/tree/main/skills/walcert",
+    "command": "install the walcert skill from https://github.com/GlobalScoreAgent/walcert-skill/tree/main/skills/walcert",
     "reference": null
   }
 }

--- a/walcert/references/api.md
+++ b/walcert/references/api.md
@@ -1,0 +1,55 @@
+# Walcert public API
+
+Host: `https://walcert.globalscoreagent.com`
+
+## Types
+
+| Type | Preview | Paid | Data |
+|------|---------|------|------|
+| `origins` | yes | yes | Alchemy inflows |
+| `activity` | yes | yes | Alchemy 15d window |
+| `multichain` | 403 | yes | GoldRush footprint + intensity |
+| `portfolio` | 403 | yes | Zerion |
+
+## Preview
+
+`POST /v1/preview/{type}`
+
+```json
+{ "wallet_address": "0x…" }
+```
+
+**200** (typical): `preview: true`, `grade`, `grade_label` `{eng,esp}`, `analyzed_at`.
+No EIP-712 signature, no `giveFeedback`, no `provider` brand block.
+
+| Status | When |
+|--------|------|
+| 403 | `multichain` or `portfolio` |
+| 429 | >8 calls / 15 min / IP (`Retry-After`) |
+| 503 | provider quota / not configured |
+
+## Paid certificate
+
+`POST /v1/certificates/{type}`
+
+Same JSON body. Without payment → **402** (`PAYMENT-REQUIRED`). After settle → **200**
+with bilingual certificate, `signature`, `onchain` (Celo). BNB settle also includes
+`certificate.receipt` (see `x402-rails.md`).
+
+## Verify
+
+`POST /v1/verify`
+
+```json
+{ "tx_hash": "0x…" }
+```
+
+Optional `data_hash`, `certificate_id`. Facade over Edge: DB + Celo `NewFeedback` + EIP-712.
+
+## Other
+
+- `GET /` — agent card JSON
+- `GET /health` — liveness
+- `GET /v1/quota` — provider quota snapshot
+
+Do not call Summit (`/v1/summit/...`) from this skill.

--- a/walcert/references/x402-rails.md
+++ b/walcert/references/x402-rails.md
@@ -1,0 +1,37 @@
+# x402 rails
+
+Same `POST /v1/certificates/{type}` lists three `accepts`. The client picks **one**.
+
+| Priority | Network | Asset | How to pay | NFT receipt |
+|---------|---------|-------|------------|-------------|
+| Default | Base `eip155:8453` | Native USDC (6 dec) | EIP-3009 via CDP | No |
+| Fallback | Celo `eip155:42220` | USDC (6 dec) | EIP-3009 via x402.celo.org | No |
+| Optional | BNB `eip155:56` | Binance-Peg USDC 18 dec `0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d` | Permit2 via Dexter | Yes, after `claim` |
+
+Price is **$0.05** on every rail. Canonical certificate (EIP-712 + `giveFeedback`) is
+always on **Celo**, regardless of which rail paid.
+
+## Default: Base
+
+Use Base unless the host cannot settle USDC there. This matches `accepts[0]` (CDP Bazaar).
+
+## BNB (optional)
+
+Only if **all** are true:
+
+1. Host wallet holds Binance-Peg USDC on BSC.
+2. Host can sign **Permit2** (first time: `approve` USDC → Permit2
+   `0x000000000022D473030F116dDEE9F6B43aC78BA3`).
+3. After HTTP 200, host will `claim` the voucher as the **payer**.
+
+The receipt contract is already deployed (do not deploy):
+[`0x4e430fB5A5f26ED08eC123373Cd8AD3cE15C24c7`](https://bscscan.com/address/0x4e430fB5A5f26ED08eC123373Cd8AD3cE15C24c7).
+Soulbound. `msg.sender` must be the x402 payer. Claim gas is BNB, not the $0.05.
+
+If the host cannot Permit2 or cannot send a BSC tx, **pay on Base**. A Base payment
+does not mint this NFT.
+
+## Forbidden
+
+Do not wrap these URLs on Bankr x402 Cloud (`x402.bankr.bot`). That creates a second
+402, a foreign URL, and a platform fee. Call Walcert directly.


### PR DESCRIPTION
## Summary
Thin skill for [Walcert](https://walcert.globalscoreagent.com) (Global Score Agent): A–F wallet-maturity certificates over the public HTTP API (preview free, full cert x402 ` $0.05 ` USDC).

Source of truth stays in [GlobalScoreAgent/walcert-agent](https://github.com/GlobalScoreAgent/walcert-agent/tree/main/skills/walcert). This folder is for Bankr Discover. Install is `external` and points at that tree.

## Test plan
- [ ] `catalog.json` validates (slug = walcert, schemaVersion 1)
- [ ] Install: `install the walcert skill from https://github.com/GlobalScoreAgent/walcert-agent/tree/main/skills/walcert`
- [ ] Preview `POST /v1/preview/origins` works from a Bankr agent after install
- [ ] Skill appears on skills.bankr.bot after merge

Made with [Cursor](https://cursor.com)