### PR TITLE
Add chit402-receipt skill (Chit402 signed USDC spend receipts)

### DIFF
--- a/chit402-receipt/SKILL.md
+++ b/chit402-receipt/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: chit402-receipt
+description: >-
+  Pay for Chit402 inference via x402 USDC on Base, collect a signed receipt, and
+  return verify_url so the principal holds the row. Use when an agent needs to
+  stamp spend through Chit402, print a shareable receipt, verify payer/payee/asset/
+  amount/tx binds offline, or budget capped USDC calls without defaulting to SP1.
+---
+
+# Chit402 Receipt — pay, stamp, return verify_url
+
+Chit402 is the book: **this agent spent Y on this job**. You hold hub, model, amount,
+and a public **`verify_url`** the principal can forward to finance or auditors.
+
+**Live API:** `https://api.chit402.com`  
+**Default rail:** x402 USDC on **Base mainnet** (CDP facilitator). Solana USDC is
+available when the 402 challenge lists it — prefer Base unless the user asks otherwise.
+
+**Do not default to SP1.** Signed receipts (Tier 1, ES256 JWS) are table stakes.
+Tier-2 settlement proofs are optional and cost extra — never request or wait for SP1
+unless the user explicitly asks for on-chain proof.
+
+## When to use
+
+- User wants an agent to **pay for inference** and return a **receipt link**
+- User asks to **stamp spend**, **print receipt**, **verify_url**, or **Chit402 book row**
+- User needs **offline verification** of payer / payee / asset / amount / tx binds
+- Bankr or similar agent with a Base USDC wallet (CDP `PAYMENT-SIGNATURE` path)
+
+## Environment
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `CHIT_API_URL` | no | Gateway base (default `https://api.chit402.com`). Aliases: `CHIT402_API_URL`, `XFUEL_API_URL`. |
+| `CHIT_API_KEY` | recommended | Partner or demo key (`chit402-demo` is rate-limited). Aliases: `CHIT402_API_KEY`, `XFUEL_API_KEY`. |
+| `CHIT_MAX_USD_PER_CALL` | recommended | Hard cap per paid call in USD (e.g. `0.10` = ten cents). **Refuse** if quoted amount exceeds cap. |
+| `CHIT_MAX_USD_SESSION` | recommended | Cumulative session cap in USD. Track spend in this conversation; **refuse** when exceeded. |
+
+Bankr agents: use the **Bankr wallet** for x402 signing (`PAYMENT-SIGNATURE` header).
+Do not paste private keys into skills or chat. Prefer Bankr submit/sign APIs over raw keys.
+
+## Spend caps (required behavior)
+
+Before every paid call:
+
+1. Parse the 402 `accepts[]` entry you will pay against. Amount is **atomic USDC**
+   (6 decimals): `"10000"` = $0.01.
+2. Compare to `CHIT_MAX_USD_PER_CALL` (default **$0.10** if unset).
+3. Add to your session running total; compare to `CHIT_MAX_USD_SESSION` (default **$1.00**
+   if unset).
+4. If either cap would be exceeded, **stop** and tell the principal the quoted amount
+   and your limits. Do not settle.
+
+Floor on the public door is ~**$0.01** per call unless the quote says otherwise.
+
+## Primary flow — `POST /v1/chat/completions` (x402 on Base)
+
+Best for Bankr and chat-native agents. Same door as OpenAI-compatible clients.
+
+### Steps
+
+1. **Probe** (optional): `GET https://api.chit402.com/v1/models` with
+   `Authorization: Bearer $CHIT_API_KEY` or `X-API-Key: $CHIT_API_KEY`.
+
+2. **Request without payment** to read the 402 challenge:
+
+   ```http
+   POST /v1/chat/completions
+   Content-Type: application/json
+
+   {
+     "model": "xfuel/auto",
+     "messages": [{ "role": "user", "content": "<prompt>" }]
+   }
+   ```
+
+   Expect **HTTP 402** with `PAYMENT-REQUIRED` (and/or body `accepts[]`).
+   Pick the **Base** entry: `network` = `eip155:8453` or `base`, asset = Base USDC
+   (`0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913`), note `payTo` (payee), `amount`.
+
+3. **Enforce caps** (above) against `accepts[].amount`.
+
+4. **Sign and retry** with CDP-native payment header (Bankr default):
+
+   ```http
+   POST /v1/chat/completions
+   Authorization: Bearer $CHIT_API_KEY
+   Content-Type: application/json
+   PAYMENT-SIGNATURE: <CDP v2 PaymentPayload from wallet>
+
+   { "model": "xfuel/auto", "messages": [...] }
+   ```
+
+   Bankr sends `PAYMENT-SIGNATURE` (not only `X-PAYMENT`). Echo the challenge's
+   `accepts[0]` shape; the gateway normalizes float-string timestamps.
+
+5. **Collect the receipt** from the 200 response:
+
+   | Source | Field |
+   |--------|-------|
+   | Header | `x-xfuel-verify-url`, `x-xfuel-task-id` |
+   | Body | `xfuel.verify_url`, `xfuel.task_id` |
+   | Constructed | `https://api.chit402.com/receipt/<task_id>` |
+
+6. **Return to the principal** — always include:
+
+   - **`verify_url`** (full HTTPS URL)
+   - One short human line, e.g.  
+     `Paid $0.01 USDC on Base for xfuel/auto — receipt: <verify_url>`
+
+### Alternate paid door — `POST /task-request`
+
+Use for M2M / agent loops that need `task-status` polling or rolling settlement.
+Same x402 handshake; see [references/api.md](references/api.md).
+
+## What the receipt binds (new upgrades)
+
+Collected USDC receipts stamp these in the **issuer-signed JWS** (`issuer_signature.jws`):
+
+| Bind | JWS / envelope field | Meaning |
+|------|----------------------|---------|
+| **Issuer key pin** | `issuer_signature.issuer_jwk` | ES256 public key **pinned in the receipt** — offline verify without fetching JWKS first |
+| **Payer** | `caller_binding.payer_wallet` | Wallet that settled USDC (matches on-chain `from`) |
+| **Payee** | `payment.payee` | x402 `payTo` / treasury recipient |
+| **Asset** | `payment.asset` | e.g. `USDC` |
+| **Amount** | `payment.gross_amount` | Atomic USDC (6 dp) |
+| **Tx** | `payment.ref` | `base:0x…` or `eip155:8453:0x…` settlement reference |
+
+Fetch JSON: `GET /receipt/<task_id>?format=json`  
+JWKS (legacy / cross-check): `GET /.well-known/jwks.json`
+
+Full offline steps: [references/verify-offline.md](references/verify-offline.md)
+
+## Offline verification (JWKS → JWS)
+
+**Pin-first (recommended):** newer receipts include `issuer_signature.issuer_jwk`.
+Verify the compact JWS with ES256 — no network required for signature check.
+
+```bash
+curl -sS "https://api.chit402.com/receipt/<task_id>?format=json" -o receipt.json
+npx xfuel-verify receipt.json --json
+# Uses pinned issuer_jwk automatically (@xfuel/verify)
+```
+
+**JWKS fallback** (older receipts or cross-check kid rotation):
+
+```bash
+curl -sS "https://api.chit402.com/.well-known/jwks.json" -o jwks.json
+npx xfuel-verify receipt.json --jwks-file jwks.json --json
+```
+
+Then confirm **payer on-chain** matches `caller_binding.payer_wallet` for `payment.ref`
+(Base USDC Transfer / EIP-3009 `from`). CLI: `--check-payer` when RPC is available.
+
+**Do not** treat SP1 / `binding.in_proof` as the default prove-it path. Signed JWS +
+payer bind is enough for most agent treasury workflows.
+
+## MCP (optional)
+
+`npx chit402-mcp` exposes `chat_completions`, `verify_receipt`, etc. Bankr installs
+this **skill file** for instructions; MCP is optional and not required for Bankr.
+
+## Failure modes
+
+| Symptom | Action |
+|---------|--------|
+| 402 after payment | Check `PAYMENT-SIGNATURE` shape, Base network CAIP-2, amount vs cap |
+| 400 on empty body | Send valid `messages` **before** payment settles (gateway validates body pre-settle) |
+| `invalid_network` | Use `eip155:8453` in signed payload for CDP v2 |
+| Cap exceeded | Report quoted atomic amount; ask principal to raise cap or narrow the task |
+| Unmetered receipt | Demo key / no settlement — `payment.rail` = `unmetered`; not a collected row |
+
+## Hard requirements
+
+- **Always return `verify_url`** on successful paid completion.
+- **Enforce spend caps** — never exceed `CHIT_MAX_USD_PER_CALL` or `CHIT_MAX_USD_SESSION`.
+- **Default to Base USDC x402** — do not silently switch rails.
+- **No SP1 by default** — do not poll `/prove-result` unless asked.
+- **Never exfiltrate** private keys; use Bankr wallet signing.
+- Point principals at **`https://api.chit402.com`** (not legacy hostnames) for live traffic.
+
+## References
+
+- [references/api.md](references/api.md) — endpoints, headers, example 402/200
+- [references/verify-offline.md](references/verify-offline.md) — pin-first JWS + payer bind
+- Repo: `docs/VERIFY_ALGORITHM.md`, `docs/X402_ADAPTER.md`, `docs/DESIGN_PARTNER_ONBOARDING.md`

