### PR TITLE
bankr: weekly sync — timed protections, granted-credit transfers, Base quote tokens

### DIFF
--- a/bankr/SKILL.md
+++ b/bankr/SKILL.md
@@ -623,7 +623,16 @@ bankr agent prompt "How many LLM credits do I have left?"
 
 The agent can also report your current LLM credit balance in conversation — including any expiring grants and when they lapse — without needing the `bankr llm credits` command.
 
-**Sending credits to another Bankr user.** Purchased credit is transferable peer-to-peer — ask the agent ("send $20 of LLM credits to @alice") or `POST /llm/credits/transfer`. The recipient must already be a Bankr user (X username or `0x` address; no ENS on this path), only purchased credit moves (grants are not transferable), the minimum is $1, and a wallet may send at most **$500 per trailing 24 hours**. Read-only API keys are refused; pass your own `transferId` so a retry can't double-send.
+**Sending credits to another Bankr user.** Credit is transferable peer-to-peer — ask the agent ("send $20 of LLM credits to @alice") or `POST /llm/credits/transfer`. The recipient must already be a Bankr user (X username or `0x` address; no ENS on this path), the minimum is $1, and a wallet may send at most **$500 per trailing 24 hours**. Read-only API keys are refused; pass your own `transferId` so a retry can't double-send.
+
+**Granted credit can be sent too, behind an opt-in.** By default only *purchased* credit moves. Set `useGrantedCredits` (the `transfer_llm_credits` tool flag, or the "use granted credits" toggle in the web Send Credits panel) to let a transfer also spend granted credit — operator grants and bonuses, including ones carrying an expiry:
+
+- **Purchased credit still spends first, and free.** Only the overflow into the granted slice carries a **10% burn fee**, charged *on top* of the amount.
+- **The recipient always receives exactly the amount you entered.** You are debited amount + fee, and the fee is burned — it isn't credited to anyone.
+- Each granted dollar is fee'd once. Concurrent sends can't double-claim the same slice, and a replayed `transferId` reports the original fee rather than charging again.
+- Leaving the flag off keeps the old behaviour byte-for-byte, so existing integrations need no change.
+
+**Two different ceilings, and the smaller one binds.** Your balance has a transferable slice (the pool net of reserve, debt and live grants), and your daily budget clamps what can move *today*. Both are exposed on `/llm/usage` — `balanceTransferableUsd` for the balance-side figure, alongside `grantedTransferableUsd` and `transferFeeBps` — so a wallet holding $265 that's temporarily gated to $10 by a rolling window can be shown as exactly that, rather than as if the money were missing. The agent quotes both figures and names which one is binding when you ask about your balance.
 
 **Daily spend budget.** You can cap what the gateway spends on your behalf, independently of your balance. The window is a **trailing 24 hours**, not a calendar day — nothing resets at midnight, capacity returns as charges age out. Over budget, spending requests return `402` with `type: daily_budget_exceeded` (distinct from `insufficient_credits`), while read-only `GET` endpoints keep working so you can poll for when you're unblocked. The same budget also ends Max Mode agent runs early.
 
@@ -736,8 +745,9 @@ Spot stocks work with swaps, transfers, limit orders, and DCA. Only issuer-token
 
 ### Token Deployment
 
-- **EVM (Base or Robinhood Chain)**: Launch ERC20 tokens via Doppler on a Uniswap V4 pool with customizable metadata and social links. Fixed **100 billion** supply. Every trade pays a **0.7% swap fee on the pool and 95% of it goes to you** (0.665% of volume, claimable anytime); the hook adds the Bankr protocol fee + BNKR buyback and LP fee on top, for **1.75% all-in**. The **0.285% LP fee is creator-side too** — it compounds as locked liquidity in your own pool, strengthening your token's liquidity on every swap, so the creator side totals **0.95% of volume**. **The default chain depends on the surface**: the CLI (`bankr launch`) and the web launch form preselect **Base**, while the AI agent and the deploy API fall back to **Robinhood Chain** when no chain is named. Name the chain explicitly (`bankr launch --chain robinhood`, `"chain": "base"`, or "launch it on Base") whenever it matters. Legacy Clanker tokens remain claimable (claims auto-detect Doppler vs Clanker).
+- **EVM (Base or Robinhood Chain)**: Launch ERC20 tokens via Doppler on a Uniswap V4 pool with customizable metadata and social links. Supply is fixed and non-mintable once deployed; standard launches use **100 billion** (the web launch flow can set a custom figure — the deploy API and CLI always use the standard supply). Ticker symbols are **1–20 characters**. Every trade pays a **0.7% swap fee on the pool and 95% of it goes to you** (0.665% of volume, claimable anytime); the hook adds the Bankr protocol fee + BNKR buyback and LP fee on top, for **1.75% all-in**. The **0.285% LP fee is creator-side too** — it compounds as locked liquidity in your own pool, strengthening your token's liquidity on every swap, so the creator side totals **0.95% of volume**. **The default chain depends on the surface**: the CLI (`bankr launch`) and the web launch form preselect **Base**, while the AI agent and the deploy API fall back to **Robinhood Chain** when no chain is named. Name the chain explicitly (`bankr launch --chain robinhood`, `"chain": "base"`, or "launch it on Base") whenever it matters. Legacy Clanker tokens remain claimable (claims auto-detect Doppler vs Clanker).
 - **Stock-paired launches** (EVM, optional): pair the new token's pool with a registry tokenized stock instead of WETH, so the token trades against equity exposure. Available on Base (B20 equities) and Robinhood Chain — pass `pairedStockAddress` to the deploy API, or ask the agent to pair the launch with a ticker. Only stocks Bankr can price are offered, since launch-curve math needs a USD price.
