### PR TITLE
aero-stock-lp: fix 0x0x calldata corruption, dead trend brake, and full script-audit findings

### DIFF
--- a/aero-stock-lp/scripts/entry.mjs
+++ b/aero-stock-lp/scripts/entry.mjs
@@ -8,6 +8,8 @@
 //   entry.mjs plan   --market AAPL --usd 50 --wallet 0x… --quote 311.20 --quote-age-s 90 [--iv 0.28 | --w 0.04] [--width standard]
 //   entry.mjs size   --market AAPL --usd 50 --wallet 0x… --tick-lower -11710 --tick-upper -10910   (ticks from plan output)
 //   entry.mjs settle --market AAPL --wallet 0x… --mint-tx 0x… [--entry-usd 50] [--state-path p]
+//                    [--recenter-of <oldTokenId> --direction up|down]  <- REQUIRED on a recenter:
+//                    carries the trend-brake history forward from the closed position
 //
 // Output: ONE JSON object on stdout: {ok, phase, gates?, band?, txs?, report, next?}
 // Gates fail closed: any failed gate -> exit code 1 and {ok:false, gate:"…"}.
@@ -19,6 +21,7 @@ import {
   MAX_UINT256,
   ERC721_TRANSFER_TOPIC,
   CL_GAUGE_FACTORY,
+  GAS_MIN_ETH,
 } from "./lib/markets.mjs";
 import {
   addrWord,
@@ -33,6 +36,7 @@ import {
   geckoPool,
   aeroSpot,
   aeroHourlyCandles,
+  ethBalance,
   tx,
 } from "./lib/chain.mjs";
 import {
@@ -97,11 +101,15 @@ async function plan() {
     fail("nav", "equity entry requires --quote and --quote-age-s (fresh real-world quote)");
   }
 
-  const gecko = await geckoPool(M.pool);
-  const [slot0Res, usdcBalRes, usdcAllowRes] = await multicall([
+  const [gecko, walletEth] = await Promise.all([
+    geckoPool(M.pool),
+    ethBalance(wallet).catch(() => null), // null = unknown; agent checks gas another way
+  ]);
+  const [slot0Res, usdcBalRes, usdcAllowRes, stockBalRes] = await multicall([
     { to: M.pool, data: SEL.slot0 },
     { to: USDC, data: SEL.balanceOf + addrWord(wallet) },
     { to: USDC, data: SEL.allowance + addrWord(wallet) + addrWord(M.router) },
+    { to: M.token, data: SEL.balanceOf + addrWord(wallet) },
   ]);
   if (!slot0Res.ok) fail("rpc", "slot0 read failed");
   const poolPrice = priceFromSqrtX96(toBigInt(wordAt(slot0Res.data, 0)), M.decimals);
@@ -126,6 +134,10 @@ async function plan() {
   // ---------- gates (§5) — ALL must pass; fail closed ----------
   const volBrake = M.kind === "equity" ? 7 : 15;
   const usdcBal = usdcBalRes.ok ? Number(toBigInt(wordAt(usdcBalRes.data, 0))) / 1e6 : 0;
+  const looseStock = stockBalRes.ok
+    ? Number(toBigInt(wordAt(stockBalRes.data, 0))) / 10 ** M.decimals
+    : 0;
+  const looseStockUsd = looseStock * poolPrice;
   const ageHours = gecko.createdAt
     ? (Date.now() - Date.parse(gecko.createdAt)) / 3.6e6
     : Infinity;
@@ -153,6 +165,14 @@ async function plan() {
       limit: "<=25% of pool TVL",
     },
     {
+      // fail closed BEFORE any tx: an entry the wallet can't fund would
+      // otherwise revert mid-sequence at the swap or mint
+      name: "balance",
+      pass: usdcBal + looseStockUsd >= usd - 0.01,
+      value: +(usdcBal + looseStockUsd).toFixed(2),
+      limit: `wallet USDC + loose ${market} must cover $${usd}`,
+    },
+    {
       name: "vol-brake",
       pass: Math.abs(gecko.change24hPct) < volBrake,
       value: gecko.change24hPct,
@@ -167,14 +187,7 @@ async function plan() {
   const band = buildBand(poolPrice, quote, w, width, M.decimals, M.tickSpacing);
   const share = stockShare((poolPrice + quote) / 2, band.bandLow, band.bandHigh);
 
-  // absorb loose stock already in the wallet
-  const [stockBalRes] = await multicall([
-    { to: M.token, data: SEL.balanceOf + addrWord(wallet) },
-  ]);
-  const looseStock = stockBalRes.ok
-    ? Number(toBigInt(wordAt(stockBalRes.data, 0))) / 10 ** M.decimals
-    : 0;
-  const looseStockUsd = looseStock * poolPrice;
+  // absorb loose stock already in the wallet (read with the gate batch above)
   const swapUsd = Math.max(0, usd * share - looseStockUsd);
 
   const txs = [];
@@ -228,6 +241,10 @@ async function plan() {
     looseStockAbsorbedUsd: +looseStockUsd.toFixed(2),
     needsConcentrationConfirm: usd > 0.5 * usdcBal,
     walletUsdc: +usdcBal.toFixed(2),
+    // gas preflight (§0.5): when gasLowNeedsTopUp, fold ~$5 USDC -> ETH into
+    // the sequence's first step and mention it in the single confirmation line
+    walletEth: walletEth !== null ? +walletEth.toFixed(6) : null,
+    gasLowNeedsTopUp: walletEth !== null ? walletEth < GAS_MIN_ETH : null,
     txs,
     report: `Deposit $${usd} into the ${market} pool at $${band.bandLow.toFixed(2)} – $${band.bandHigh.toFixed(2)}?`,
     next:
@@ -389,6 +406,28 @@ async function settle() {
   const state = loadState(statePathArg);
   const entryUsd = args["entry-usd"] !== undefined ? Number(args["entry-usd"]) : null;
   const now = new Date().toISOString();
+
+  // Trend-brake history (§3): a recenter must carry the closed position's
+  // recenter log forward, or the brake can never see 2+ same-direction moves
+  // across the exit/re-enter cycle. exit.mjs finish parks closed records in
+  // state.recentExits for exactly this hand-off.
+  const recenterOf =
+    args["recenter-of"] !== undefined && args["recenter-of"] !== true
+      ? String(args["recenter-of"])
+      : null;
+  const direction =
+    args.direction === "up" || args.direction === "down" ? args.direction : null;
+  let recenters = [];
+  if (recenterOf) {
+    const prev =
+      (state.recentExits || []).find((p) => p.tokenId === recenterOf) ||
+      (state.positions || []).find((p) => p.tokenId === recenterOf);
+    recenters = [
+      ...(prev?.recenters || []),
+      { at: now, direction: direction || "unknown", from: recenterOf },
+    ].slice(-10);
+  }
+
   state.positions = (state.positions || []).filter((p) => p.tokenId !== String(tokenId));
   state.positions.push({
     market,
@@ -396,7 +435,7 @@ async function settle() {
     entryUsd,
     enteredAt: now,
     lastMintAt: now,
-    recenters: [],
+    recenters,
   });
   saveState(state, statePathArg);
 
@@ -415,7 +454,11 @@ async function settle() {
       minStakeTimeS: minStakeS,
     },
     txs,
-    stateRecorded: { entryUsd, enteredAt: now },
+    stateRecorded: { entryUsd, enteredAt: now, recentersCarried: recenters.length },
+    recenterWarning:
+      recenterOf && !direction
+        ? "recenter recorded WITHOUT --direction — the trend brake cannot match it; pass --direction up|down next time"
+        : null,
     memoryLine: `aero-stock-lp: active Aerodrome LP positions on Base — see ~/.aero-stock-lp/state.json. Manage with the aero-stock-lp skill.`,
     report:
       route === "staked"

--- a/aero-stock-lp/scripts/exit.mjs
+++ b/aero-stock-lp/scripts/exit.mjs
@@ -8,10 +8,12 @@
 //   exit.mjs finish --market AAPL --token-id 123 --wallet 0x… [--state-path p]
 //     -> sell stock residual -> USDC, sell claimed AERO (> 0.1) -> USDC, burn
 //        (burn failure is NON-FATAL — funds are already out), remove from state
+//        (closed record parked in state.recentExits so a recenter's
+//        entry.mjs settle --recenter-of can carry the trend-brake history)
 //   exit.mjs sell-aero --wallet 0x…
 //     -> standalone AERO -> USDC sell of the wallet's AERO balance (compounding)
 
-import { getMarket, MARKETS, USDC, AERO, ROUTER_MAIN, SEL, MAX_UINT128 } from "./lib/markets.mjs";
+import { getMarket, MARKETS, USDC, AERO, ROUTER_MAIN, SEL, MAX_UINT128, GAS_MIN_ETH } from "./lib/markets.mjs";
 import {
   addrWord,
   uintWord,
@@ -21,6 +23,7 @@ import {
   toBigInt,
   toInt,
   toAddr,
+  ethBalance,
   tx,
 } from "./lib/chain.mjs";
 import { priceFromSqrtX96 } from "./lib/math.mjs";
@@ -74,9 +77,12 @@ async function begin() {
   const wallet = need("wallet");
   const idW = uintWord(tokenId);
 
-  const [ownerRes, posRes] = await multicall([
-    { to: M.npm, data: SEL.ownerOf + idW },
-    { to: M.npm, data: SEL.positions + idW },
+  const [[ownerRes, posRes], walletEth] = await Promise.all([
+    multicall([
+      { to: M.npm, data: SEL.ownerOf + idW },
+      { to: M.npm, data: SEL.positions + idW },
+    ]),
+    ethBalance(wallet).catch(() => null),
   ]);
   if (!ownerRes.ok || !posRes.ok) out({ ok: false, gate: "rpc", detail: "position reads failed" }, 1);
   const holder = toAddr(wordAt(ownerRes.data, 0));
@@ -107,6 +113,10 @@ async function begin() {
     market,
     tokenId: String(tokenId),
     wasStaked: staked,
+    // gas preflight (§0.5): when gasLowNeedsTopUp, fold ~$5 USDC -> ETH into
+    // the sequence's first step and mention it in the single confirmation line
+    walletEth: walletEth !== null ? +walletEth.toFixed(6) : null,
+    gasLowNeedsTopUp: walletEth !== null ? walletEth < GAS_MIN_ETH : null,
     txs,
     report: `Exit ${market} #${tokenId}: ${txs.length} txs (funds land in the wallet after collect).`,
     next: "submit txs in order via Bankr, then run: exit.mjs finish",
@@ -130,6 +140,11 @@ async function finish() {
       { to: M.pool, data: SEL.slot0 },
       { to: aeroPool.pool, data: SEL.slot0 },
     ]);
+  // Fail closed: a failed balance/price read here would silently skip a
+  // residual sell while the report claims the user lands in USDC.
+  if (!stockBalRes.ok || !aeroBalRes.ok || !slot0Res.ok || !aeroSlot0Res.ok) {
+    out({ ok: false, gate: "rpc", detail: "balance/price reads failed — cannot size residual sells; re-run finish" }, 1);
+  }
 
   const txs = [];
   const price = slot0Res.ok ? priceFromSqrtX96(toBigInt(wordAt(slot0Res.data, 0)), M.decimals) : 0;
@@ -160,11 +175,19 @@ async function finish() {
   // burn is cosmetic; a burn failure after collect must NOT fail the exit
   txs.push(tx(M.npm, SEL.burn + idW, `burn #${tokenId} (NON-FATAL if it reverts — funds are already out)`));
 
-  // remove from state; report basis for the final P&L decomposition
+  // Remove from state, but PARK the record in recentExits: a follow-up
+  // entry.mjs settle --recenter-of <tokenId> pulls the trend-brake history
+  // from there. Without this hand-off the brake resets on every recenter.
   const statePathArg = args["state-path"];
   const state = loadState(statePathArg);
   const rec = (state.positions || []).find((p) => p.tokenId === String(tokenId));
   state.positions = (state.positions || []).filter((p) => p.tokenId !== String(tokenId));
+  if (rec) {
+    state.recentExits = [
+      ...(state.recentExits || []),
+      { ...rec, closedAt: new Date().toISOString() },
+    ].slice(-10);
+  }
   saveState(state, statePathArg);
 
   out({
@@ -187,8 +210,10 @@ async function sellAero() {
     { to: AERO, data: SEL.allowance + addrWord(wallet) + addrWord(ROUTER_MAIN) },
     { to: aeroPool.pool, data: SEL.slot0 },
   ]);
-  const aeroRaw = aeroBalRes.ok ? toBigInt(wordAt(aeroBalRes.data, 0)) : 0n;
+  if (!aeroBalRes.ok) out({ ok: false, gate: "rpc", detail: "AERO balance read failed — re-run" }, 1);
+  const aeroRaw = toBigInt(wordAt(aeroBalRes.data, 0));
   if (aeroRaw <= 10n ** 17n) out({ ok: true, phase: "sell-aero", txs: [], report: "AERO balance below 0.1 — nothing to sell." });
+  if (!aeroSlot0Res.ok) out({ ok: false, gate: "rpc", detail: "AERO pool price read failed — cannot set minOut; re-run" }, 1);
   const aeroPrice = priceFromSqrtX96(toBigInt(wordAt(aeroSlot0Res.data, 0)), 18);
   const txs = [];
   const allow = aeroAllowRes.ok ? toBigInt(wordAt(aeroAllowRes.data, 0)) : 0n;

--- a/aero-stock-lp/scripts/lib/chain.mjs
+++ b/aero-stock-lp/scripts/lib/chain.mjs
@@ -203,6 +203,23 @@ export async function aeroHourlyCandles() {
 
 // ---------- unsigned tx helper ----------
 
-export function tx(to, dataNo0x, label) {
-  return { label, to, data: "0x" + dataNo0x, value: "0", chainId: 8453 };
+// Emits validated, ready-to-submit calldata. Accepts data with or without a
+// 0x prefix (selectors in markets.mjs carry one) and normalizes to exactly
+// one — blindly prepending here once produced 0x0x calldata that reverted
+// on submission. Fails closed on anything that isn't clean hex.
+export function tx(to, data, label) {
+  const d = "0x" + strip0x(String(data)).toLowerCase();
+  if (d.length < 10 || !/^0x(?:[0-9a-f]{2})+$/.test(d)) {
+    throw new Error(`malformed calldata for "${label}" — refusing to emit tx`);
+  }
+  if (!/^0x[0-9a-fA-F]{40}$/.test(to)) {
+    throw new Error(`malformed to-address for "${label}" — refusing to emit tx`);
+  }
+  return { label, to, data: d, value: "0", chainId: 8453 };
+}
+
+// native Base ETH balance (for the gas preflight)
+export async function ethBalance(addr) {
+  const out = await rpc("eth_getBalance", [addr, "latest"]);
+  return Number(BigInt(out)) / 1e18;
 }

--- a/aero-stock-lp/scripts/lib/markets.mjs
+++ b/aero-stock-lp/scripts/lib/markets.mjs
@@ -129,6 +129,10 @@ export const ERC721_TRANSFER_TOPIC =
 export const MAX_UINT256 = (1n << 256n) - 1n;
 export const MAX_UINT128 = (1n << 128n) - 1n;
 
+// Gas preflight (SKILL.md §0.5): below this native ETH balance, the agent
+// folds a small USDC -> ETH top-up into the sequence's first step.
+export const GAS_MIN_ETH = 0.0015;
+
 export function getMarket(name) {
   const m = MARKETS[String(name || "").toUpperCase()];
   if (!m) {

--- a/aero-stock-lp/scripts/lib/positions.mjs
+++ b/aero-stock-lp/scripts/lib/positions.mjs
@@ -96,24 +96,25 @@ export async function discoverPositions(wallet, knownIds = {}) {
       });
     }
   });
+  const posCalls = [];
   if (enumCalls.length) {
     const ids = await multicall(enumCalls.map((e) => e.call));
-    const posCalls = ids
-      .map((r, i) => ({
-        npm: enumCalls[i].npm,
-        tokenId: r.ok ? toBigInt(wordAt(r.data, 0)) : null,
-      }))
-      .filter((x) => x.tokenId !== null);
-    // state-file positions are always checked, even past the cap
-    // (skip ones already found staked — the gauge holds those NFTs)
-    for (const [id, market] of Object.entries(knownIds)) {
-      if (
-        !posCalls.some((p) => String(p.tokenId) === String(id)) &&
-        !found.some((f) => String(f.tokenId) === String(id))
-      ) {
-        posCalls.push({ npm: MARKETS[market]?.npm || NPM_EQUITY, tokenId: BigInt(id) });
-      }
+    for (let i = 0; i < ids.length; i++) {
+      if (ids[i].ok) posCalls.push({ npm: enumCalls[i].npm, tokenId: toBigInt(wordAt(ids[i].data, 0)) });
     }
+  }
+  // state-file positions are ALWAYS checked directly — even past the cap,
+  // even when enumeration is empty or a balance read failed (skip ones
+  // already found staked — the gauge holds those NFTs)
+  for (const [id, market] of Object.entries(knownIds)) {
+    if (
+      !posCalls.some((p) => String(p.tokenId) === String(id)) &&
+      !found.some((f) => String(f.tokenId) === String(id))
+    ) {
+      posCalls.push({ npm: MARKETS[market]?.npm || NPM_EQUITY, tokenId: BigInt(id) });
+    }
+  }
+  if (posCalls.length) {
     const details = await multicall(
       posCalls.map((p) => ({ to: p.npm, data: SEL.positions + uintWord(p.tokenId) }))
     );

--- a/aero-stock-lp/scripts/manage.mjs
+++ b/aero-stock-lp/scripts/manage.mjs
@@ -15,6 +15,7 @@ import {
   SEL,
   CL_GAUGE_FACTORY,
   MAX_UINT128,
+  GAS_MIN_ETH,
 } from "./lib/markets.mjs";
 import {
   addrWord,
@@ -24,8 +25,10 @@ import {
   toBigInt,
   geckoPool,
   aeroSpot,
+  ethBalance,
   tx,
 } from "./lib/chain.mjs";
+import { priceFromSqrtX96 } from "./lib/math.mjs";
 import {
   discoverPositions,
   readPosition,
@@ -61,10 +64,11 @@ async function main() {
   const knownIds = Object.fromEntries(
     (state.positions || []).map((p) => [p.tokenId, p.market])
   );
-  const [found, loose, spot] = await Promise.all([
+  const [found, loose, spot, walletEth] = await Promise.all([
     discoverPositions(wallet, knownIds),
     looseBalances(wallet),
     aeroSpot().catch(() => null),
+    ethBalance(wallet).catch(() => null),
   ]);
 
   // gecko + minStakeTimes once per market that has a position
@@ -174,7 +178,9 @@ async function main() {
           emisDen > 0n ? (p.rewardRatePerSec * 31536000 * spot) / Number(emisDen) : 0;
         const current = p.staked ? emisPerL : feePerL;
         const other = p.staked ? feePerL : emisPerL;
-        if (current > 0 && other >= HYSTERESIS * current) {
+        // other > 0 alone covers the dead-route case (current = 0, e.g. a
+        // killed gauge): any paying alternative beats a route paying nothing
+        if (other > 0 && other >= HYSTERESIS * current) {
           entry.routeSwitchProposed = p.staked ? "unstake -> collect fees" : "stake -> earn AERO";
           if (p.staked) {
             txs.push(
@@ -225,6 +231,7 @@ async function main() {
         reentryCostEstUsd: +reentryCost.toFixed(2),
         costHurdleMet: hurdleMet,
         trendBrake,
+        priceDirection: direction,
         quoteProvided: quote !== null || f.market === "AERO",
         action: !hurdleMet
           ? "hold — waiting out the cost hurdle"
@@ -232,7 +239,7 @@ async function main() {
             ? "stand aside in cash — trend brake (2+ same-direction recenters)"
             : quote === null && f.market !== "AERO"
               ? "exit-ready, but re-entry BLOCKED: no fresh quote passed (--quote-" + f.market + ")"
-              : "exit and re-enter: run exit.mjs begin, then entry.mjs plan",
+              : `exit and re-enter: exit.mjs begin/finish, entry.mjs plan/size, then settle --recenter-of ${f.tokenId} --direction ${direction} (records the trend-brake history)`,
       };
       report.push(
         `${f.market}: $${value.toFixed(2)}, OUT of range ($${bandLow.toFixed(2)} – $${bandHigh.toFixed(2)}, now $${p.poolPrice.toFixed(2)}), earning nothing — ${entry.outOfRange.action}.`
@@ -241,16 +248,26 @@ async function main() {
     positions.push(entry);
   }
 
-  // loose balances are real book money
+  // loose balances are real book money — including stock in markets with no
+  // open position (mid-recenter, after a partial exit): price those off slot0
+  // rather than silently valuing them at $0
+  const looseStockMarkets = Object.keys(MARKETS).filter((m) => m !== "AERO" && loose[m] > 0);
+  const loosePrices = {};
+  const unpriced = looseStockMarkets.filter((m) => !positions.some((p) => p.market === m));
+  if (unpriced.length) {
+    const res = await multicall(unpriced.map((m) => ({ to: MARKETS[m].pool, data: SEL.slot0 })));
+    unpriced.forEach((m, i) => {
+      if (res[i].ok)
+        loosePrices[m] = priceFromSqrtX96(toBigInt(wordAt(res[i].data, 0)), MARKETS[m].decimals);
+    });
+  }
   const looseUsd =
     loose.USDC +
     (spot ? loose.AERO * spot : 0) +
-    Object.keys(MARKETS)
-      .filter((m) => m !== "AERO" && loose[m] > 0)
-      .reduce((s, m) => {
-        const pos = positions.find((p) => p.market === m);
-        return s + loose[m] * (pos ? pos.poolPrice : 0);
-      }, 0);
+    looseStockMarkets.reduce((s, m) => {
+      const pos = positions.find((p) => p.market === m);
+      return s + loose[m] * (pos ? pos.poolPrice : loosePrices[m] || 0);
+    }, 0);
 
   report.push(
     `Total: $${(totalUsd).toFixed(2)} in positions${pnlKnown && positions.length ? `, ${totalPnl >= 0 ? "+" : ""}$${totalPnl.toFixed(2)} net` : ""}; loose wallet balances ~$${looseUsd.toFixed(2)}. Emissions reset Thursday.`
@@ -262,10 +279,15 @@ async function main() {
     positions,
     loose,
     aeroSpot: spot,
+    walletEth: walletEth !== null ? +walletEth.toFixed(6) : null,
+    gasLowNeedsTopUp: walletEth !== null ? walletEth < GAS_MIN_ETH : null,
     txs,
     report,
     notes: [
       positions.length === 0 ? "No LP positions found on-chain for this wallet." : null,
+      walletEth !== null && walletEth < GAS_MIN_ETH
+        ? "Base ETH is low — fold a ~$5 USDC -> ETH top-up into the next tx sequence's first step (§0.5)"
+        : null,
       found.truncated
         ? "wallet holds many position NFTs — enumeration capped at the most recent 400; state-file positions were checked directly regardless"
         : null,

--- a/aero-stock-lp/scripts/selftest.mjs
+++ b/aero-stock-lp/scripts/selftest.mjs
@@ -4,7 +4,7 @@
 // Exit 0 = all pass; any failure exits 1 with the failing check named.
 
 import { MARKETS, SEL } from "./lib/markets.mjs";
-import { intWord, uintWord, addrWord, toInt, multicall, wordAt, toBigInt } from "./lib/chain.mjs";
+import { intWord, uintWord, addrWord, toInt, multicall, wordAt, toBigInt, strip0x, tx } from "./lib/chain.mjs";
 import {
   priceFromSqrtX96,
   tickFromPrice,
@@ -104,6 +104,26 @@ const swapData =
   uintWord(3400000n) +
   uintWord(0);
 check("exactInputSingle calldata = 4 + 8*32 bytes", swapData.length === 2 + (4 + 8 * 32) * 2);
+
+// --- unsigned tx hygiene (REGRESSION: SEL selectors carry 0x; a blind
+// "0x" + data in tx() once emitted 0x0x… calldata that failed on submission) ---
+const t1 = tx(MARKETS.AAPL.gauge, SEL.getReward + uintWord(123n), "claim vector");
+check("tx() exactly one 0x prefix", t1.data.startsWith("0x") && !t1.data.startsWith("0x0x"));
+check("tx() clean hex payload", /^0x(?:[0-9a-f]{2})+$/.test(t1.data));
+check("tx() selector at head", t1.data.slice(0, 10) === SEL.getReward);
+check("tx() word-aligned length", (t1.data.length - 10) % 64 === 0);
+check("tx() to is 42 chars", t1.to.length === 42);
+check("tx() value/chainId shape", t1.value === "0" && t1.chainId === 8453);
+const t2 = tx(MARKETS.AAPL.gauge, strip0x(SEL.gaugeDeposit) + uintWord(1n), "unprefixed vector");
+check("tx() normalizes unprefixed data too", t2.data.slice(0, 10) === SEL.gaugeDeposit);
+const mintTx = tx(MARKETS.AAPL.npm, mintData, "mint vector");
+check("tx() mint calldata single-prefixed", !mintTx.data.startsWith("0x0x") && mintTx.data.length === mintData.length);
+let badDataThrew = false;
+try { tx(MARKETS.AAPL.gauge, "0xZZ123", "bad calldata"); } catch { badDataThrew = true; }
+check("tx() malformed calldata throws (fail closed)", badDataThrew);
+let badToThrew = false;
+try { tx("0x1234", SEL.getReward + uintWord(1n), "bad to"); } catch { badToThrew = true; }
+check("tx() malformed to-address throws (fail closed)", badToThrew);
 
 // --- live (read-only) ---
 if (process.argv.includes("--live")) {


### PR DESCRIPTION
Full audit of all 8 bundled script files, triggered by field reports of failed claim transactions on non-frontier models. Scripts-only — no overlap with #673 (SKILL.md v2); the two merge independently and are designed to land together.

## Root cause of the failed claims (and it wasn't claims-only)

`chain.mjs` `tx()` blindly prepended `"0x"` to calldata, while **every** selector in `markets.mjs` `SEL` already carries a `0x` prefix. Result: **every write transaction the scripts emitted** — approve, swap, mint, stake, unstake, collect, burn, getReward — had corrupted `0x0x…` calldata. Frontier models were silently stripping the extra prefix on relay (masking the bug); models that relayed faithfully failed on every submission. The selftest never caught it because its vectors checked raw `SEL + words` strings and never ran anything through `tx()`.

This also makes SKILL.md §0's "relay verbatim, never repair calldata" rule (in #673) actually safe to obey: the script now guarantees clean output, the model guarantees fidelity.

## Fixes

**Critical**
- `tx()` normalizes via `strip0x` (accepts prefixed or unprefixed input, emits exactly one `0x`) and **fails closed** on malformed calldata or a malformed `to` address — a bad tx can no longer be emitted at all.
- **The trend brake was dead code.** Nothing ever wrote to `recenters[]`, and `exit finish` deleted the position record, so the brake could never observe 2+ same-direction recenters across an exit/re-enter cycle. Now: `exit.mjs finish` parks closed records in `state.recentExits` (capped 10); `entry.mjs settle` accepts `--recenter-of <oldTokenId> --direction up|down` and carries the history forward; `manage.mjs` prints the exact flags in its out-of-range action text so agents can't miss the hand-off.

**Hardening (audit findings)**
- `selftest.mjs`: 11 new regression vectors that exercise `tx()` **output** — single `0x` prefix, selector at head, word-aligned length, `to`/`value`/`chainId` shape, and malformed-input-throws. `0x0x` can never ship silently again.
- `entry.mjs plan`: new `balance` gate — a `--usd` the wallet can't cover fails closed before any tx instead of reverting mid-sequence at the swap or mint.
- Gas preflight support for SKILL.md §0.5: `plan`, `exit begin`, and `manage` now report `walletEth` + `gasLowNeedsTopUp` (threshold `GAS_MIN_ETH = 0.0015`), so the preflight is a script fact rather than a model chore.
- `positions.mjs`: state-file known tokenIds are now checked directly even when NFT enumeration is empty or a balance read fails (previously the recovery path was silently skipped).
- `manage.mjs`: a route switch is now proposed when the current route pays zero (e.g. a killed gauge — previously the position would earn nothing forever); loose stock in markets with no open position is priced off `slot0` instead of being silently valued at $0 in the book total.
- `exit.mjs finish`: fails closed if balance/price reads fail — it previously skipped residual sells silently while the report claimed "user lands in USDC". `sell-aero` guards its balance and `slot0` reads the same way.

## Verification

- **All 52 selector/address entries in `markets.mjs` verified against live Base bytecode** (PUSH4 dispatcher scan, resolving EIP-1167 clones for pools and gauges) — 52/52 present, including `getReward 0x1c4b774b` on both gauge implementations.
- `node --check` clean on all 8 files.
- `selftest.mjs`: 34/34 offline; `--live` 59/59 against Base mainnet.
- Live read-only smoke tests: `plan` on a funded wallet (all 10 gates evaluated, emitted approve + swap txs verified single-prefixed and word-aligned), `plan` on an empty wallet (balance gate fails closed, exit 1), `manage` with a dead state-file tokenId (no crash, gas fields reported), `exit finish` (record correctly parked in `recentExits`), `sell-aero` (clean no-op).