--- a/chit402-receipt/catalog.json
+++ b/chit402-receipt/catalog.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": 1,
+  "slug": "chit402-receipt",
+  "provider": "Chit402",
+  "providerUrl": "https://chit402.com",
+  "demo": {
+    "title": "chit402-receipt-flow.sh",
+    "language": "bash",
+    "code": "# 1) Read the 402 challenge (no payment yet)\ncurl -sS -D - -X POST https://api.chit402.com/v1/chat/completions \\\n  -H 'Content-Type: application/json' \\\n  -d '{\"model\":\"xfuel/auto\",\"messages\":[{\"role\":\"user\",\"content\":\"Say hi in five words.\"}]}'\n# Expect HTTP 402 + PAYMENT-REQUIRED (Base USDC, amount \"10000\" = $0.01)\n\n# 2) Agent wallet signs CDP v2 PaymentPayload \u2192 PAYMENT-SIGNATURE (Bankr does this)\n# 3) Retry with payment header + API key; read verify_url from response:\n#    x-xfuel-verify-url  OR  body.xfuel.verify_url\n\n# 4) Offline verify (pinned issuer_jwk \u2014 no JWKS fetch required)\ncurl -sS \"https://api.chit402.com/receipt/<task_id>?format=json\" -o receipt.json\nnpx xfuel-verify receipt.json --json"
+  },
+  "setup": [
+    "Set CHIT_API_URL=https://api.chit402.com (optional; this is the default)",
+    "Set CHIT_API_KEY to your partner key (demo: chit402-demo \u2014 rate-limited, unmetered /v1 only)",
+    "Set CHIT_MAX_USD_PER_CALL (e.g. 0.10) and CHIT_MAX_USD_SESSION (e.g. 1.00) before spending",
+    "Fund the Bankr agent wallet with Base USDC for x402 settlement",
+    "Install: install the chit402-receipt skill from https://github.com/XFuel-Lab/chit402/tree/main/skills/chit402-receipt"
+  ],
+  "install": {
+    "type": "bankr",
+    "repoPath": "chit402-receipt",
+    "command": "install the chit402-receipt skill from https://github.com/BankrBot/skills/tree/main/chit402-receipt"
+  }
+}

