### PR TITLE
bankr: weekly sync — Arbitrum launches, five Base quote tokens, universal launch quota, Merkl rewards

### DIFF
--- a/bankr/SKILL.md
+++ b/bankr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bankr
-description: AI-powered crypto trading agent, wallet API, and LLM gateway via natural language. Use when the user wants to trade crypto, trade tokenized stocks and ETFs (spot or leveraged), check portfolio balances (with PnL and NFTs), view token prices, search tokens, research token holders, transfer crypto, manage NFTs, use leverage (Hyperliquid or Avantis), bet on Polymarket, deploy tokens, set up automated trading, sign and submit raw transactions, call or deploy x402 paid API endpoints, browse the web, store and query files on their wallet's filesystem, or access LLM models through the Bankr LLM gateway funded by your Bankr wallet — including zero-data-retention and TEE-private inference tiers, plus topping up and sending LLM credits to another Bankr user. Supports Base, Ethereum, Polygon, Solana, Unichain, World Chain, Arbitrum, BNB Chain, and Robinhood Chain.
+description: AI-powered crypto trading agent, wallet API, and LLM gateway via natural language. Use when the user wants to trade crypto, trade tokenized stocks and ETFs (spot or leveraged), check portfolio balances (with PnL and NFTs), view token prices, search tokens, research token holders, transfer crypto, manage NFTs, use leverage (Hyperliquid or Avantis), bet on Polymarket, deploy tokens, check and claim onchain incentive rewards (Merkl), set up automated trading, sign and submit raw transactions, call or deploy x402 paid API endpoints, browse the web, store and query files on their wallet's filesystem, or access LLM models through the Bankr LLM gateway funded by your Bankr wallet — including zero-data-retention and TEE-private inference tiers, plus topping up and sending LLM credits to another Bankr user. Supports Base, Ethereum, Polygon, Solana, Unichain, World Chain, Arbitrum, BNB Chain, and Robinhood Chain.
 metadata:
   {
     "clawdbot":
@@ -355,12 +355,13 @@ Pricing is $20/mo or $198/yr USD-equivalent. Actual on-chain amount depends on t
 | Terminal messages | 5/day | Unlimited |
 | Agent API requests | 100/day | 1,000/day |
 | Concurrent recurring agent-command automations | — | Up to 20 |
-| Gas-sponsored token deploys | 3/day | 10/day |
-| Token deploys | 50/day | 100/day |
+| Token launches | 3 per rolling 24h | 3 per rolling 24h — **Club does not raise this** |
 | File storage | 1 GB (10 MB/file) | 10 GB (50 MB/file) |
 | Monthly file downloads | 10 GB | 100 GB |
 | Model routing | Standard | Top-tier models |
 | Browser sessions, advanced research (Bankr score, PnL & volume analytics, web search, social sentiment) | — | Included |
+
+The launch cap is the one perk row that is deliberately flat: every Bankr wallet — Standard, Club, partner organization, provisioned partner — gets the same 3 counted launch attempts per rolling 24 hours. See [Token Deployment](#token-deployment).
 
 **Max Mode is the alternative to a subscription** — pay per request from LLM credits for unlimited terminal messages, and it works with external/connected wallets, which Club checkout does not (Club requires an embedded Bankr wallet). On the Agent API, non-Club Max Mode is still capped at 100 requests/day. Holding a legacy Bankr Club NFT does **not** grant membership; it was a commemorative token for the first 1,000 subscribers.
 
@@ -581,7 +582,7 @@ bankr llm models --zdr                                   # which models have a Z
 
 ### Max Mode — Pick the Agent's Model
 
-Max Mode overrides the Bankr agent's default model with any model from the gateway, billed per token from your **LLM credit balance** (not your trading wallet):
+Max Mode overrides the Bankr agent's default model (currently **Gemini 3.8 Flash**) with any model from the gateway, billed per token from your **LLM credit balance** (not your trading wallet):
 
 ```bash
 bankr agent "analyze my portfolio" --model claude-opus-5     # or -m
@@ -632,7 +633,9 @@ The agent can also report your current LLM credit balance in conversation — in
 - Each granted dollar is fee'd once. Concurrent sends can't double-claim the same slice, and a replayed `transferId` reports the original fee rather than charging again.
 - Leaving the flag off keeps the old behaviour byte-for-byte, so existing integrations need no change.
 
-**Two different ceilings, and the smaller one binds.** Your balance has a transferable slice (the pool net of reserve, debt and live grants), and your daily budget clamps what can move *today*. Both are exposed on `/llm/usage` — `balanceTransferableUsd` for the balance-side figure, alongside `grantedTransferableUsd` and `transferFeeBps` — so a wallet holding $265 that's temporarily gated to $10 by a rolling window can be shown as exactly that, rather than as if the money were missing. The agent quotes both figures and names which one is binding when you ask about your balance.
+**Two different ceilings, and the smaller one binds.** Your balance limits what you *own*; your daily spend budget clamps what can move *today*. `GET /llm/credits/state` is the canonical read for both — `creditBalanceUsd` (purchased pool), `creditGrantsUsd` and `creditGrants[]` (live grants with their expiries), `totalCreditsUsd`, and a `dailyBudget` object (`limitUsd`, `spentUsd`, `remainingUsd`; `limitUsd: null` means uncapped). So a wallet holding $265 that's temporarily gated to $10 by a rolling window reads as exactly that, rather than as if the money were missing. The agent quotes both figures and names which one is binding when you ask about your balance.
+
+> **Endpoint split:** `GET /llm/usage` is **usage-only** — token counts and spend over a historical window. It no longer carries credit-balance or transferable fields; read credit state from `GET /llm/credits/state`. Over the daily transfer cap, `POST /llm/credits/transfer` returns `429`.
 
 **Daily spend budget.** You can cap what the gateway spends on your behalf, independently of your balance. The window is a **trailing 24 hours**, not a calendar day — nothing resets at midnight, capacity returns as charges age out. Over budget, spending requests return `402` with `type: daily_budget_exceeded` (distinct from `insufficient_credits`), while read-only `GET` endpoints keep working so you can poll for when you're unblocked. The same budget also ends Max Mode agent runs early.
 
@@ -700,12 +703,29 @@ For full details — setup paths, model list, provider config, SDK examples, key
 - Browse and search collections
 - View floor prices and listings
 - Purchase NFTs via OpenSea — including listings priced in an **ERC-20** rather than the native token (e.g. USDG on Robinhood Chain). The token approval, the payment-currency balance check, and decimals-aware pricing are all handled for you
+- **Floor buys survive a snipe.** Asking for "the cheapest X" without naming a token ID now walks the candidate listings: if the one Bankr picked is filled by someone else mid-purchase (or the order goes invalid, or the signer's simulation reverts), it moves to the next-cheapest listing instead of failing the whole request — up to three purchase attempts, and the reply names the substitution so it's never silent. Naming an explicit token ID stays a single attempt, by design
 - Accept offers on NFTs you own
 - View your NFT portfolio
 - Transfer NFTs
 - Mint from supported platforms
 
 **Reference**: [references/nft-operations.md](references/nft-operations.md)
+
+### Onchain Reward Campaigns (Merkl)
+
+The agent can read and claim **Merkl** incentive rewards — the campaign rewards protocols distribute to liquidity providers and holders — on **Base** and **Robinhood Chain**:
+
+- **Check** what a wallet has earned and what's currently claimable, per chain, with USD totals. Only your own wallet address is accepted
+- **Claim** the claimable rewards on one chain in a single transaction. Claiming signs from your embedded Bankr wallet, so it isn't available in wallet mode (external/connected wallets)
+- **Discover earn opportunities** — live Merkl campaigns ranked by APR, with TVL, daily rewards, protocol and deposit link; optionally filtered to a token symbol
+
+```bash
+bankr agent prompt "Do I have any Merkl rewards to claim?"
+bankr agent prompt "Claim my Merkl rewards on base"
+bankr agent prompt "What are the best Merkl earn opportunities for USDC on base?"
+```
+
+Campaign availability and eligibility change over time — ask the agent for the live picture rather than assuming a campaign is still running.
 
 ### Polymarket Betting
 
@@ -723,6 +743,7 @@ For full details — setup paths, model list, provider config, SDK examples, key
 - **Avantis** (secondary) — Perpetuals on Base for crypto, equities (NVDA, TSLA, AAPL, HOOD, and more), forex, and commodities. Equity, forex, and commodity pairs trade during their underlying market hours only.
 - Stop loss, take profit, and position management on both platforms
 - Funding Hyperliquid is a **venue** deposit/withdraw, not a bridge: a deposit only reaches Hyperliquid, a withdrawal only lands on Arbitrum. Name the venue ("deposit $500 to hyperliquid") rather than saying "bridge"; to move withdrawn funds onward, chain a cross-chain swap after the withdrawal
+- **Closing a Hyperliquid position always reports its PnL**, derived from the price the close was quoted at — the fill price when it filled, the limit price while it rests, the mid as a fallback — and a partial fill is flagged as such rather than reported as a full close. Transient venue rate limits (429s) are retried with backoff instead of surfacing as a failed order
 - Hyperliquid charges a **1 USDC withdrawal fee, taken out of the requested amount** — so your full withdrawable balance is requestable (you receive amount − 1), and withdrawals under $1 are refused rather than netting to zero
 
 **Reference**: [references/leverage-trading.md](references/leverage-trading.md) | [references/hyperliquid.md](references/hyperliquid.md)
@@ -745,9 +766,11 @@ Spot stocks work with swaps, transfers, limit orders, and DCA. Only issuer-token
 
 ### Token Deployment
 
-- **EVM (Base or Robinhood Chain)**: Launch ERC20 tokens via Doppler on a Uniswap V4 pool with customizable metadata and social links. Supply is fixed and non-mintable once deployed; standard launches use **100 billion** (the web launch flow can set a custom figure — the deploy API and CLI always use the standard supply). Ticker symbols are **1–20 characters**. Every trade pays a **0.7% swap fee on the pool and 95% of it goes to you** (0.665% of volume, claimable anytime); the hook adds the Bankr protocol fee + BNKR buyback and LP fee on top, for **1.75% all-in**. The **0.285% LP fee is creator-side too** — it compounds as locked liquidity in your own pool, strengthening your token's liquidity on every swap, so the creator side totals **0.95% of volume**. **The default chain depends on the surface**: the CLI (`bankr launch`) and the web launch form preselect **Base**, while the AI agent and the deploy API fall back to **Robinhood Chain** when no chain is named. Name the chain explicitly (`bankr launch --chain robinhood`, `"chain": "base"`, or "launch it on Base") whenever it matters. Legacy Clanker tokens remain claimable (claims auto-detect Doppler vs Clanker).
-- **Stock-paired launches** (EVM, optional): pair the new token's pool with a registry tokenized stock instead of WETH, so the token trades against equity exposure. Available on Base (B20 equities) and Robinhood Chain — pass `pairedStockAddress` to the deploy API, or ask the agent to pair the launch with a ticker. Only stocks Bankr can price are offered, since launch-curve math needs a USD price.
-- **Base quote-token launches** (optional): on Base, quote the pool in **BNKR** or **ba3Pump** (Bankr-bridged PUMP from Solana) instead of WETH — pass `chain: "base"` with the matching fixed `pairedTokenAddress`. User-key launches only; it can't be combined with `pairedStockAddress`, and omitting both gives you WETH. Volume in these pools stays eligible for the weekly developer rebate on the same terms as WETH-quoted launches.
+- **EVM (Base, Robinhood Chain, or Arbitrum One)**: Launch ERC20 tokens via Doppler on a Uniswap V4 pool with customizable metadata and social links. Supply is fixed and non-mintable once deployed; standard launches use **100 billion** (the web launch flow can set a custom figure — the deploy API and CLI always use the standard supply). Ticker symbols are **1–20 characters**. Every trade pays a **0.7% swap fee on the pool and 95% of it goes to you** (0.665% of volume, claimable anytime); the hook adds the Bankr protocol fee + BNKR buyback and LP fee on top, for **1.75% all-in**. The **0.285% LP fee is creator-side too** — it compounds as locked liquidity in your own pool, strengthening your token's liquidity on every swap, so the creator side totals **0.95% of volume**. **The default chain depends on the surface**: the CLI (`bankr launch`) and the web launch form preselect **Base**, while the AI agent and the deploy API fall back to **Robinhood Chain** when no chain is named. Name the chain explicitly (`bankr launch --chain robinhood`, `"chain": "base"`, or "launch it on Base") whenever it matters. Legacy Clanker tokens remain claimable (claims auto-detect Doppler vs Clanker).
+- **Arbitrum One launches** (`chain: "arbitrum"`, `bankr launch --chain arbitrum`, or "launch it on Arbitrum") are **WETH-paired only** — neither `pairedStockAddress` nor `pairedTokenAddress` is accepted there — and the launch wallet pays its own network gas (Bankr sponsors retail launch gas on Base only). Everything else — supply, fee schedule, creator vesting, quote-only fees, degen mode — behaves as on Base.
+- **Stock-paired launches** (Base and Robinhood Chain, optional): pair the new token's pool with a registry tokenized stock instead of WETH, so the token trades against equity exposure. Available on Base (B20 equities) and Robinhood Chain — pass `pairedStockAddress` to the deploy API, or ask the agent to pair the launch with a ticker. Only stocks Bankr can price are offered, since launch-curve math needs a USD price. Not available on Arbitrum.
+- **Base quote-token launches** (optional): on Base, quote the pool in one of **five fixed tokens** instead of WETH — **BNKR**, **ba3Pump** (Bankr-bridged PUMP from Solana), **cbHYPE** (Coinbase-wrapped HYPE), **cbZEC** (Coinbase-wrapped ZEC), or **TAO** (Bittensor on Base). Pass `chain: "base"` with the matching fixed `pairedTokenAddress`. User-key launches only; it can't be combined with `pairedStockAddress`, and omitting both gives you WETH. Volume in these pools stays eligible for the weekly developer rebate on the same terms as WETH-quoted launches. cbHYPE and cbZEC additionally wait on reviewed on-chain quote-token liquidity — if Bankr reports the pair isn't ready, that's a real refusal, not a fallback to WETH. The list is allowlisted by address; an arbitrary ERC-20 is never accepted as a quote token.
+- **Creator vesting is on by default on EVM**: every non-partner launch premints **15% of supply to the fee recipient** and vests it over **1 year with a 30-day cliff** (the cliff sits inside the year, not on top of it); the other 85% seeds the pool. Turn it off at launch — "deploy with no vesting", `disableVesting: true`, or `bankr launch --no-vesting` — and 100% of supply goes into the pool instead. There is no custom percentage or schedule; the recipient is fixed at launch and transferring fee rights later does **not** move the allocation. Vested tokens are claimable once the cliff passes: `GET /token-launches/{tokenAddress}/vesting` reads the public schedule and position (phase, claimable, locked, unlocked %), and the claim runs from the token page or the API.
 - **Quote-only fees** (EVM, optional): opt in at launch to collect all creator fees in the quote token (e.g. WETH) instead of a mix of the launched token and quote token — your total take is identical either way. Ask for "quote-only fees", pass `quoteOnlyFees: true` to the deploy API, or use `bankr launch --quote-only-fees`. Fixed at launch, like the fee schedule itself.
 - **Degen mode** (EVM, optional): start the token at a **$2,500 market cap** instead of the standard starting cap, for maximum early volatility. Explicit opt-in only — ask for "degen mode" by name, or pass `degenMode: true` to the deploy API. The figure is fixed; there is no custom starting market cap, a token *named* DEGEN does not opt you in, and the mode is unavailable on partner deploys.
 - **Solana**: Launch SPL tokens via Raydium LaunchLab with bonding curve and auto-migration to CPMM
@@ -756,8 +779,26 @@ Spot stocks work with swaps, transfers, limit orders, and DCA. Only issuer-token
 - Optional fee recipient designation with 99.9%/0.1% split (Solana)
 - Both creator AND fee recipient can claim bonding curve fees (gas sponsored)
 - Optional vesting parameters (Solana)
-- Base launch limits: 50/day standard, 100/day Bankr Club (gas sponsored within limits)
 - Tokens deployed through Bankr are always visible in your portfolio, even without market price data
+
+**EVM launch limits and eligibility** — code these into any programmatic deploy flow:
+
+| Rule | Value |
+|------|-------|
+| Counted launch attempts | **3 per Bankr wallet per rolling 24 hours** — identical for Standard, Bankr Club, partner organization and provisioned partner wallets |
+| Launch rate | At most **one token per minute** |
+| Launch-wallet age | Wallet must be **≥ 24 hours old** (measured from when Bankr created it, not from your X/social account's age) |
+| Launch-wallet balance | Must hold **≥ 0.002 native ETH on the launch chain** — required even on Base, where deploy gas is sponsored |
+| Same name, per account | 3 launches of the same token name per hour → `429` |
+| Same name, all accounts | 10 launches of the same name per hour → `429` |
+| Per fee-recipient address | 20 launches per 24 hours across *all* accounts → `429` |
+
+- **Only launches that actually went out consume budget.** Quota is reserved just before metadata pinning, and an attempt Bankr can prove never reached the chain hands its slot — and its name/fee-recipient allowance — back. Anything that was broadcast, or that Bankr can't prove wasn't, keeps counting: the classification fails safe, so never assume a failed deploy was free.
+- Validation, resolution and pricing failures before that reservation point never consume a slot, and **simulations don't either** (`--simulate` / `simulateOnly`). Retail simulations still require the 24h-old wallet; the balance minimum is skipped.
+- Validated partner-organization and provisioned-wallet launch paths are exempt from the wallet age and balance requirements, but not from the 3-per-24h cap.
+- **Gas sponsorship for retail launches is Base-only.** On Robinhood Chain and Arbitrum the launch wallet pays its own gas. Across every sponsored path a wallet gets at most **10 sponsored transactions and $3 of gas per day** — whichever runs out first ends sponsorship until the window resets.
+- **Five-minute balance cap**: for the first five minutes after a non-partner launch, no wallet may hold more than **2% of total supply** — a buy or transfer that would push a recipient over 2% fails until the cap expires. This is separate from the ~10-second anti-snipe fee decay, which changes the fee rather than the balance. Partner launches are exempt, and the expiry is encoded on-chain at launch.
+- Sustained high-volume deploying can trip automated spam protection; repeatedly breaching the one-per-minute limit on the X path restricts the account for 24 hours (a limited state — login, balances and withdrawals still work).
 
 **Reference**: [references/token-deployment.md](references/token-deployment.md)
 
@@ -847,11 +888,13 @@ Skills work in **two directions**, and they're easy to confuse. This document is
 | Solana      | SOL          | High-speed trading            | Minimal  |
 | Unichain    | ETH          | Newer L2 option               | Very Low |
 | World Chain | ETH          | Uniswap V3/V4 swaps          | Very Low |
-| Arbitrum    | ETH          | DeFi, low-cost transactions   | Very Low |
+| Arbitrum    | ETH          | DeFi, low-cost transactions, token launches (WETH-paired) | Very Low |
 | BNB Chain   | BNB          | BSC ecosystem trading         | Low      |
 | Robinhood Chain | ETH      | Tokenized stocks & ETFs (USDG), memecoins, token launches | Very Low |
 
 **Robinhood Chain** is an EVM L2 (chainId `4663`) whose native stablecoin is **USDG** (Global Dollar). It hosts 200 Robinhood-issued tokenized stocks and ETFs alongside memecoins, and supports Bankr token launches (Doppler). Tokenized-stock trades require location verification (see [Tokenized Stock Trading](#tokenized-stock-trading)); memecoin swaps, token launches, bridging, and transfers do not.
+
+**Arbitrum One** is a Doppler launch chain as well as a trading chain. Launches there are WETH-paired only and are **not** gas-sponsored — fund the launch wallet with ETH on Arbitrum before deploying.
 
 **Base** additionally hosts the **B20 tokenized equities** — Coinbase-issued, 8-decimal equity tokens whose redemption ratio to the underlying share is an on-chain multiplier that moves on corporate actions. Trading them is gated by the same location verification as Robinhood stocks; everything else on Base is not.
 
@@ -925,9 +968,10 @@ Per-key settings configured at [bankr.bot/api-keys](https://bankr.bot/api-keys):
 If you suspect a key is compromised:
 
 1. **Pause** the wallet at [bankr.bot](https://bankr.bot) → Security — halts every outbound transaction immediately
-2. **Revoke** the key at [bankr.bot/api-keys](https://bankr.bot/api-keys)
-3. **Rotate** — generate a new key and update deployments
-4. **Audit** — review recent transactions and agent job history before unpausing
+2. **Sign out of all sessions** — the Active sessions panel under Security has a **Sign out of all** action that revokes every live session at once, the device you're on included. Use it when you suspect the account itself (not just a key) is compromised
+3. **Revoke** the key at [bankr.bot/api-keys](https://bankr.bot/api-keys)
+4. **Rotate** — generate a new key and update deployments
+5. **Audit** — review recent transactions and agent job history before unpausing
 
 ### General
 
@@ -1203,12 +1247,24 @@ See [references/safety.md](references/safety.md) for comprehensive safety guidan
 - "Claim my fee NFT for ROCKET" (post-migration)
 - "Transfer fees for MOON to 7xKXtg..."
 
-**EVM (Base & Robinhood Chain, via Doppler):**
+**EVM (Base, Robinhood Chain & Arbitrum, via Doppler):**
 
 - "Deploy a token called BankrFan with symbol BFAN on Base"
+- "Launch MOON on Arbitrum" (WETH-paired only; the wallet pays its own gas)
 - "Launch a token with quote-only fees" (all creator fees collected in the quote token)
 - "Launch MOON in degen mode" (starts at a $2,500 market cap)
+- "Launch FROG on Base paired with TAO" (also BNKR, ba3Pump, cbHYPE, cbZEC)
+- "Launch a token with no vesting" (skips the default 15% creator allocation)
+- "How much of my MTK allocation has vested?"
+- "Claim my vested MTK"
 - "Claim fees for my token MTK"
+
+### Onchain Rewards
+
+- "Do I have any Merkl rewards to claim?"
+- "Claim my Merkl rewards on base"
+- "Show Merkl earn opportunities on base"
+- "What's the best APR on Merkl for USDC?"
 
 ### LLM Credits
 

--- a/bankr/references/hyperliquid.md
+++ b/bankr/references/hyperliquid.md
@@ -63,6 +63,8 @@ Perps trading requires USDC in the perps account. Bankr auto-transfers from spot
 - "Close 50% of my ETH position"
 - "Close all my hyperliquid positions"
 
+A close always reports the position's realised PnL and ROE, derived from the price the close was quoted at — the fill price when the order filled, the limit price while it's still resting, the mid as a fallback — and sized on the amount actually filled. A **partial** fill is flagged as such rather than reported as a full close, so don't treat a close reply as proof the position is flat. Transient venue rate limits (`429`) are retried with backoff rather than surfacing as a failed order.
+
 **Manage leverage and margin:**
 - "Set my BTC leverage to 20x"
 - "Change ETH leverage to 5x isolated"

--- a/bankr/references/llm-gateway.md
+++ b/bankr/references/llm-gateway.md
@@ -40,7 +40,8 @@ bankr config get llmKey
 
 | Model | Provider | Best For |
 |-------|----------|----------|
-| `claude-fable-5` | Anthropic | Latest generation, agentic + multimodal (1M context, image input) |
+| `claude-fable-5.1` | Anthropic | Most powerful Claude — long-running autonomous work (1M context, image input) |
+| `claude-fable-5` | Anthropic | Previous-generation Fable, agentic + multimodal (1M context, image input) |
 | `claude-opus-5` | Anthropic | Latest Opus, most capable reasoning (1M context, image input) |
 | `claude-opus-4.8` | Anthropic | Previous flagship Opus (1M context) |
 | `claude-opus-4.7` | Anthropic | Advanced reasoning (1M context) |
@@ -50,13 +51,14 @@ bankr config get llmKey
 | `claude-sonnet-4.6` | Anthropic | Previous generation Sonnet (1M context) |
 | `claude-sonnet-4.5` | Anthropic | Earlier Sonnet (1M context) |
 | `claude-haiku-4.5` | Anthropic | Fast, cost-effective (200K context) |
-| `gemini-3.7-flash` | Google | Latest Flash — the Bankr agent's default model (1M, image input) |
-| `gemini-3.6-flash` | Google | Previous Flash, coding and agents (1M, image input) |
+| `gemini-3.8-flash` | Google | Latest Flash — **the Bankr agent's default model** (1M, image input) |
+| `gemini-3.7-flash` | Google | Previous Flash, coding and agents (1M, image input) |
+| `gemini-3.6-flash` | Google | Fast, cost-effective multimodal (1M, image input) |
 | `gemini-3.5-flash` | Google | Fast general-purpose (1M) |
 | `gemini-3.5-flash-lite` | Google | Ultra-fast, lowest cost (1M) |
 | `gemini-3.1-pro` | Google | Long context, reasoning (1M) |
 | `gemini-3.1-flash-lite` | Google | Ultra-fast, lowest cost (1M) |
-| `gemini-3-pro` | Google | Previous-gen Pro, long context (1M) |
+| ~~`gemini-3-pro`~~ | Google | **Deprecated** — use `gemini-3.1-pro` |
 | `gemini-3-flash` | Google | High throughput (1M) |
 | `gemini-2.5-pro` | Google | Long context, multimodal |
 | `gemini-2.5-flash` | Google | Speed, high throughput |
@@ -81,9 +83,11 @@ bankr config get llmKey
 | `deepseek-v4-pro` | DeepSeek | Previous V4 Pro build, 0423 (1M, 384K output) |
 | `deepseek-v4-flash` | DeepSeek | High throughput, cost-effective (1M) |
 | `deepseek-v3.2` | DeepSeek | Cost-effective (164K context) |
-| `qwen3.7-max` | Alibaba | Latest flagship (1M) |
-| `qwen3.7-plus` | Alibaba | Latest, long-context reasoning (1M) |
-| `qwen3.7-flash` | Alibaba | Latest fast tier, economical (1M, image input) |
+| `qwen3.8-max` | Alibaba | Flagship Qwen, multimodal (1M, image input) |
+| `qwen3.8-flash` | Alibaba | Latest fast tier, multimodal (1M, image input) |
+| `qwen3.7-max` | Alibaba | Previous flagship, reasoning (1M) |
+| `qwen3.7-plus` | Alibaba | Agentic reasoning, lower cost (1M) |
+| `qwen3.7-flash` | Alibaba | Previous fast tier, vision (1M, image input) |
 | `qwen3.6-flash` | Alibaba | Fast, economical (1M) |
 | `qwen3.5-plus` | Alibaba | Long-context reasoning (1M) |
 | `qwen3.5-flash` | Alibaba | Fast, economical (1M) |
@@ -181,7 +185,7 @@ Only a **trailing** tier token counts as the opt-in, so unrelated model IDs cont
 
 ### Max Mode — Choose the Agent's Model
 
-Max Mode replaces the Bankr agent's default model (`gemini-3.7-flash`) with any gateway model, billed per token from your **LLM credit balance**. It's the pay-per-use alternative to a Bankr Club subscription for unlimited terminal messages, and unlike Club checkout it works with external/connected wallets.
+Max Mode replaces the Bankr agent's default model (`gemini-3.8-flash`) with any gateway model, billed per token from your **LLM credit balance**. It's the pay-per-use alternative to a Bankr Club subscription for unlimited terminal messages, and unlike Club checkout it works with external/connected wallets.
 
 ```bash
 bankr agent "analyze my portfolio" --model claude-opus-5
@@ -246,7 +250,7 @@ spendable = permanent pool + Σ (remaining of each grant where expiry > now)
 spend order = expiring grants first (soonest-expiring), then the permanent pool
 ```
 
-Expired grants drop off automatically — there is no manual cleanup. The Credits page and `/llm/usage` show a breakdown of your permanent pool vs. each grant and its expiry, and your credit history labels grant rows.
+Expired grants drop off automatically — there is no manual cleanup. The Credits page and `GET /llm/credits/state` show a breakdown of your permanent pool vs. each grant and its expiry, and your credit history labels grant rows.
 
 ### Sending Credits to Another Bankr User
 
@@ -291,20 +295,27 @@ By default a transfer refuses to touch granted credit. Passing `useGrantedCredit
 - **The two funding modes never replay each other** — an opted-in transfer carries a distinct transfer id, so an opted-in retry can't collide with a default-mode send of the same nominal id.
 - **Leaving the flag off is byte-identical to the previous behaviour**, so existing integrations need no change.
 
-Success responses and the agent's balance tool carry `feeUsd`, `grantedTransferableUsd` and `transferFeeBps`, so a client can preview Fee / Recipient receives / Total deducted before sending, and solve "Max" for amount + fee rather than amount alone.
+A successful transfer response carries `feeUsd`, so a client can show Fee / Recipient receives / Total deducted after the fact. The fee rate itself is fixed at 10% (1000 bps), so a "Max" solve for amount + fee can be computed client-side rather than read from the response.
 
-#### Reading the two ceilings
+#### Reading credit state
 
-`GET /llm/usage` returns two different figures, and the smaller one is what actually binds:
+**`GET /llm/credits/state` is the canonical read for what a wallet owns and what it may spend today.** (`GET /llm/usage` is *usage-only* — token counts and spend over a historical window; it no longer carries balance or transferable fields.)
 
 | Field | Meaning |
 |-------|---------|
-| `transferableUsd` | Today's allowance — already clamped by the remaining 24h cap and by any daily spend budget. A client can offer this as "Max" and the transfer endpoint won't reject it. |
-| `balanceTransferableUsd` | The sendable slice of the **balance itself** — the pool net of reserve, debt and live grants, *before* the cap/budget clamp. |
-| `grantedTransferableUsd` | The granted portion available when `useGrantedCredits` is set. |
-| `transferFeeBps` | The burn fee applied to the granted portion, in basis points. |
+| `creditBalanceUsd` | The permanent, purchased pool. |
+| `creditGrantsUsd` | Total remaining across all live grants. |
+| `totalCreditsUsd` | `creditBalanceUsd + creditGrantsUsd` — the headline spendable figure. |
+| `creditGrants[]` | Per-grant rows: `grantId`, `source`, `note`, `amountUsd`, `remainingUsd`, `expiresAt`. |
+| `dailyBudget` | `{ limitUsd, spentUsd, remainingUsd }`. `limitUsd: null` means uncapped. |
 
-Quote both figures rather than only the clamped one. A wallet holding $265 that a rolling window has temporarily gated to $10 reads as *missing money* if you show only `transferableUsd`; showing the balance alongside it, and naming the daily gate as the binding constraint, reads as a timer. The agent's credit-balance tool follows the same rule — it quotes the balance next to the allowance when a daily gate binds, and stays quiet when the structural balance is what's limiting.
+```bash
+curl -s "https://api.bankr.bot/llm/credits/state" -H "X-API-Key: $BANKR_API_KEY"
+```
+
+**Balance and budget are two different ceilings, and the smaller one binds.** Quote both rather than only the tighter one: a wallet holding $265 that a rolling window has temporarily gated to $10 reads as *missing money* if you show only the remaining budget; showing the balance alongside it, and naming the daily gate as the binding constraint, reads as a timer. The agent's credit-balance tool follows the same rule.
+
+The transfer endpoint enforces its own $500 / 24h principal cap on top of both — neither figure above accounts for it, so a send above the remaining daily allowance returns `429 daily-cap-exceeded` rather than being clamped for you.
 
 ### Daily Spend Budget
 

--- a/bankr/references/nft-operations.md
+++ b/bankr/references/nft-operations.md
@@ -36,6 +36,8 @@ Browse, purchase, and manage NFTs across chains via OpenSea integration.
 
 Listings priced in an **ERC-20** rather than the chain's native token — for example USDG listings on Robinhood Chain — are buyable the same way. Bankr submits the token approval the marketplace conduit needs, checks your balance of the payment currency before signing, and prices the listing using that token's decimals, so the quoted amount is the amount you pay. If a listing turns out to be stale, it moves on to the next one instead of failing the whole request.
 
+**Floor buys survive being sniped.** When you ask for "the cheapest X" without naming a token ID, Bankr walks the candidate listings rather than committing to the first one it resolved. If that listing is bought out from under you mid-purchase — the order goes invalid or not-found, the marketplace rejects it, or the signer's simulation reverts — it falls back to the next-cheapest candidate, up to **three purchase attempts**. Anything that isn't snipe-shaped (a price above your cap, insufficient balance, a wallet-safety block) fails immediately without burning a candidate. The reply and the activity record name the floor picks that were taken, so a substitution is never silent, and nothing is retried after a broadcast. Naming an explicit token ID is a single attempt by design and keeps its own anti-frontrun age guard.
+
 **Accept offers:**
 - "Accept the best offer on my Pudgy Penguin #1234"
 - "What's the highest offer on my Bored Ape?"

--- a/bankr/references/safety.md
+++ b/bankr/references/safety.md
@@ -87,9 +87,10 @@ If an agent needs these operations, give it a key **without** a recipient allowl
 If you suspect a key is compromised:
 
 1. **Pause** the wallet at [bankr.bot](https://bankr.bot) → Security. Halts every outbound transaction immediately, including in-flight broadcasts. Revoking the key alone does not stop transactions already past auth.
-2. **Revoke** the key at [bankr.bot/api-keys](https://bankr.bot/api-keys).
-3. **Rotate** — generate a new key with the same access profile and update deployments.
-4. **Audit** — review recent transactions and agent job history before unpausing.
+2. **Sever sessions** — if you suspect the account itself rather than one key, use **Sign out of all** in the Active sessions panel under Security. It revokes every live session at once, including the device you're on, so nothing already signed in stays authenticated. (Individual sessions can still be logged out one at a time from the same panel.)
+3. **Revoke** the key at [bankr.bot/api-keys](https://bankr.bot/api-keys).
+4. **Rotate** — generate a new key with the same access profile and update deployments.
+5. **Audit** — review recent transactions and agent job history before unpausing.
 
 ## API Key Types & Separation
 
@@ -413,4 +414,4 @@ Before deploying an agent or integration:
 - [ ] Implement **error handling** for rate limits (429) and access control errors (403)
 - [ ] Monitor the agent's **daily message usage** against your tier limit
 - [ ] Review and **rotate all keys** (API and LLM) periodically; revoke immediately if compromised
-- [ ] Know the **incident response** procedure: pause wallet → revoke key → rotate → audit
+- [ ] Know the **incident response** procedure: pause wallet → sign out of all sessions → revoke key → rotate → audit

--- a/bankr/references/token-deployment.md
+++ b/bankr/references/token-deployment.md
@@ -178,7 +178,7 @@ Optional vesting for team tokens or investor allocations.
 Gas is sponsored for token launches within daily limits (1/day standard, 10/day Bankr Club).
 Shared fee claims are always sponsored to ensure atomic claim+transfer.
 
-### Rate Limits
+### Rate Limits (Solana)
 
 | User Type | Daily Limit | Gas Sponsored |
 |-----------|-------------|---------------|
@@ -187,11 +187,24 @@ Shared fee claims are always sponsored to ensure atomic claim+transfer.
 
 Users can launch additional tokens beyond sponsored limits by paying ~0.01 SOL gas.
 
+> These figures cover **Solana LaunchLab launches only**. EVM (Doppler) launches run on a separate and much tighter quota — 3 counted attempts per rolling 24 hours for every wallet type. See [Launch Quota and Rate Limits](#launch-quota-and-rate-limits).
+
 ---
 
-## EVM Token Launches (Base & Robinhood Chain, via Doppler)
+## EVM Token Launches (Base, Robinhood Chain & Arbitrum, via Doppler)
 
-Launch ERC20 tokens on Base or Robinhood Chain. New launches create a Uniswap V4 pool via Doppler with a fixed supply and a single swap-fee tier shared between you and the protocol. The default chain differs by surface (see [Supported Chains](#supported-chains)), so name it explicitly — `bankr launch --chain robinhood`, `"chain": "base"`, or "launch a token on robinhood". Robinhood Chain memecoin launches need no location verification — that gate only applies to Robinhood-issued tokenized stocks.
+Launch ERC20 tokens on Base, Robinhood Chain or Arbitrum One. New launches create a Uniswap V4 pool via Doppler with a fixed supply and a single swap-fee tier shared between you and the protocol. The default chain differs by surface (see [Supported Chains](#supported-chains)), so name it explicitly — `bankr launch --chain robinhood`, `"chain": "arbitrum"`, or "launch a token on base". Robinhood Chain memecoin launches need no location verification — that gate only applies to Robinhood-issued tokenized stocks.
+
+**Chain capability matrix:**
+
+| | Base | Robinhood Chain | Arbitrum One |
+|---|---|---|---|
+| Default quote asset | WETH | WETH | WETH |
+| `pairedStockAddress` (tokenized stock) | Yes — B20 equities | Yes — Robinhood stocks | **No** |
+| `pairedTokenAddress` (quote token) | Yes — 5 fixed tokens | **No** | **No** |
+| Retail launch gas | Sponsored | Wallet pays | Wallet pays |
+
+Arbitrum launches are therefore **WETH-paired only**. Everything else — supply, fee schedule, creator vesting, quote-only fees, degen mode, fee claiming — behaves as on Base. Fund the launch wallet with ETH on Arbitrum before deploying.
 
 ### Token Economics
 
@@ -236,18 +249,54 @@ Like the fee schedule, this option cannot be changed after launch.
 
 ### Base Quote Tokens (optional, fixed at launch)
 
-Base launches can quote the new token's pool in **BNKR** or **ba3Pump** instead of WETH. ba3Pump is Bankr-bridged PUMP from Solana. Pass `chain: "base"` together with one of the fixed allowlisted addresses:
+Base launches can quote the new token's pool in one of **five fixed tokens** instead of WETH. Pass `chain: "base"` together with one of the allowlisted addresses:
 
-| Quote token | `pairedTokenAddress` |
-|-------------|----------------------|
-| BNKR | `0x22af33fe49fd1fa80c7149773dde5890d3c76f3b` |
-| ba3Pump | `0x5577a294ae5a21446a11b0e4100ca83803995720` |
+| Quote token | What it is | `pairedTokenAddress` | Decimals |
+|-------------|------------|----------------------|----------|
+| BNKR | BankrCoin, Bankr's native token | `0x22af33fe49fd1fa80c7149773dde5890d3c76f3b` | 18 |
+| ba3Pump | Bankr-bridged $PUMP from Solana | `0x5577a294ae5a21446a11b0e4100ca83803995720` | 18 |
+| cbHYPE | Coinbase Wrapped Hyperliquid (HYPE) on Base | `0xB200000000000000000000451d033a5000cb479e` | 18 |
+| cbZEC | Coinbase Wrapped ZEC on Base | `0xB2000000000000000000008501b13360000cb2EC` | 8 |
+| TAO | Bittensor's TAO on Base | `0xf3081494b87e8d5fb7960f066e931d1d0e6e3d67` | 18 |
 
+- **Base only.** These are not launch quote-token options on Robinhood Chain or Arbitrum.
 - **User-key launches only** — not available on org Partner Key deploys.
 - **Mutually exclusive with `pairedStockAddress`.** Sending both is rejected; omit both to get WETH.
 - The allowlist is fixed — an arbitrary ERC-20 is not accepted as a quote token.
+- **cbHYPE and cbZEC wait on reviewed on-chain quote-token liquidity.** If Bankr reports either pair isn't ready, that's a real refusal — the launch does not silently fall back to WETH or to a paired stock. Retry once the pair is live.
+- cbHYPE and cbZEC are Coinbase-wrapped **crypto** assets, not tokenized stocks: they go in `pairedTokenAddress`, never `pairedStockAddress`, and no location/geo verification applies to them.
 - Volume in a BNKR- or ba3Pump-quoted pool remains eligible for the weekly developer rebate under the same rules as a WETH-quoted launch.
 - Everything else — supply, the fee schedule, creator vesting, quote-only fees, degen mode — behaves exactly as on a WETH launch. "Quote token" here just names the pool's other side.
+
+### Creator Vesting (on by default, fixed at launch)
+
+Every non-partner EVM launch premints **15% of supply to the fee recipient** and vests it over **1 year with a 30-day cliff** — nothing unlocks for the first 30 days, then it vests continuously until fully unlocked at the one-year mark (the cliff sits *inside* the year, not on top of it). The remaining **85%** seeds the Uniswap V4 pool, so trading starts clean.
+
+| Property | Value |
+|----------|-------|
+| Allocation | 15% of supply (15B on a standard 100B launch) |
+| Cliff | 30 days |
+| Total duration | 1 year, including the cliff |
+| Recipient | The fee recipient set at launch — fixed, and **not** moved by a later fee-rights transfer |
+
+- **Turning it off**: ask the agent to deploy "with no vesting", pick **No vesting** in the web launch flow, pass `disableVesting: true` to the deploy API, or use `bankr launch --no-vesting`. With vesting off, 100% of supply is sold into the pool and nothing is preminted.
+- There is no custom percentage or schedule — vesting is either the default 15% or off.
+
+**Reading and claiming the allocation.** The schedule is public on-chain data, so the read needs no authentication:
+
+```bash
+# Schedule + position for a launch (optionally for a specific beneficiary)
+curl "https://api.bankr.bot/token-launches/0xTOKEN/vesting?beneficiary=0xWALLET"
+```
+
+The response carries the chain, token symbol, the recorded `recipient`, whether the queried `beneficiary` is `eligible`, and a `vesting` object: `phase` (`cliff` | `vesting` | `complete`), `vestingStart` / `cliffEndsAt` / `vestingEndsAt` (unix seconds), `totalAmount`, `releasedAmount`, `claimableAmount`, `lockedAmount`, and `unlockedPercent`. A non-Bankr token returns `404`.
+
+Claiming releases whatever has vested to the beneficiary. Custodial Bankr wallets claim through the authenticated claim route or the token page at [bankr.bot](https://bankr.bot); an external/connected wallet fetches an unsigned `release()` transaction from `POST /token-launches/{tokenAddress}/vesting/build-claim` (body `{ "beneficiaryAddress": "0x…" }`) and signs it locally — `release()` only ever pays `msg.sender`, so holding the key is the authorization.
+
+```bash
+bankr agent prompt "How much of my MTK allocation has vested?"
+bankr agent prompt "Claim my vested MTK"
+```
 
 ### Degen Mode (optional, fixed at launch)
 
@@ -279,7 +328,9 @@ Degen mode starts the token at a **$2,500 market cap** instead of the standard s
 | **Quote-only fees** | No | Collect all creator fees in the quote token; fixed at launch | `quoteOnlyFees: true` |
 | **Degen mode** | No | Start at a $2,500 market cap; explicit opt-in, not on partner deploys | `degenMode: true` |
 | **Paired stock** | No | Quote the pool in a registry tokenized stock instead of WETH | `pairedStockAddress: "0x…"` |
-| **Paired quote token** | No | Base only — quote the pool in BNKR or ba3Pump instead of WETH; not combinable with a paired stock | `pairedTokenAddress: "0x…"` |
+| **Paired quote token** | No | Base only — quote the pool in BNKR, ba3Pump, cbHYPE, cbZEC or TAO instead of WETH; not combinable with a paired stock | `pairedTokenAddress: "0x…"` |
+| **Chain** | No | `robinhood` (agent/API default), `base` (CLI and web default), or `arbitrum` | `chain: "arbitrum"` |
+| **Disable vesting** | No | Skip the default 15% creator vesting and sell 100% of supply into the pool | `disableVesting: true` (`--no-vesting`) |
 
 ### Prompt Examples
 
@@ -292,6 +343,14 @@ Degen mode starts the token at a **$2,500 market cap** instead of the standard s
 - "Launch a token called CoolBot on robinhood"
 - "Launch a token called CoolBot and route fees to @partner"
 - "Launch a token with quote-only fees"
+- "Launch MOON on Arbitrum"
+- "Launch FROG on Base paired with TAO"
+- "Launch a token with no vesting"
+
+**Creator vesting:**
+- "How much of my MTK allocation has vested?"
+- "When does my MTK vesting cliff end?"
+- "Claim my vested MTK"
 
 **Claim fees:**
 - "Claim fees for my token MTK"
@@ -303,20 +362,60 @@ Degen mode starts the token at a **$2,500 market cap** instead of the standard s
 - "Add Twitter link to my token"
 - "Update logo for MyToken"
 
-### Rate Limits
+### Launch Quota and Rate Limits
 
-| User Type | Deploys per day | Gas-sponsored deploys per day |
-|-----------|-----------------|-------------------------------|
-| Standard Users | 50 | 3 |
-| Bankr Club Members | 100 | 10 |
+**The launch quota is universal — Bankr Club does not raise it.**
 
-The two limits are separate: the daily cap is how many tokens you may deploy, the sponsorship cap is how many of those Bankr pays gas for. Past the sponsorship cap you can keep deploying up to the daily cap by paying gas yourself. A deploy that fails before broadcast because of gas doesn't consume sponsorship quota, though it still counts against the daily cap.
+| Wallet type | Counted launch attempts per rolling 24 hours |
+|-------------|----------------------------------------------|
+| Standard | 3 |
+| Bankr Club | 3 |
+| Partner organization wallet | 3 |
+| Provisioned partner wallet | 3 |
 
-**Past the sponsorship cap, a near-empty wallet is refused up front.** An unsponsored deploy checks the wallet's native balance against a conservative per-chain floor *before* building or broadcasting anything, and returns copy explaining that sponsorship is exhausted and what to do about it — rather than spending a signer round-trip to fail on-chain with a bare "not enough native token to cover gas". The floor is deliberately low, so borderline balances still proceed to real estimation downstream; sponsored deploys skip the check entirely. If you deploy programmatically past the sponsored quota, fund the deploying wallet with gas rather than relying on the retry.
+On top of the quota you may deploy at most **one token per minute**.
 
-A separate cross-account limit applies to fee recipients: an address may be named fee recipient on at most **20 deploys per 24 hours** across all accounts.
+**When a slot is actually consumed.** Quota is reserved immediately before metadata pinning: validation, recipient resolution and pricing failures ahead of that point never cost you a slot, and **simulations** (`--simulate` / `simulateOnly: true`) never reserve one. Once an attempt has been — or may have been — broadcast, it counts. A failed attempt that Bankr can prove never reached the chain gives its slot back, along with its name and fee-recipient allowance; the classification deliberately fails safe, so a deploy that errors after submission stays counted rather than being handed back on a guess.
 
-High-volume or bot-like deploy patterns can trigger automated spam protections and temporary or permanent restrictions. For legitimate programmatic deploy use cases, open a support ticket before scaling up.
+After the third counted attempt, wait for the oldest one to age out of the 24-hour window.
+
+**Anti-spam caps (all return `429`), counting only launches that went out:**
+
+| Cap | Scope | Limit |
+|-----|-------|-------|
+| Same token name | Per account, per hour | 3 |
+| Same token name | Across all accounts, per hour | 10 |
+| Fee-recipient address | Across all accounts, per 24 hours | 20 |
+
+### Launch-Wallet Requirements (anti-sybil)
+
+Standard and Bankr Club launches require the Bankr wallet to be:
+
+- **At least 24 hours old**, measured from when Bankr created the wallet — not from the age of the linked X or other social account
+- Holding **at least 0.002 native ETH on the launch chain**
+
+Both checks run *before* quota is reserved, metadata is pinned, or a transaction is submitted, so a rejection here costs neither a launch attempt nor gas. The balance minimum applies even on Base, where Bankr sponsors deploy gas; on Robinhood Chain and Arbitrum it also has to cover the launch's own gas. Validated active partner-organization and provisioned-wallet launch paths are exempt from both requirements — only while the organization is active with token launching enabled, and (for a provisioned wallet) while the wallet stays active and linked to that organization. Retail **simulations** still require the 24-hour wallet age, but skip the balance check.
+
+### Gas Sponsorship
+
+**Retail launch gas is sponsored on Base only.** On Robinhood Chain and Arbitrum the launch wallet pays its own network gas. Partner launches follow their organization's sponsorship policy instead.
+
+Across every sponsored path (launches, fee claims, transfers), a non-partner wallet gets at most:
+
+- **10 sponsored transactions per rolling 24 hours**, and
+- **$3 of sponsored gas per rolling 24 hours**
+
+Whichever runs out first ends sponsorship until the window resets. This matters for agents claiming many tokens' fees daily, or launching on a chain during a fee spike — budget for paying your own gas past those ceilings.
+
+**On an unsponsored deploy, a near-empty wallet is refused up front.** The wallet's native balance is checked against a conservative per-chain floor *before* anything is built or broadcast, returning copy that explains the situation rather than spending a signer round-trip to fail on-chain with a bare "not enough native token to cover gas". The floor is deliberately low, so borderline balances still proceed to real estimation downstream. If you deploy programmatically, fund the deploying wallet with gas rather than relying on the retry.
+
+### Five-Minute Balance Cap
+
+For the first **five minutes** after a non-partner launch, each wallet may hold no more than **2% of the token's total supply**. A buy or transfer that would leave the receiving wallet above 2% fails until the cap expires.
+
+This is separate from the roughly 10-second anti-snipe fee decay: the anti-snipe mechanism changes the swap fee, while this rule limits the recipient's balance. Partner launches are exempt, and the expiry is encoded on-chain at launch, so existing tokens keep whatever expiry they launched with.
+
+High-volume or bot-like deploy patterns can trigger automated spam protections and temporary or permanent restrictions — enforced hardest on the X path, where repeatedly breaching the one-per-minute limit restricts the account for 24 hours (a limited state: login, balances and withdrawals still work). For legitimate programmatic deploy use cases, open a support ticket before scaling up.
 
 ### Stock-Paired Launches
 
@@ -360,7 +459,8 @@ Selling a token you earn creator fees on through Bankr's swap/limit/stop/DCA/TWA
 
 | Issue | Chain | Resolution |
 |-------|-------|------------|
-| Rate limit reached | Both | Wait 24 hours or upgrade to Bankr Club |
+| Launch quota reached (EVM) | EVM | Wait for the oldest of your 3 attempts to age out of the rolling 24h window — Bankr Club does not raise the cap |
+| Launch wallet rejected (EVM) | EVM | Wallet must be ≥ 24h old and hold ≥ 0.002 native ETH on the launch chain |
 | Name/symbol taken | EVM | Choose different name |
 | Insufficient SOL | Solana | Add SOL for gas fees |
 | NFT not found | Solana | Token may still be on bonding curve |


### PR DESCRIPTION
Weekly sync of the `bankr` skill against the platform capabilities that are now live, plus a few gaps earlier syncs left behind.

Every figure below was checked against the shipped behaviour and the public docs rather than carried over.

## Shipped this week

**Token launches**

- **Arbitrum One is a third Doppler launch chain.** `chain: "arbitrum"` / `bankr launch --chain arbitrum` / "launch it on Arbitrum". WETH-paired only — neither `pairedStockAddress` nor `pairedTokenAddress` is accepted there — and the launch wallet pays its own network gas. Added to the chain table, the capability bullets, the prompt examples and a new chain-capability matrix in the reference.
- **Base launch quote tokens grew from two to five**: BNKR, ba3Pump, plus **cbHYPE**, **cbZEC** and **TAO**. The reference table now carries every address and decimal count, notes that cbHYPE/cbZEC wait on reviewed on-chain quote-token liquidity (a refusal there is real — there is no silent fallback to WETH), and warns that the two Coinbase wrappers are crypto assets for `pairedTokenAddress`, never tokenized stocks for `pairedStockAddress`.
- **The launch quota is now universal — 3 counted attempts per rolling 24 hours for every wallet type, and Bankr Club does not raise it.** The skill previously advertised 50/day standard and 100/day Club in three separate places, all wrong. Replaced with the real quota plus the one-token-per-minute rate.
- **Launch-wallet eligibility gates**: wallet must be ≥ 24 hours old and hold ≥ 0.002 native ETH on the launch chain. Both run before quota is reserved, so a rejection costs neither an attempt nor gas. Partner paths are exempt from the gates but not from the quota.
- **Only launches that actually went out consume budget.** Quota is reserved just before metadata pinning; an attempt that provably never reached the chain hands its slot — and its name / fee-recipient allowance — back. The classification fails safe, so a failure after submission stays counted. Simulations never reserve a slot.
- **Retail launch gas is sponsored on Base only.** Robinhood Chain and Arbitrum: the wallet pays. Sponsorship across all paths is capped at **10 transactions and $3 of gas per rolling 24 hours**, whichever runs out first.
- **Five-minute balance cap**: for five minutes after a non-partner launch no wallet may hold more than 2% of supply. Documented alongside the (separate) anti-snipe fee decay so the two aren't conflated.

**New agent capability**

- **Merkl incentive rewards** — new "Onchain Reward Campaigns" section: check earned and claimable rewards, claim on one chain, and browse live earn opportunities ranked by APR, on Base and Robinhood Chain. Notes that claiming signs from the embedded wallet and so isn't available in wallet mode, and that campaign availability changes over time.
- **Creator vesting claim** — `GET /token-launches/{tokenAddress}/vesting` reads the public schedule and position (phase, claimable, locked, released, unlocked %); external beneficiaries can fetch an unsigned `release()` transaction to sign locally.

**LLM gateway**

- **Credit state moved.** `GET /llm/credits/state` is now the canonical read (`creditBalanceUsd`, `creditGrantsUsd`, `totalCreditsUsd`, `creditGrants[]`, `dailyBudget`). `GET /llm/usage` is **usage-only** and no longer carries balance or transferable fields — the skill documented three fields on it that no longer exist, in both `SKILL.md` and the reference.
- Model table refreshed, `gemini-3-pro` marked deprecated, and the agent's **default model is now Gemini 3.8 Flash** (was 3.7) in all three places it was named.

**Other**

- **Floor NFT buys survive a snipe** — a floor buy now walks its candidate listings and falls back to the next-cheapest when the selected one is filled mid-purchase, up to three attempts, with the substitution named in the reply. An explicit token ID stays a single attempt.
- **Hyperliquid closes always report PnL**, derived from the quoted fill price and sized on the amount actually filled, with partial fills flagged rather than reported as a full close.
- **Sign out of all sessions** added to incident response in both `SKILL.md` and the safety reference.

## Gaps caught while syncing

These are pre-existing, not this week's changes:

- **EVM launches have always carried a default 15% creator vesting allocation** (1 year, 30-day cliff, to the fee recipient) — the skill only mentioned vesting as a Solana option. Now documented with the full schedule, how to turn it off, and the fact that a later fee-rights transfer does *not* move the allocation.
- **Duplicate-name and per-fee-recipient anti-spam caps were undocumented**: 3 same-name launches per account per hour, 10 across all accounts per hour, 20 launches per fee-recipient address per 24h — all `429`.
- **Solana launch limits read as universal.** They're in the Solana section but nothing said so; scoped explicitly and cross-linked to the (much tighter) EVM quota. Solana's own figures were not re-verified this cycle and are unchanged.
- **Two gateway models were missing** from the reference model table.

## Files

| File | What changed |
|------|--------------|
| `bankr/SKILL.md` | Club perks table, token deployment section + launch limits table, chain table, Merkl section, LLM credit state, NFT/Hyperliquid bullets, incident response, prompt examples, frontmatter description |
| `bankr/references/token-deployment.md` | Chain capability matrix, five quote tokens, launch quota / wallet requirements / gas sponsorship / balance cap sections, creator vesting section, parameter table, common issues |
| `bankr/references/llm-gateway.md` | Model table, credit-state endpoint, default model |
| `bankr/references/nft-operations.md` | Floor-buy snipe fallback |
| `bankr/references/hyperliquid.md` | Close PnL reporting |
| `bankr/references/safety.md` | Sign out of all sessions |

---
_Generated by [Claude Code](https://claude.ai/code/session_01JXPaC62yswFKzcR72VjiY6)_