+- **Base quote-token launches** (optional): on Base, quote the pool in **BNKR** or **ba3Pump** (Bankr-bridged PUMP from Solana) instead of WETH — pass `chain: "base"` with the matching fixed `pairedTokenAddress`. User-key launches only; it can't be combined with `pairedStockAddress`, and omitting both gives you WETH. Volume in these pools stays eligible for the weekly developer rebate on the same terms as WETH-quoted launches.
 - **Quote-only fees** (EVM, optional): opt in at launch to collect all creator fees in the quote token (e.g. WETH) instead of a mix of the launched token and quote token — your total take is identical either way. Ask for "quote-only fees", pass `quoteOnlyFees: true` to the deploy API, or use `bankr launch --quote-only-fees`. Fixed at launch, like the fee schedule itself.
 - **Degen mode** (EVM, optional): start the token at a **$2,500 market cap** instead of the standard starting cap, for maximum early volatility. Explicit opt-in only — ask for "degen mode" by name, or pass `degenMode: true` to the deploy API. The figure is fixed; there is no custom starting market cap, a token *named* DEGEN does not opt you in, and the mode is unavailable on partner deploys.
 - **Solana**: Launch SPL tokens via Raydium LaunchLab with bonding curve and auto-migration to CPMM
@@ -805,6 +815,18 @@ Every Bankr wallet has a persistent filesystem, shared across the CLI, web termi
 
 The agent can answer questions about Bankr itself — how features work, official domains and links, the official Telegram bot, and support channels — grounded in Bankr's own documentation. When it doesn't have a confident answer it abstains rather than guessing, so you won't get fabricated links or facts. Useful for onboarding questions and for verifying that a link or channel is genuinely official.
 