--- a/chit402-receipt/references/api.md
+++ b/chit402-receipt/references/api.md
@@ -1,0 +1,122 @@
+# Chit402 API — receipt door
+
+Live host: **https://api.chit402.com**
+
+## Auth
+
+- `Authorization: Bearer <CHIT_API_KEY>`
+- or `X-API-Key: <CHIT_API_KEY>`
+
+Demo key `chit402-demo`: unmetered `POST /v1/chat/completions` (signed receipt, no USDC).
+Partner keys + wallet: collected USDC row with `payment.ref`.
+
+## Public paid door — chat completions
+
+| Method | Path | Notes |
+|--------|------|-------|
+| `GET` | `/v1/models` | Catalog |
+| `POST` | `/v1/chat/completions` | **Primary x402 door.** Unauth POST → 402. Bankr: `PAYMENT-SIGNATURE`. |
+
+### 402 challenge (excerpt)
+
+```json
+{
+  "x402Version": 2,
+  "accepts": [{
+    "scheme": "exact",
+    "network": "eip155:8453",
+    "asset": "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913",
+    "amount": "10000",
+    "payTo": "0x…",
+    "maxTimeoutSeconds": 300,
+    "extra": { "name": "USD Coin", "version": "2" }
+  }]
+}
+```
+
+`amount` is atomic USDC (6 dp). `10000` = $0.01.
+
+### 200 response (receipt fields)
+
+Headers:
+
+- `x-xfuel-task-id`
+- `x-xfuel-verify-url`
+
+Body (`xfuel` extension):
+
+```json
+{
+  "choices": [{ "message": { "role": "assistant", "content": "…" } }],
+  "xfuel": {
+    "task_id": "openai-abc123",
+    "verify_url": "https://api.chit402.com/receipt/openai-abc123",
+    "payment": { "rail": "usdc", "ref": "base:0x…", "gross_amount": "10000" }
+  }
+}
+```
+
+## M2M paid door — task request
+
+| Method | Path | Notes |
+|--------|------|-------|
+| `POST` | `/task-request` | Agent M2M; poll `GET /task-status` |
+| `POST` | `/task-quote` | Read-only price preview |
+| `GET` | `/task-status?task_id=` | Status + `verify_url` |
+
+Payment object:
+
+```json
+{
+  "payment": {
+    "rail": "usdc",
+    "network": "base",
+    "maxAmount": "50000"
+  }
+}
+```
+
+Retry headers after 402: `X-PAYMENT` + nonce, or `PAYMENT-SIGNATURE` (CDP v2).
+
+## Receipt endpoints (public, no auth)
+
+| Method | Path | Notes |
+|--------|------|-------|
+| `GET` | `/receipt/:taskId` | HTML receipt page |
+| `GET` | `/receipt/:taskId?format=json` | JSON envelope + `issuer_signature` |
+| `GET` | `/receipt/by-tx?tx=<hash>` | Lookup by settlement tx |
+| `GET` | `/.well-known/jwks.json` | ES256 issuer keys (JWKS fallback) |
+
+## Issuer signature envelope (v3)
+
+```json
+{
+  "task_id": "openai-abc123",
+  "verify_url": "https://api.chit402.com/receipt/openai-abc123",
+  "verification": {
+    "source_of_truth": "issuer_signature.jws",
+    "jwks_uri": "https://api.chit402.com/.well-known/jwks.json",
+    "issuer_jwk_pin": "<kid>",
+    "offline_key_source": "issuer_signature.issuer_jwk"
+  },
+  "issuer_signature": {
+    "alg": "ES256",
+    "kid": "<kid>",
+    "jws": "<header>.<payload>.<sig>",
+    "issuer_jwk": { "kty": "EC", "crv": "P-256", "x": "…", "y": "…", "kid": "…" }
+  }
+}
+```
+
+Signed JWS payload (decode middle segment) includes:
+
+- `payment.ref`, `payment.gross_amount`, `payment.asset`, `payment.payee`
+- `caller_binding.payer_wallet`
+- `route.model`, `route.provider`
+- `binding.expected_commitment`
+
+## Related
+
+- `docs/CHAT_COMPLETIONS_GATEWAY.md`
+- `docs/M2M_API.md`
+- `docs/X402_ADAPTER.md`