+### Extending the Agent with Skills
+
+Skills work in **two directions**, and they're easy to confuse. This document is the first direction: the Bankr skill installed into *your* agent, so it can trade. The second is the reverse — installing skills **into** your Bankr agent to teach it new behaviours.
+
+- **Install by pasting a link.** A public GitHub folder URL (`tree/<branch>/<path>` containing a `SKILL.md`), a `blob/…/SKILL.md` URL, a bare repo when the skill sits at the root, or a direct `.md` file URL. Links from the [bankr.bot](https://bankr.bot) Discover and partner pages work too — both the canonical share URL and the in-app routes the UI hands out resolve to the catalogue entry.
+- **Reinstalling replaces.** A skill installed under a name that already exists overwrites it — that's the update path.
+- **Size limits**: `SKILL.md` is capped at **1 MB**, and each individual file under `references/` at **100 KB**. The agent loads a reference file's text inline on demand (up to 200 KB); binary files (images, PDFs) arrive as metadata plus a path it can hand to CLI tools.
+- **Frontmatter is optional.** A skill published in the frontmatter-less convention still installs — Bankr synthesizes the `name` from the first heading and the `description` from the opening prose, and keeps the full document as the body without truncating it.
+- **Curated skills are suggested, not silently used.** When a request has no native route but a curated skill covers it, the agent can name that skill even if you haven't installed it — so a capability gap reads as "install this" rather than a flat failure. Nothing is installed on your behalf.
+
+`bankr agent skills` lists what the agent currently has.
+
 ### Arbitrary Transactions
 
 - Submit raw EVM transactions with explicit calldata
@@ -848,13 +870,27 @@ User-controlled settings that apply to every surface — chat, agent, API, CLI. 
 | Per-transaction limit | $500 | Rejects any single tx priced above the limit |
 | Price impact limit | On (15%) | Rejects a swap whose estimated price impact exceeds the limit — guards against catastrophic fills in thin/low-liquidity pools. Adjustable 1–100% or turned off |
 | Permitted recipients | Off | Restricts transfers/swaps to an allowlist; new entries enter a configurable cooldown (default 24h) |
-| Disable arbitrary contract calls | Off | Blocks `write_contract`, raw `/wallet/submit`, and arbitrary transaction tools (named operations like swaps still work) |
+| Arbitrary contract calls | Off (blocked) | While off, blocks `write_contract`, raw `/wallet/submit`, and arbitrary transaction tools (named operations like swaps still work). Enabling is a timed opt-in — see below |
+| Response channels | All on | Per-channel control over where the agent is allowed to reply (X, Farcaster, Telegram). A disabled channel is silently skipped; account management on Telegram (`/start`, wallet linking) stays live |
 
 If USD pricing is unavailable and a limit is enabled, the transaction is **rejected** (fail-closed) rather than waved through. Your own wallet addresses are always implicitly allowed as recipients.
 
 Spend limits apply to **every** swap path, including cross-chain and Solana legs — the sell side is priced and checked before execution, and a successful swap counts toward your rolling 24h total.
 
+**The $500 defaults are real limits, not placeholders.** A wallet that has never touched its daily/per-transaction settings is enforced at $500 on *every* path — including the ones that skip the agent preflight: x402 calls, raw `/wallet/submit`, and direct signer callers. If your integration signs large transactions, raise the limit explicitly rather than assuming an unconfigured wallet is uncapped.
+
 One side effect worth knowing: the price-impact limit also fails closed on venues that can't report an impact figure. The clearest case is a brand-new Solana token still on its LaunchLab bonding curve — with the limit enabled, that fallback is refused rather than filled unguarded. Turn the limit off if you specifically need those fills.
+
+#### Timed Windows (auto-restoring)
+
+Rather than turning a protection off indefinitely, you can turn it off for a fixed window and let it restore itself. Available on the **daily limit**, **per-transaction limit**, **price impact limit**, **arbitrary contract calls**, and each **response channel**; the duration vocabulary is fixed at **10, 30, 60, or 1440 minutes**.
+
+- **A deadline only ever resolves toward the safer state.** On a protection, the timer runs while it is *off* and restores it when the window lapses. On arbitrary contract calls the framing inverts — the timer runs while calls are *enabled* and revokes them at expiry — so in both cases a lapsed deadline locks down rather than opens up.
+- **Resolution happens at read time**, not on a sweeper, so an expired window is already in effect the moment the next transaction is evaluated. There is no gap to race.
+- **Every explicit write replaces the timer.** Toggling a setting or editing its amount clears any running window, so a stale off-window can't survive a change you thought was unrelated.
+- **The window is server-computed** from the duration you pick; you can't hand the API a deadline of your own.
+
+These are web-authenticated settings like the rest of the Security screen — an API key can read the resolved state (`/user`, `/user/security`) but cannot change it. Treat "the limit is off" as a fact with an expiry attached: a long-running integration should re-read the resolved settings rather than caching what it saw at startup.
 
 ### Protected-Token Swap Guard
 
@@ -881,6 +917,8 @@ Per-key settings configured at [bankr.bot/api-keys](https://bankr.bot/api-keys):
 **IP Whitelisting**: Set `allowedIps` on your API key to restrict usage to specific IPs or CIDR ranges (e.g., `10.0.0.0/24`). Requests from non-whitelisted IPs are rejected with 403 at the auth layer.
 
 **Recipient Allowlist**: Restrict which addresses the key can send funds to. Independent from the wallet-level permitted recipients — when both are configured, both must pass.
+
+> **A recipient allowlist also disables uncontrolled-counterparty operations.** Some actions pay an address the allowlist can't be checked against — a marketplace escrow, a mint contract, a prediction-market exchange. Rather than let those slip past the restriction, Bankr refuses them outright whenever a key carries a non-empty allowlist (EVM or Solana): **Polymarket buys and sells**, **NFT purchases, mints, listings and offer acceptance**, and **airdrop tools**. The error names the action and tells you to contact the key administrator. Swaps and transfers are unaffected — their recipient *is* checkable. If your agent needs these operations, use a key without an allowlist and constrain it with spend limits instead.
 
 ### Incident Response
 
@@ -1231,6 +1269,7 @@ Venue selection is automatic and the Wallet API now covers the same edge cases t
 - **Polygon `pUSD` → `USDC.e`** uses the 1:1 on-chain Offramp unwrap rather than a DEX quote: no fee, no slippage, no price impact. Asking the agent to convert pUSD to plain "USDC" on Polygon resolves to `USDC.e` and takes this path — the request is read as the one routable thing it can mean, so the quote, the signing card, and the confirmation all name `USDC.e` rather than the pair failing to route. The reverse direction (`USDC.e` → `pUSD`) is quoted like any ordinary pair, and **buying** pUSD is untouched — the Offramp can only unwrap. The unwrap settles to your own wallet, so a **swap-and-send** naming a different recipient routes through the normal venues instead — it never silently settles to you
 - **Robinhood Chain tokenized stocks** are quoted and filled through the aggregator's RFQ makers, settling against USDG, while ordinary Robinhood Chain pairs keep their thin-pool protection
 - **Wallet-mode swaps** — where you sign from an external/connected wallet rather than a Bankr-custodied one — now walk the same venue order as every other swap, so a thin-liquidity pair reaches its direct-pool venue instead of being diverted to the bridge aggregator. Practical effects: a route that used to need an approval plus a router call can now come back as a single transaction to sign, and a leg whose build fails is reported as **failed** rather than handed to you as something to sign under a success message
+- **`/wallet/swap-quote` falls back the same way execution does.** When the primary aggregator reports no route on an EVM pair, the quote retries the bridge/swap aggregator rather than returning "No quote available". This matters most for pairs whose only pool is an exotic one — a launch pool quoted in a tokenized stock, say, which the primary aggregator will fill single-hop but won't compose *through* as an intermediate. Quote and execution now agree on what's routable, so a quote you can get is a quote you can fill
 
 ```bash
 # CLI — quote only (no execution)

--- a/bankr/references/leverage-trading.md
+++ b/bankr/references/leverage-trading.md
@@ -16,6 +16,10 @@ Two leverage platforms are available:
 **Chain**: Base
 **Protocol**: [Avantis](https://docs.avantisfi.com/)
 
+Avantis prices come from **Avantis' own price feed**, keyed by the pair — one bounded fetch, with no third-party price oracle and no on-chain read in the price path, so a slow Base RPC can't stall a quote.
+
+**Closing a position never depends on the price feed.** A close is encoded as a market close and doesn't read a price to execute — the quote is only used to render the PnL card. If pricing is unavailable, the close still goes through and the card is simply less detailed. An open position is never stranded by a pricing outage.
+
 ### Leverage Limits
 
 | Asset Class | Max Leverage |

--- a/bankr/references/llm-gateway.md
+++ b/bankr/references/llm-gateway.md
@@ -77,7 +77,8 @@ bankr config get llmKey
 | `grok-4.5` | xAI | Latest, balanced multimodal (500K context, image input) |
 | `grok-4.3` | xAI | Balanced performance (1M context) |
 | `grok-4.1-fast` | xAI | Fast, economical, largest context (2M) |
-| `deepseek-v4-pro` | DeepSeek | Long context reasoning (1M, 384K output) |
+| `deepseek-v4-pro-0813` | DeepSeek | Latest frontier, high-capacity reasoning (1M) |
+| `deepseek-v4-pro` | DeepSeek | Previous V4 Pro build, 0423 (1M, 384K output) |
 | `deepseek-v4-flash` | DeepSeek | High throughput, cost-effective (1M) |
 | `deepseek-v3.2` | DeepSeek | Cost-effective (164K context) |
 | `qwen3.7-max` | Alibaba | Latest flagship (1M) |
@@ -88,14 +89,16 @@ bankr config get llmKey
 | `qwen3.5-flash` | Alibaba | Fast, economical (1M) |
 | `qwen3-coder` | Alibaba | Code generation, debugging (262K) |
 | `kimi-k3` | Moonshot AI | Latest flagship, long-context multimodal (1M context, image input) |
-| `kimi-k2.7-code` | Moonshot AI | Code-focused long-context (262K) |
+| `kimi-k2.7-code` | Moonshot AI | Code-focused / agentic long-context (262K) |
 | `kimi-k2.6` | Moonshot AI | Long-context (262K) |
 | `kimi-k2.5` | Moonshot AI | Long-context reasoning (262K) |
 | `minimax-m3` | MiniMax | Flagship multimodal reasoning (512K context) |
 | `minimax-m2.7` | MiniMax | Balanced performance (204.8K) |
 | `minimax-m2.7-highspeed` | MiniMax | Faster variant, double throughput (204.8K) |
 | `minimax-m2.5` | MiniMax | Cost-effective (204.8K) |
-| `glm-5.2` | Z.ai | Latest, long-context reasoning (1M) |
+| `glm-5.3` | Z.ai | Latest flagship, long-context reasoning (1M) |
+| `glm-5.3-flash` | Z.ai | Efficient coding and agents (1M, image input) |
+| `glm-5.2` | Z.ai | Previous flagship, long-context reasoning (1M) |
 | `glm-5.1` | Z.ai | Advanced reasoning (202K) |
 | `glm-5` | Z.ai | General purpose reasoning (202K) |
 | `glm-5-turbo` | Z.ai | Fast, cost-effective (202K) |
@@ -247,7 +250,7 @@ Expired grants drop off automatically — there is no manual cleanup. The Credit
 
 ### Sending Credits to Another Bankr User
 
-Purchased credit is transferable peer-to-peer. Ask the agent, or call the API directly:
+Credit is transferable peer-to-peer — purchased credit by default, and granted credit behind an opt-in flag. Ask the agent, or call the API directly:
 
 ```bash
 bankr agent prompt "Send $20 of LLM credits to @alice"
@@ -268,7 +271,8 @@ The sender is debited and the recipient credited atomically — there is no pend
 | Rule | Detail |
 |------|--------|
 | **Recipient** | Must already be a Bankr user. The agent accepts an X (Twitter) username or a `0x` address; the API takes the resolved EVM address. ENS names are not supported on this path. |
-| **Only purchased credit moves** | Grant credit (promotional, developer, partner) is **not** transferable — your sendable figure is the purchased slice of your pool, minus usage that's metered but not yet deducted. |
+| **Purchased credit moves by default** | Without the opt-in below, only the purchased slice of your pool moves — minus usage that's metered but not yet deducted. |
+| **Granted credit moves on opt-in** | Set `useGrantedCredits` to also spend granted credit (promotional, developer, partner, operator grants — including ones carrying an expiry). See the burn fee below. |
 | **Minimum** | $1 per transfer. |
 | **Rolling cap** | $500 gross sent per wallet per **trailing 24 hours** (shared with the same window the daily spend budget uses). Over it, the call returns `429`. |
 | **Write scope** | Read-only API keys are refused (`403`). If the key has an `--allowed-recipients` allowlist, the recipient must be on it. |
@@ -277,7 +281,30 @@ The sender is debited and the recipient credited atomically — there is no pend
 
 Failure codes are explicit rather than generic: `self-transfer` / `amount-too-small` (`400`), `insufficient-credit` (`402`), `wallet-paused` / `recipient-not-permitted` (`403`), `recipient-invalid` (`404`), `transfer-conflict` (`409`), `daily-cap-exceeded` / `daily-budget-exceeded` (`429`).
 
-`GET /llm/usage` returns `transferableUsd` — the sendable figure, already clamped by the remaining 24h cap and by any daily spend budget — so a client can offer a "Max" the transfer endpoint won't then reject.
+#### Granted-credit transfers (opt-in, 10% burn fee)
+
+By default a transfer refuses to touch granted credit. Passing `useGrantedCredits` unlocks it — as a flag on the agent's `transfer_llm_credits` tool, or as the "use granted credits" toggle in the web Send Credits panel:
+
+- **Purchased credit still spends first, and free.** Granted credit is only reached once the purchased slice is exhausted, and only that overflow is fee'd.
+- **The fee is 10%, charged on top.** The recipient receives exactly the amount you entered; you are debited amount + fee. The fee is burned — it is credited to no one, and appears as its own transfer-fee row in your ledger.
+- **A granted dollar is fee'd once.** The granted slice is derived and stamped inside the transaction, so concurrent sends can't double-claim it, and a replayed `transferId` reports the original fee rather than charging a second one.
+- **The two funding modes never replay each other** — an opted-in transfer carries a distinct transfer id, so an opted-in retry can't collide with a default-mode send of the same nominal id.
+- **Leaving the flag off is byte-identical to the previous behaviour**, so existing integrations need no change.
+
+Success responses and the agent's balance tool carry `feeUsd`, `grantedTransferableUsd` and `transferFeeBps`, so a client can preview Fee / Recipient receives / Total deducted before sending, and solve "Max" for amount + fee rather than amount alone.
+
+#### Reading the two ceilings
+
+`GET /llm/usage` returns two different figures, and the smaller one is what actually binds:
+
+| Field | Meaning |
+|-------|---------|
+| `transferableUsd` | Today's allowance — already clamped by the remaining 24h cap and by any daily spend budget. A client can offer this as "Max" and the transfer endpoint won't reject it. |
+| `balanceTransferableUsd` | The sendable slice of the **balance itself** — the pool net of reserve, debt and live grants, *before* the cap/budget clamp. |
+| `grantedTransferableUsd` | The granted portion available when `useGrantedCredits` is set. |
+| `transferFeeBps` | The burn fee applied to the granted portion, in basis points. |
+
+Quote both figures rather than only the clamped one. A wallet holding $265 that a rolling window has temporarily gated to $10 reads as *missing money* if you show only `transferableUsd`; showing the balance alongside it, and naming the daily gate as the binding constraint, reads as a timer. The agent's credit-balance tool follows the same rule — it quotes the balance next to the allowance when a daily gate binds, and stays quiet when the structural balance is what's limiting.
 
 ### Daily Spend Budget
 

--- a/bankr/references/polymarket.md
+++ b/bankr/references/polymarket.md
@@ -131,6 +131,7 @@ If you don't have USDC on Polygon:
 | Market closed | Can't bet on closed/resolved markets |
 | Low liquidity | May get worse prices on small markets |
 | Slippage | Large bets may move price against you |
+| "not supported when trusted-recipient restrictions are configured" | The API key carries a recipient allowlist. Polymarket trades pay an exchange contract that can't be validated against it, so buys and sells are refused outright — see [safety.md](safety.md). Use a key without an allowlist for this workflow |
 
 ## Tips for Success
 

--- a/bankr/references/portfolio.md
+++ b/bankr/references/portfolio.md
@@ -70,6 +70,7 @@ All chains: Base, Polygon, Ethereum, Unichain, Solana, World Chain, Arbitrum, BN
 - **Comprehensive View**: Shows all tokens with meaningful balances
 - **Wrap/Unwrap Aware**: Wrapping and unwrapping the native token (ETH ↔ WETH and equivalents) updates both balances, so a portfolio read straight after an unwrap reflects it
 - **Exact Balances**: token `balance` is the exact decimal amount in plain notation, carried as a string — never rounded, and never in scientific notation for very small or very large holdings. If you do arithmetic on it, parse it with a decimal-safe library rather than relying on a float
+- **Partial-Failure Resilient**: the native balance and the token-list lookup are fetched independently per chain, so an indexer failure on the token side no longer takes the chain's native row down with it. A degraded chain returns the native balance it did retrieve rather than reporting the wallet as empty of it
 
 ## Common Tokens Tracked
 

--- a/bankr/references/safety.md
+++ b/bankr/references/safety.md
@@ -17,9 +17,29 @@ User-controlled wallet safety features configured at [bankr.bot](https://bankr.b
 | Per-transaction limit | $500 | Rejects any single tx priced above the limit |
 | Price impact limit | On (15%) | Rejects a swap whose estimated price impact exceeds the limit |
 | Permitted recipients | Off | Restricts transfers/swaps to an allowlist; new entries enter a configurable cooldown |
-| Disable arbitrary contract calls | Off | Blocks `write_contract`, raw `/wallet/submit`, and arbitrary transaction tools (named operations like swaps still work) |
+| Arbitrary contract calls | Off (blocked) | While off, blocks `write_contract`, raw `/wallet/submit`, and arbitrary transaction tools (named operations like swaps still work). Enabling is a timed opt-in |
+| Response channels | All on | Per-channel control over where the agent may reply — X, Farcaster, Telegram. A disabled channel is skipped silently |
 
 USD limits accept `1` to `1,000,000`. Setting `0` is rejected — disable the limit instead. Cooldown accepts `0` to `168` hours (default 24h).
+
+### Defaults Are Enforced, Everywhere
+
+A wallet that has never opened the Security page still has a **$500 daily and $500 per-transaction limit**, and those defaults are enforced on every signing path — including the ones that don't run the agent's preflight: **x402 paid calls**, **raw `/wallet/submit`**, and direct signer callers. Don't design an integration around the idea that an unconfigured wallet is uncapped; if it needs to sign above $500, raise the limit deliberately.
+
+(System-owned vesting wallets are the one exception — they have no Security screen and no user to configure them, and are governed by their signing policy's authorized-caller gate instead.)
+
+### Timed Windows (auto-restoring)
+
+Most controls can be turned off for a bounded window instead of indefinitely, after which they restore themselves. Supported on the **daily limit**, **per-transaction limit**, **price impact limit**, **arbitrary contract calls**, and each **response channel**. Durations are a fixed vocabulary: **10, 30, 60, or 1440 minutes**.
+
+| Property | Behaviour |
+|----------|-----------|
+| Direction | A deadline only ever resolves toward the **safer** state. On a protection the timer runs while it is *off* and restores it at the deadline; on arbitrary contract calls the framing inverts — the timer runs while calls are *enabled* and revokes them. Neither can turn an enabled protection off, or hold one off past its deadline. |
+| Resolution | Read-time, not swept. An expired window is already in effect at the next transaction evaluation — there is no window to race. |
+| Replacement | Every explicit write replaces the timer. Toggling a control or editing its amount clears any running window, so a stale off-window can't outlive an edit you thought was unrelated. |
+| Authority | The deadline is computed server-side from the duration you choose. A client-supplied timestamp is rejected, and a duration is only accepted on the write direction that starts a timer. |
+
+`/user` and `/user/security` expose the resolved state, so an API key can *read* whether a protection is currently off and when it returns — but not change it. Long-running integrations should re-read rather than cache what they saw at startup: "the limit is off" is a fact with an expiry attached.
 
 ### Price Impact Limit
 
@@ -49,6 +69,18 @@ The wallet-level permitted-recipients list is independent from the API-key `allo
 
 - **API-key allowlist** = where this key is allowed to send
 - **Wallet allowlist** = where this wallet is allowed to send, regardless of key
+
+### Allowlists Disable Uncontrolled-Counterparty Operations
+
+Some operations pay an address that can't be meaningfully checked against an allowlist — a marketplace escrow, a mint contract, a prediction-market exchange. Rather than let those slip past a restriction the operator deliberately configured, Bankr **refuses them outright** whenever the key carries a non-empty `allowedRecipients` list (EVM or Solana):
+
+- **Polymarket** — buying and selling shares
+- **NFTs** — purchases, Seadrop and Manifold mints, listing for sale, accepting offers, creating collection offers
+- **Airdrops** — both the general airdrop tool and the top-members variant
+
+The error names the action and points at the key administrator; it is not a transient failure and retrying won't help. Swaps and transfers are unaffected — their recipient *is* checkable, and the allowlist gates them normally.
+
+If an agent needs these operations, give it a key **without** a recipient allowlist and constrain it with spend limits, read-only scoping, or IP whitelisting instead. Trying to have both is the case this rule exists to refuse.
 
 ### Incident Response
 

--- a/bankr/references/token-deployment.md
+++ b/bankr/references/token-deployment.md
@@ -25,7 +25,7 @@ Launch SPL tokens on Solana with a bonding curve mechanism that auto-migrates to
 | Parameter | Required | Description | Example |
 |-----------|----------|-------------|---------|
 | **Name** | Yes | Token name (1-32 chars) | "MoonRocket" |
-| **Symbol** | No | Ticker (1-10 chars), defaults to name | "MOON" |
+| **Symbol** | No | Ticker (1-20 chars), defaults to name | "MOON" |
 | **Image** | No | Logo URL | "https://example.com/logo.png" |
 | **Decimals** | No | Token decimals (0-9), default 6 | 6 |
 | **Fee Recipient** | No | Wallet to receive 99.9% of creator fees | "7xKXtg..." |
@@ -197,7 +197,7 @@ Launch ERC20 tokens on Base or Robinhood Chain. New launches create a Uniswap V4
 
 | Property | Value |
 |----------|-------|
-| **Supply** | Fixed 100 billion (not mintable after deployment) |
+| **Supply** | 100 billion on standard launches; fixed and not mintable after deployment. The web launch flow accepts a custom whole-number supply (1 to 100 billion); the deploy API and CLI always launch at the standard 100 billion |
 | **Pool** | Uniswap V4 |
 | **Pool swap fee** | 0.7% per trade — **95% to the creator** |
 | **All-in swap fee** | 1.75% of volume (pool fee + hook-added legs) |
@@ -234,6 +234,21 @@ Two knock-on effects for anyone integrating against a quote-only token:
 
 Like the fee schedule, this option cannot be changed after launch.
 
+### Base Quote Tokens (optional, fixed at launch)
+
+Base launches can quote the new token's pool in **BNKR** or **ba3Pump** instead of WETH. ba3Pump is Bankr-bridged PUMP from Solana. Pass `chain: "base"` together with one of the fixed allowlisted addresses:
+
+| Quote token | `pairedTokenAddress` |
+|-------------|----------------------|
+| BNKR | `0x22af33fe49fd1fa80c7149773dde5890d3c76f3b` |
+| ba3Pump | `0x5577a294ae5a21446a11b0e4100ca83803995720` |
+
+- **User-key launches only** — not available on org Partner Key deploys.
+- **Mutually exclusive with `pairedStockAddress`.** Sending both is rejected; omit both to get WETH.
+- The allowlist is fixed — an arbitrary ERC-20 is not accepted as a quote token.
+- Volume in a BNKR- or ba3Pump-quoted pool remains eligible for the weekly developer rebate under the same rules as a WETH-quoted launch.
+- Everything else — supply, the fee schedule, creator vesting, quote-only fees, degen mode — behaves exactly as on a WETH launch. "Quote token" here just names the pool's other side.
+
 ### Degen Mode (optional, fixed at launch)
 
 Degen mode starts the token at a **$2,500 market cap** instead of the standard starting cap, so the curve's early range is far more volatile. Everything else about the launch — supply, fee schedule, curve shape, vesting — is unchanged.
@@ -254,7 +269,7 @@ Degen mode starts the token at a **$2,500 market cap** instead of the standard s
 | Parameter | Required | Description | Example |
 |-----------|----------|-------------|---------|
 | **Name** | Yes | Full token name | "My Token" |
-| **Symbol** | No | Ticker; defaults to name if omitted | "MTK" |
+| **Symbol** | No | Ticker, 1-20 characters; defaults to the first 4 characters of the name if omitted | "MTK" |
 | **Description** | No | Token description | "A community token" |
 | **Image** | No | Logo URL or upload | URL or file |
 | **Website** | No | Project website | "myproject.com" |
@@ -263,6 +278,8 @@ Degen mode starts the token at a **$2,500 market cap** instead of the standard s
 | **Fee Recipient** | No | Route creator fees to a wallet, ENS, or social handle | "@partner" |
 | **Quote-only fees** | No | Collect all creator fees in the quote token; fixed at launch | `quoteOnlyFees: true` |
 | **Degen mode** | No | Start at a $2,500 market cap; explicit opt-in, not on partner deploys | `degenMode: true` |
+| **Paired stock** | No | Quote the pool in a registry tokenized stock instead of WETH | `pairedStockAddress: "0x…"` |
+| **Paired quote token** | No | Base only — quote the pool in BNKR or ba3Pump instead of WETH; not combinable with a paired stock | `pairedTokenAddress: "0x…"` |
 
 ### Prompt Examples
 
@@ -294,6 +311,8 @@ Degen mode starts the token at a **$2,500 market cap** instead of the standard s
 | Bankr Club Members | 100 | 10 |
 
 The two limits are separate: the daily cap is how many tokens you may deploy, the sponsorship cap is how many of those Bankr pays gas for. Past the sponsorship cap you can keep deploying up to the daily cap by paying gas yourself. A deploy that fails before broadcast because of gas doesn't consume sponsorship quota, though it still counts against the daily cap.
+
+**Past the sponsorship cap, a near-empty wallet is refused up front.** An unsponsored deploy checks the wallet's native balance against a conservative per-chain floor *before* building or broadcasting anything, and returns copy explaining that sponsorship is exhausted and what to do about it — rather than spending a signer round-trip to fail on-chain with a bare "not enough native token to cover gas". The floor is deliberately low, so borderline balances still proceed to real estimation downstream; sponsored deploys skip the check entirely. If you deploy programmatically past the sponsored quota, fund the deploying wallet with gas rather than relying on the retry.
 
 A separate cross-account limit applies to fee recipients: an address may be named fee recipient on at most **20 deploys per 24 hours** across all accounts.
 

--- a/bankr/references/tokenized-stocks.md
+++ b/bankr/references/tokenized-stocks.md
@@ -62,6 +62,8 @@ Base hosts the **B20 tokenized equities** — Coinbase-issued equity tokens trad
 "sell half my META on base"
 ```
 
+**Two spellings resolve to the same token.** A B20's own on-chain `symbol()` is **c-suffixed** — `AAPLc`, `NVDAc`, `GOOGLc`, `METAc` and so on across all thirteen — which is the spelling you'll copy off a block explorer or a DEX front-end. The bare equity ticker (`AAPL`) names the underlying security and is also the canonical symbol of the separate **Robinhood Chain** listing. Both spellings resolve: the c-suffixed form identifies the Base B20 token specifically, while a bare ticker leaves the venue choice to Bankr's resolution. Prefer the c-suffixed symbol when you have it and mean the Base token — it's unambiguous, and it keeps the query out of pool-indexed search, where a memecoin on a near-identical ticker can outrank the genuine equity pool.
+
 B20 is an ERC-20 extension: transfers and approvals behave normally, but the redemption ratio to the underlying share is an **on-chain multiplier** that moves on corporate actions (splits, dividends), and issuer policy can block transfers. Token price = the underlying equity's price × that multiplier, so Bankr prices these off the equity rather than off pool liquidity — a B20 is quotable before any Base liquidity exists. They are 8-decimal tokens (Robinhood stocks are 18-decimal), which matters if you're reading raw amounts from the API rather than the formatted figures.
 
 **Base B20 trades are behind the same location verification as Robinhood stocks** — same site-visit verdict, same blocked-country list, same 30-day expiry, and the same fail-closed behaviour. Everything else on Base is ungated.


### PR DESCRIPTION
Weekly sync of the `bankr` skill against the platform's shipped behaviour.

Two categories below: capabilities that landed this week, and gaps in already-shipped behaviour that the sync surfaced. They're separated because the second group isn't news — it's documentation debt being paid down.

## Shipped this week

**Safety controls**

- **Timed, auto-restoring windows.** The daily limit, per-transaction limit, price-impact limit, arbitrary contract calls and each response channel can now be turned off for a bounded window (10 / 30 / 60 / 1440 minutes) instead of indefinitely. Documented the properties that actually matter to an integrator: a deadline only ever resolves toward the safer state, resolution is read-time so there's no window to race, every explicit write replaces the running timer, and the deadline is server-computed rather than client-supplied.
- **Arbitrary contract calls reframed.** The control flipped from "disable" to a timed *enable* with an expiry. The table row and the surrounding prose were written around the old framing.
- **The $500 defaults are enforced everywhere now.** Previously some signing paths — x402 calls, raw submit, direct signer callers — didn't apply the resolved default cap. They do now, so an unconfigured wallet is genuinely capped at $500 rather than effectively uncapped on those routes. Called out explicitly, since an integration signing above that threshold has to raise the limit deliberately.
- **Response channels** added to the wallet-security table (per-channel control over where the agent may reply).

**LLM credits**

- **Corrected a claim that is now false.** The skill said grants are not transferable. Granted credit can now be sent behind an opt-in flag, with a 10% burn fee on the granted portion only — purchased credit still spends first and free, the recipient receives exactly the entered amount, and the fee is burned rather than credited to anyone. Documented the charge-once and replay semantics alongside it.
- **Two ceilings, and the smaller one binds.** The balance-side transferable figure is now exposed separately from the daily-clamped one, so a wallet that's temporarily gated by a rolling window can be shown as gated rather than as missing money. Added the field table and the guidance to quote both.

**Token launches**

- **Base quote-token launches** — pools can be quoted in BNKR or ba3Pump instead of WETH, with a fixed address allowlist, user-key only, mutually exclusive with a paired stock. New reference section plus the deployment-parameter rows.
- **Supply is no longer flatly "fixed 100 billion"** — the web launch flow accepts a custom figure; the API and CLI still launch at the standard supply. Corrected in both places that asserted the old wording.
- **Symbols widened to 1–20 characters** (was 1–10 in two tables).
- **Unsponsored deploys pre-flight gas** against a per-chain floor before building or broadcasting, returning actionable copy instead of an on-chain gas failure.

**Other capability changes**

- New gateway models in the model tables: `glm-5.3`, `glm-5.3-flash`, `deepseek-v4-pro-0813`; `deepseek-v4-pro` relabelled as the previous build.
- **Polymarket is refused under a recipient allowlist** — the exchange counterparty can't be validated against one.
- **B20 equities resolve by their c-suffixed on-chain symbol** (`AAPLc`, `NVDAc`, …) as well as the bare ticker. Worth documenting because the c-form is what users copy off explorers and DEX front-ends, and it's the unambiguous one.
- **Avantis** prices from its own feed, and closing a position no longer depends on the price path at all — an open position can't be stranded by a pricing outage.
- **Quote-side routing fallback**, so a quote and an execution now agree on what's routable instead of the quote failing on pairs execution would have filled.
- **Portfolio native balances survive a partial token-indexer failure** — a degraded chain returns the native row it did retrieve rather than reporting the wallet empty of it.

## Gaps caught while syncing

Pre-existing behaviour that was never documented, found while checking the above:

- **Recipient allowlists also disable NFT and airdrop operations**, not just Polymarket. Same reason — an escrow or mint contract isn't checkable against an allowlist. This has been true for a while and was undocumented; anyone hitting it saw only the runtime error. Now listed in full, with the guidance to constrain such a key with spend limits instead.
- **No coverage of installing skills into the Bankr agent.** The skill documents one direction only (Bankr installed into another agent). Added a short section for the reverse: which link shapes resolve, that reinstalling replaces, the size limits, that frontmatter is optional, and that curated skills are suggested rather than silently installed.

## Verification

- Every capability claim checked against current platform behaviour rather than restated from the previous sync; the two corrections above (grant transferability, fixed supply) came out of that check.
- `SKILL.md` and each reference file are within the enforced size caps.
- No changes to `catalog.json` or the frontmatter — install path and discovery description are unchanged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XDyLqV1SBEoqxeQZ4nANqr)_