--- a/chit402-receipt/references/verify-offline.md
+++ b/chit402-receipt/references/verify-offline.md
@@ -1,0 +1,68 @@
+# Offline receipt verification
+
+Third parties verify a Chit402 receipt **without trusting HTML or live API**
+for the signature step.
+
+## Pin-first path (issuer_jwk)
+
+New receipts pin the issuer public key at `issuer_signature.issuer_jwk`.
+
+1. `GET /receipt/:taskId?format=json` (or use a saved file).
+2. Read `issuer_signature.jws` (compact JWS).
+3. Verify ES256 with `issuer_signature.issuer_jwk` (P-256).
+4. Decode JWS payload → confirm binds:
+   - `caller_binding.payer_wallet` (payer)
+   - `payment.payee` (treasury / payTo)
+   - `payment.asset` (USDC)
+   - `payment.gross_amount` (atomic 6 dp)
+   - `payment.ref` (tx: `base:0x…`)
+5. Optionally fetch tx on Base RPC and confirm USDC transfer `from` = payer,
+   `to` = payee, amount ≥ gross.
+
+CLI (no JWKS download):
+
+```bash
+npx xfuel-verify receipt.json --json
+```
+
+Library:
+
+```typescript
+import { verifyReceipt } from '@xfuel/verify';
+
+const result = await verifyReceipt(receipt);
+// result.issuer_signature.valid — uses pinned issuer_jwk
+// result.payer_binding — when --check-payer / RPC enabled
+```
+
+## JWKS fallback
+
+If `issuer_jwk` is absent (older receipt):
+
+```bash
+curl -sS https://api.chit402.com/.well-known/jwks.json -o jwks.json
+npx xfuel-verify receipt.json --jwks-file jwks.json --json
+```
+
+Match `issuer_signature.kid` to `jwks.keys[].kid`.
+
+## What not to default to
+
+- **SP1 / `binding.in_proof`** — optional Tier-2; extra cost and latency.
+- **HMAC shared secret** — treasury/auditor path; public verify uses ES256/JWS.
+
+## Payer bind algorithm (Base)
+
+For `payment.ref` = `base:0x<txHash>`:
+
+1. Fetch tx receipt on Base (chain id 8453).
+2. Find USDC (`0x833589…`) `Transfer` event.
+3. `from` must equal `caller_binding.payer_wallet`.
+4. Transferred amount ≥ `payment.gross_amount` (atomic).
+
+Solana: `solana:<sig>` — see `docs/VERIFY_ALGORITHM.md` §11.
+
+## Further reading
+
+- `docs/VERIFY_ALGORITHM.md`
+- `packages/verify/README.md`


### PR DESCRIPTION
## Summary
Adds **chit402-receipt** for Bankr Discover: x402 USDC on Base → signed receipt → `verify_url` the principal holds.

## Why
Bankr already stamped a live third-party row through this skill:
https://api.chit402.com/receipt/chit-1ebc5616-d9ce-4da9-b56c-847062ff6b96

Club feedback: Discover listing of this **same** skill + optional client-side tracking app later. **No** different install shape / no second skill.

## Install (after merge)
```
install the chit402-receipt skill from https://github.com/BankrBot/skills/tree/main/chit402-receipt
```

## Contents
- `SKILL.md` — settle flow, caps, no SP1 default, issuer_jwk pin + payer/payee/asset/amount/tx binds
- `catalog.json` — Discover schema v1
- `references/` — API + offline verify

Provider: Chit402 · https://chit402.com