### PR TITLE
Add lienfi — research and buy tokenized US tax lien certificates on Base (USDC)

### DIFF
--- a/lienfi/SKILL.md
+++ b/lienfi/SKILL.md
@@ -1,0 +1,388 @@
+---
+name: lienfi
+description: Research and buy tokenized US tax lien certificates on LienFi (Base, USDC) — screen the live book by NET yield with no credential, then, once your operator has authorized your wallet in a browser, register and run the prepare → sign → confirm → submit → report purchase loop from the wallet you control. LienFi signs only the price; every transaction leaves your wallet.
+emoji: 🏛️
+tags: [lienfi, tax-liens, real-estate, base, usdc, mcp, investing]
+visibility: public
+---
+
+# LienFi Skill
+
+LienFi is a marketplace for tokenized US tax lien certificates and redeemable tax deeds,
+settled onchain in USDC on Base (chain id 8453). This skill teaches you to research the
+book, get authorized by your operator, and buy from the wallet you control.
+
+Three facts before anything else:
+
+- **LienFi never holds your key and never submits a transaction for you.** It signs the
+  price quote; you sign an acknowledgment and submit the transactions it hands back.
+- **Purchases are final.** A lien you buy belongs to your operator. The exit is redemption
+  by the property owner or relisting it — there is no undo.
+- **One human step exists, and it cannot be skipped or retried around.** Your operator
+  signs an authorization in a browser at https://app.lienfi.com/agents/authorize and
+  hands you what that page prints. When a tool answers `not_registered` with a
+  `handoff_url` — and your call carried the bearer — surface the link to your
+  operator and STOP.
+
+## Prerequisites
+
+### Your wallet
+
+Two ways to hold a Bankr wallet, and every step below works either way:
+
+- **You are Bankr's own agent** (the terminal, X or Telegram). There is nothing to
+  create: you sign typed data and submit transactions with your own wallet tools.
+  Verified 2026-09-08 — a key proof and two consents were signed with
+  `eth_signTypedData_v4` and registered while the account's only Wallet API key was
+  revoked. Wherever a step shows a `curl` to `api.bankr.bot`, do the same thing with
+  your wallet tool instead.
+- **You run somewhere else and hold a Bankr wallet through the Wallet API** (Claude
+  Code, OpenClaw, a bot of your own). Create a key at https://bankr.bot/api-keys and
+  keep it as `BANKR_API_KEY`. The key MUST have `walletApiEnabled` on (the default);
+  `readOnly` OFF — it is ON by default, and a read-only key answers 403 to signing and
+  submitting; and `allowedRecipients` EMPTY — a non-empty list blocks
+  `eth_signTypedData_v4` on `/wallet/sign` and every raw submission on
+  `/wallet/submit`, and this skill needs both. Use `allowedIps` for restriction
+  instead.
+
+In both cases, in the Bankr security settings leave **arbitrary contract calls** ON (its
+default); off, raw submissions are blocked. Bankr's per-transaction and rolling-24-hour
+limits (defaults of $500 each, re-read 2026-09-07) apply on every surface and must cover
+what one purchase moves: an `approve` and a `buyNFT`, each for the lien's total. Whether
+both count against the daily limit is undocumented, so have your operator set it to at
+least twice the lien price. Only your operator can change these, in the Bankr web app.
+On X, Bankr answers only Bankr Club members.
+
+Fund the wallet with USDC on Base — and no more than your operator is willing to commit,
+because LienFi records but does not enforce the cumulative cap. Gas on Base is
+sponsored for Bankr embedded wallets.
+
+### Your wallet address
+
+Inside Bankr, it is the wallet your portfolio shows. Over the Wallet API:
+
+```bash
+curl -s https://api.bankr.bot/wallet/me -H "X-API-Key: $BANKR_API_KEY"
+```
+
+The address that holds the funds is the one your operator must name as the agent wallet.
+Give it to them exactly as returned. Verified 2026-09-07: Bankr signs with this same
+address (see "Verified and unverified" at the end).
+
+## Endpoints
+
+- **LienFi MCP** — JSON-RPC 2.0 over stateless HTTP, nothing to install, no session:
+  `POST https://api.lienfi.com/api/v1/mcp` with `content-type: application/json`.
+  Every LienFi call in this skill is one `curl` to it. Research tools take no header;
+  wallet and purchase tools take `Authorization: Bearer $LIENFI_BEARER`.
+- **Research REST, no credential** — `https://api.lienfi.com/api/public/liens/{id}`
+  (one lien, flat, carrying the NET per-year rate) and
+  `https://api.lienfi.com/api/v1/liens?...` (the book with filters).
+- **Read before your first call** — https://app.lienfi.com/llms.txt (the money
+  conventions), https://app.lienfi.com/docs/api#mcp-walkthrough (the loop below with a
+  request body for every step), https://app.lienfi.com/docs/api#mcp-refusals (every
+  refusal code with what to do). Trust `tools/list` over any document, including this one.
+
+Keep the operator's bearer from the moment you have it, and send it on every wallet and
+purchase call for as long as the authorization lasts — `$LIENFI_BEARER` below stands for
+wherever your runtime keeps a credential; LienFi does not care where, only that it
+arrives. Registering opens no session: a later call without the header is answered as
+`not_registered` even though you are. Never print the bearer and never send it anywhere
+but `api.lienfi.com`. (Bankr's own agent carried it across sessions unaided in testing on
+2026-09-08; an agent whose memory does not persist secrets keeps it as an env var.)
+
+## Money rules that are not guessable from the field names
+
+- Every yield LienFi's API returns is **gross**. LienFi takes a share of the GAIN over the
+  purchase price when a lien redeems (currently 10%, read the live rate from
+  `fee_config`), never of the redemption value. Rank on `net_apy`, which `search_liens`
+  computes with the same arithmetic the site displays.
+- A buyer pays `listing_price`. Most listings (`deal_type: par`) are priced AT the live
+  redemptive value, so the price climbs with accrual and a redemption on the day of
+  purchase returns the basis and no gain.
+- Liens under 30 days from maturity carry **no per-year rate**; `search_liens` returns
+  them in a separate `maturing_soon` list. Do not annualize them yourself.
+- `redemptive_value`, `accrued_interest` and `listing_price` on a raw row are frozen
+  snapshots; read the `calculated` block, which is recomputed live.
+- `redemption_deadline` is the statutory deadline and is immutable onchain. Never
+  recompute it.
+
+## Step 1 — Research (no credential)
+
+List what the server serves, then screen:
+
+```bash
+MCP=https://api.lienfi.com/api/v1/mcp
+curl -s -X POST $MCP -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+
+curl -s -X POST $MCP -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call",
+       "params":{"name":"market_overview","arguments":{}}}'
+
+curl -s -X POST $MCP -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":3,"method":"tools/call",
+       "params":{"name":"search_liens","arguments":{"budget_usd": 2000, "states": "FL", "limit": 5}}}'
+
+curl -s -X POST $MCP -H 'content-type: application/json' \
+  -d '{"jsonrpc":"2.0","id":4,"method":"tools/call",
+       "params":{"name":"get_lien","arguments":{"lien_id": "<lien-uuid>"}}}'
+```
+
+Every result is a text content block whose `text` is JSON. `search_liens` answers
+`liens` ranked on `net_apy`, plus `maturing_soon`, `dropped` (what could not be scored,
+counted rather than hidden), `fee_config` and `apy_labels`. Keep the `lien_id` you want.
+
+## Step 2 — Get authorized (the human step)
+
+First, check whether this step is already done. If you hold a bearer for this wallet from
+an earlier conversation, skip to Step 5: the authorization lasts until its `expires_at`,
+and a new conversation does not end it. If you are not sure whether the wallet is
+registered, ask LienFi, with no credential:
+
+```bash
+curl -s https://api.lienfi.com/api/v1/agents/<agent-wallet-address>
+```
+
+It answers `registered`, `expiresAt` and `revokedAt`. `registered: true` while you hold no
+bearer means the blob is lost to you, and a second authorization does NOT replace the
+first: your operator must press **Revoke** on the existing one at
+https://app.lienfi.com/agents/authorize before signing again, or registration is refused
+(`registration_refused`, "already has a different active authorization"). Say so before
+they sign, not after the refusal.
+
+Then tell your operator, in these words: go to https://app.lienfi.com/agents/authorize,
+enter the agent wallet address from *Your wallet address* above exactly, choose the most
+the agent may spend on one lien, a cumulative total, and an expiry of at most 90 days, and
+sign. The page then opens a handoff with a **Copy the prompt** button; ask them to paste
+that whole block to you. The block carries a credential, so it has to reach you privately:
+if this conversation is public — a reply on X, a group chat — ask them to paste it in the
+Bankr terminal or a direct message instead, never in the open. It carries all four of:
+
+1. the **bearer** — the authorization blob, base64url-encoded, ready for an
+   `Authorization: Bearer` header;
+2. the **key-proof typed data**, with the authorization digest filled in;
+3. one **consent typed data** per required agreement;
+4. the ready **registration call**, over MCP and over REST.
+
+If they hand you the envelopes individually instead — the page still renders each one,
+under *Raw envelopes* — the steps below are the same.
+
+Wait. Do not poll LienFi for it, and do not retry a refused tool while you wait.
+
+## Step 3 — Sign the key proof and the consents (your wallet)
+
+For the key proof and for EACH consent envelope: set `message.timestamp` to now in unix
+seconds (LienFi refuses one more than 600 seconds off its clock), change nothing else,
+and sign. Inside Bankr: your wallet tool's `eth_signTypedData_v4` over the envelope. Over
+the Wallet API:
+
+```bash
+curl -s -X POST https://api.bankr.bot/wallet/sign \
+  -H "X-API-Key: $BANKR_API_KEY" -H 'content-type: application/json' \
+  -d '{"signatureType":"eth_signTypedData_v4","typedData":<the envelope, with timestamp set>}'
+```
+
+Either way you get a `signature` (the Wallet API answers
+`{ "success": true, "signature": "0x…", "signer": "0x…" }`). Keep each `signature` with
+the `timestamp` you signed. The envelopes are described field by field
+in `references/typed-data.md`; the sentence in each `agreement` is hashed, so it must be
+byte-identical to what the page printed.
+
+## Step 4 — Register
+
+Over MCP, with the bearer:
+
+```bash
+curl -s -X POST $MCP -H 'content-type: application/json' \
+  -H "Authorization: Bearer $LIENFI_BEARER" \
+  -d '{"jsonrpc":"2.0","id":5,"method":"tools/call",
+       "params":{"name":"register_agent","arguments":{
+         "agent_key_proof": {"specVersion":"agent-keyproof-v1","signature":"0x…","timestamp":1756800000},
+         "agent_consents": [
+           {"specVersion":"consent-v2","documentType":"terms-and-conditions","version":3,"signature":"0x…","timestamp":1756800000},
+           {"specVersion":"consent-v2","documentType":"wallet-connection-consent","version":1,"signature":"0x…","timestamp":1756800000}
+         ]}}}'
+```
+
+Use the `documentType` and `version` values the page printed — they are the versions
+LienFi currently publishes. The answer is `registered: true`. The same body also works
+as `POST https://api.lienfi.com/api/v1/agents/register` with the printed
+`operatorAuthorization` included. Registering again with the same bearer is idempotent
+and tops up any consent that lapsed after a document was republished.
+
+From now on send the bearer on every LienFi call.
+
+## Step 5 — Check yourself, then price
+
+```bash
+curl -s -X POST $MCP -H 'content-type: application/json' -H "Authorization: Bearer $LIENFI_BEARER" \
+  -d '{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"agent_status","arguments":{}}}'
+
+curl -s -X POST $MCP -H 'content-type: application/json' -H "Authorization: Bearer $LIENFI_BEARER" \
+  -d '{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"quote_lien","arguments":{"lien_id":"<lien-uuid>"}}}'
+```
+
+`agent_status` is the first call to make when anything refuses: `registered`,
+`expires_at`, `balances`, and `spend` (what settled and what is live beside the caps
+your operator signed, with `enforced: false` on the cumulative). `quote_lien` is
+indicative — `lien_price_usdc`, `total_to_approve_usdc`, `affordable`,
+`shortfall_usdc` — and reserves nothing, so ask as often as you like.
+
+## Step 6 — Buy, one purchase at a time
+
+**6a. Prepare.** Runs every gate (authorization, the signed per-lien cap, consents,
+sanctions, your ceiling, the wallet's balance), then RESERVES for ten minutes and returns
+the acknowledgment typed data. Set `max_total_usdc` to `quote_lien`'s
+`total_to_approve_usdc` plus a small margin (1% covers accrual between calls); it is a
+stale-quote guard, not a budget, and never higher than the operator's per-lien cap.
+
+```bash
+curl -s -X POST $MCP -H 'content-type: application/json' -H "Authorization: Bearer $LIENFI_BEARER" \
+  -d '{"jsonrpc":"2.0","id":8,"method":"tools/call",
+       "params":{"name":"prepare_purchase","arguments":{"lien_id":"<lien-uuid>","max_total_usdc":1515}}}'
+```
+
+Returns `reservation_id`, `acknowledgment.typed_data`, `total_to_approve_usdc`,
+`expires_at` and `spend`. A refusal here leaves nothing behind. Calling it again for the
+same lien is safe: same reservation, same typed data while at least five of the ten
+minutes remain (`acknowledgment.reused: true`).
+
+**6b. Sign the acknowledgment** exactly as in Step 3, over
+`acknowledgment.typed_data` as returned — do NOT change its `timestamp`.
+
+**6c. Confirm.** Records the acknowledgment, THEN mints LienFi's price signature — bound
+to your wallet, valid 300 seconds from this moment — and returns the transactions,
+unsigned:
+
+```bash
+curl -s -X POST $MCP -H 'content-type: application/json' -H "Authorization: Bearer $LIENFI_BEARER" \
+  -d '{"jsonrpc":"2.0","id":9,"method":"tools/call",
+       "params":{"name":"confirm_purchase","arguments":{"reservation_id":"<reservation-uuid>","acknowledgment_signature":"0x…"}}}'
+```
+
+Returns `transactions[]` — each `{ step, name, to, data, value, chainId, why }`:
+`approve` (USDC, for exactly the total, never unlimited), `buyNFT` (carries the price
+signature), and `setApprovalForAll` (present unless the vault is already approved;
+WITHOUT it the lien is owned but cannot be redeemed) — plus `data_suffix`,
+`expires_at` and `consent_id`. If the live price moved above your ceiling, the
+reservation is released and the signature discarded (`quote_above_ceiling`): prepare
+again with a higher ceiling or skip the lien.
+
+**6d. Submit, in order, from your wallet.** Each one only after the previous is mined
+with `status: "success"`. Append `data_suffix` without its `0x` prefix to each `data` (it
+is Base Builder Code attribution — ignored by every contract, and omitting it only loses
+attribution). All three inside the 300 seconds. Inside Bankr: your wallet's raw
+transaction tool, with `to`, `data` and `value` exactly as returned, on chain 8453,
+waiting for the receipt each time. Over the Wallet API, which takes `value` in wei as a
+decimal string (send `"0"` for LienFi's `"0x0"`):
+
+```bash
+curl -s -X POST https://api.bankr.bot/wallet/submit \
+  -H "X-API-Key: $BANKR_API_KEY" -H 'content-type: application/json' \
+  -d '{"transaction":{"to":"<tx.to>","chainId":8453,"data":"<tx.data + data_suffix without 0x>","value":"0"},
+       "description":"LienFi approve","waitForConfirmation":true}'
+```
+
+Either way, read the receipt (the Wallet API answers `transactionHash`, `status` and
+`blockNumber`). A reverted
+transaction is mined too: a `buyNFT` sent after a reverted `approve` fails on allowance,
+one step removed from the cause. Check `status` every time. The `buyNFT` hash is the one
+you report.
+
+**6e. Report.**
+
+```bash
+curl -s -X POST $MCP -H 'content-type: application/json' -H "Authorization: Bearer $LIENFI_BEARER" \
+  -d '{"jsonrpc":"2.0","id":10,"method":"tools/call",
+       "params":{"name":"report_purchase","arguments":{"reservation_id":"<reservation-uuid>","tx_hash":"<buyNFT hash>"}}}'
+```
+
+LienFi reads the receipt: a success with the purchase event answers `settled: true`,
+`paid_usdc` and `vault_approval`; a revert releases the reservation; an unmined hash is
+`receipt_pending` — retry once it confirms. If you never submitted, report
+`{"reservation_id":"…","failed":true,"reason":"…"}` so the wallet can buy again.
+`vault_approval` must read `approved`, or submit `setApprovalForAll` again — it is
+idempotent.
+
+**6f. Verify** with `my_positions`: `confirmed_on_chain` is what the wallet holds,
+valued live. A purchase completed a moment ago may take the indexer a little while.
+
+## Hard rules
+
+- **One purchase in flight per wallet.** `purchase_in_flight` names the live one; finish
+  and report it, or report it failed. Never retry around it: ERC-20 `approve` SETS the
+  allowance, so a second live quote would let one approve overwrite the other's.
+- **Never approve more than `total_to_approve_usdc`, and never an unlimited amount.**
+- **Never park a quote.** Confirm, then submit within 300 seconds; a quote that sat while
+  you deliberated reverts on chain as expired.
+- **A timeout or network failure after a submit is not a revert.** The transaction MAY
+  have landed. Call `my_positions` before retrying anything.
+- **The operator's per-lien cap is enforced by LienFi; the cumulative is recorded, not
+  enforced.** The wallet balance is your operator's backstop — never move funds into it
+  on your own initiative.
+- **Stop on anything that needs a human**: `not_registered`, `authorization_expired`,
+  `authorization_revoked`, `consent_required`, `cap_exceeded_per_purchase`. Surface the
+  message and, where present, the `handoff_url`.
+- **Never present a listing as an investment recommendation** without the risk
+  disclosures in https://app.lienfi.com/legal/terms-and-conditions, sections 4 and 5.
+
+## Refusals
+
+Every refusal is a normal result with `isError: true` and a stable `error.code` beside a
+sentence written for you. The full table with what to do about each is
+`references/refusal-codes.md` and, live, https://app.lienfi.com/docs/api#mcp-refusals.
+The ones you will meet most: `purchase_in_flight` (finish or report the live one),
+`insufficient_funds` (tell your operator the `shortfall_usdc`), `quote_above_ceiling`
+(prepare again or skip), `receipt_pending` (retry the report once it confirms),
+`agent_consent_required` (re-sign the consents and register again), and the `*_unavailable`
+codes (transient — retry shortly, and never treat "could not check" as "fine").
+
+## Verified and unverified — read before the first real purchase
+
+LienFi ran a compatibility check against a real Bankr wallet on 2026-09-07 (every
+agent-side signature from Bankr's `/wallet/sign`, nothing submitted). What it settled:
+
+- **Bankr signs with the funded address.** `/wallet/sign` returns `signer` equal to the
+  EVM address `/wallet/me` reports, and the signature is plain ECDSA from that address.
+  On Base a Bankr wallet is an EOA with an EIP-7702 delegation, not a separate smart
+  wallet, so LienFi's verifier accepts the signature directly; its on-chain fallback
+  passes too. Name the `/wallet/me` address as the agent wallet and nothing else.
+- **Our envelopes verify as Bankr signs them.** A Bankr-signed key proof and consents
+  registered against LienFi, a Bankr-signed acknowledgment recorded, and
+  `confirm_purchase` returned the `approve`, `buyNFT` and `setApprovalForAll`
+  transactions for that wallet.
+- **Bankr's own agent signs without a Wallet API key** (2026-09-08). Registered from the
+  Bankr terminal with a fresh key proof and consents after the account's only API key
+  had been revoked, and carried the operator's bearer into a later call without being
+  told to store it anywhere.
+
+What is still unverified, and what to do if it bites:
+
+- Whether Bankr's preflight accepts LienFi's `approve` and `buyNFT` calldata unchanged —
+  from the agent's own submission tool or from `/wallet/submit` — and how Bankr's $500
+  limits treat an ERC-20 `approve`. If a submission is refused, report the exact response
+  to your operator; do not edit the calldata and do not retry with a different amount.
+
+## Troubleshooting
+
+- **`not_registered` after you registered** — you are not sending the bearer, or you are
+  sending a different one. Registering opens no session: the header goes on every call,
+  starting with the very next one. Send exactly the blob the page printed. (The message
+  says which case it is: "carried no Authorization header" or "No agent registration
+  exists for <wallet>".)
+- **`acknowledgment_invalid`** — you signed an edited or re-timestamped envelope, or with
+  a different wallet. Prepare again and sign the returned typed data verbatim.
+- **`authorization_required` on a REST quote** — the REST route needs the same bearer
+  for a signed quote; the MCP path does this for you.
+- **`receipt_mismatch`** — you reported the `approve` hash. Report the `buyNFT` hash.
+- **Every `*_unavailable` code** — transient on LienFi's side; wait and retry. Nothing was
+  reserved or moved.
+
+## Links
+
+- Walkthrough with every request body: https://app.lienfi.com/docs/api#mcp-walkthrough
+- Refusal codes: https://app.lienfi.com/docs/api#mcp-refusals
+- Conventions for machines: https://app.lienfi.com/llms.txt
+- Operator setup and authorization: https://app.lienfi.com/agents
+- OpenAPI: https://api.lienfi.com/api/v1/openapi.json

--- a/lienfi/catalog.json
+++ b/lienfi/catalog.json
@@ -1,0 +1,23 @@
+{
+  "schemaVersion": 1,
+  "slug": "lienfi",
+  "provider": "LienFi",
+  "providerUrl": "https://app.lienfi.com",
+  "logo": "logo.svg",
+  "demo": {
+    "title": "lienfi.sh",
+    "language": "bash",
+    "code": "# Research needs no credential\n\"Using the lienfi skill, find Florida tax liens under $2,000 with the best net yield\"\n# ✓ market_overview → search_liens (ranked NET of LienFi's fee) → get_lien\n\n# The one human step: your operator authorizes your wallet in a browser\n\"Using the lienfi skill, get me authorized to buy\"\n# → surfaces https://app.lienfi.com/agents/authorize, waits for the bearer\n\n# Buy from your own wallet — LienFi signs only the price\n\"Using the lienfi skill, buy the top result if it costs under $1,500\"\n# ✓ prepare_purchase → sign acknowledgment → confirm_purchase\n# ✓ submit approve, buyNFT, setApprovalForAll → report_purchase → my_positions"
+  },
+  "setup": [
+    "Inside Bankr's own agent there is nothing to set up: your wallet signs and submits. From another agent holding a Bankr wallet, create a key at https://bankr.bot/api-keys with `walletApiEnabled` on, `readOnly` OFF and `allowedRecipients` EMPTY, and keep it as `BANKR_API_KEY`",
+    "Fund the Bankr wallet with USDC on Base for no more than your operator is willing to commit; leave \"arbitrary contract calls\" on and set the daily limit to at least twice the lien price",
+    "Ask your operator to authorize the wallet address from `GET /wallet/me` at https://app.lienfi.com/agents/authorize and hand you what the page prints",
+    "Register once, then keep sending the operator authorization as `Authorization: Bearer <blob>` on every LienFi call"
+  ],
+  "install": {
+    "type": "bankr",
+    "repoPath": "lienfi",
+    "command": "install the lienfi skill from https://github.com/BankrBot/skills/tree/main/lienfi"
+  }
+}

--- a/lienfi/logo.svg
+++ b/lienfi/logo.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="2024" height="700" viewBox="0 0 2024 700" role="img" aria-label="LienFi logo">
+  <defs>
+    <linearGradient id="lgCircle" x1="0%" y1="50%" x2="100%" y2="50%">
+      <stop offset="0" stop-color="#22C7C8"/>
+      <stop offset="0.55" stop-color="#8FAE6A"/>
+      <stop offset="1" stop-color="#F3A018"/>
+    </linearGradient>
+    <linearGradient id="lgWord" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0" stop-color="#22C7C8"/>
+      <stop offset="0.55" stop-color="#8FAE6A"/>
+      <stop offset="1" stop-color="#F3A018"/>
+    </linearGradient>
+  </defs>
+  <circle cx="345" cy="350" r="345" fill="url(#lgCircle)"/>
+  <text x="883" y="530" font-family="Avenir Next, Inter, Helvetica Neue, Arial, sans-serif" font-size="410" font-weight="700" letter-spacing="-8" fill="url(#lgWord)" style="white-space: pre; font-size: 410px;">LienFi</text>
+</svg>

--- a/lienfi/references/refusal-codes.md
+++ b/lienfi/references/refusal-codes.md
@@ -1,0 +1,51 @@
+# LienFi refusal codes
+
+Every LienFi MCP tool refusal is a normal JSON-RPC result with `isError: true`. The text
+block carries JSON: `{ "error": { "code", "message", ... } }`. Branch on `code`; read
+`message` for the reason. Some refusals carry more: `not_registered` and the
+`authorization_*` codes carry `handoff_url` (surface it to your operator and stop),
+`purchase_in_flight` carries the live `reservation_id`, `lien_id` and `quote_deadline`,
+`insufficient_funds` carries `shortfall_usdc`, and `quote_above_ceiling` carries
+`quoted_usdc` and `ceiling_usdc`.
+
+The live table, kept in step with the server, is
+https://app.lienfi.com/docs/api#mcp-refusals. This copy is pinned against the server's
+own error set by a test in the LienFi monorepo.
+
+| code | what it means | what to do |
+| --- | --- | --- |
+| `invalid_arguments` | The arguments failed validation. | Fix the call against the schema in `tools/list`. Never retry it unchanged. |
+| `not_registered` | No Authorization header reached the call, or no registration exists for the wallet the bearer names; the message says which. Carries `handoff_url`. | Check the header first: if you already hold the blob, send it as `Authorization: Bearer <blob>` on every call — registering opens no session. Only then surface `handoff_url` to your operator and stop. |
+| `authorization_malformed` | The Authorization header could not be read as an authorization blob. | Send the blob exactly as the authorization page printed it — base64url or raw JSON. |
+| `authorization_mismatch` | This wallet is registered under a different signature than the one presented. | Use the blob it was registered with. For a NEW authorization, the operator revokes the active one first; then register. |
+| `authorization_revoked` | The operator revoked this authorization. | Stop. A new authorization is required. |
+| `authorization_expired` | The authorization’s term ran out. | Stop. Ask the operator to re-authorize. |
+| `authorization_unavailable` | The credential could not be CHECKED — an outage on our side, not a bad credential. | Retry shortly. Do not re-authorize. |
+| `authorization_required` | REST only: a signed quote for a bound wallet was asked for without its operator authorization, or with a different one. | Send `Authorization: Bearer <blob>`, or ask with `intent=indicative` or `intent=preflight`, which need none. |
+| `authorization_missing_caps` | The authorization carries no spend cap. | Ask the operator to re-authorize; a cap is part of what they sign. |
+| `binding_mismatch` | The wallet was re-registered under a newer authorization since this request started. | Retry with the current bearer. |
+| `lien_not_found` | No lien has that id. | Check the id; `search_liens` returns real ones. |
+| `lien_not_purchasable` | The lien exists but cannot be quoted or bought — delisted, lapsed or matured. The message says which. | Pick another lien. |
+| `cap_exceeded_per_purchase` | The lien costs more than the per-lien cap the operator signed. | Pick a cheaper lien. The cap is the operator’s to raise, by a new authorization. |
+| `consent_required` | The OPERATOR has not accepted the current LienFi agreements. | Surface it to the operator; that acceptance happens in a browser. |
+| `agent_consent_required` | The agent wallet’s own acceptance is missing or stale — usually a republished document. | Re-sign the consents from the agent wallet and register again; a replay tops them up. |
+| `consent_unavailable` | A required agreement is unpublished on our side. | Retry later. Not your fault. |
+| `sanctioned_address` | The wallet is on a sanctions list. | Stop. Terminal. |
+| `sanctions_screening_unavailable` | The sanctions oracle could not be read; the screen fails closed rather than passing. | Retry shortly. |
+| `purchase_in_flight` | This wallet already holds a live signed quote for another lien — named by `reservation_id`, `lien_id` and `quote_deadline`. | Finish and report that purchase, or report it failed. Do not retry around it; a second live quote would let one approve overwrite the other. |
+| `spend_ledger_unavailable` | The reservation ledger could not be written, or is disabled on this deployment (the message says which). | Retry shortly. Where it is disabled, buy over REST from your own wallet. |
+| `quote_above_ceiling` | The quote is above the `max_total_usdc` you passed. Nothing was reserved (or the reservation was released, at confirm). | Raise the ceiling and prepare again, or skip the lien. |
+| `insufficient_funds` | The wallet cannot cover the total; `shortfall_usdc` says by how much. Nothing was reserved. | Fund the wallet and prepare again. |
+| `affordability_unavailable` | The balance could not be read. It is never assumed affordable. | Retry shortly. |
+| `reservation_not_found` | No reservation with that id belongs to this binding — one answer for every miss. | Use the `reservation_id` prepare returned to you. |
+| `reservation_expired` | The reservation lapsed, was released, or its window passed. | Start again with `prepare_purchase`. |
+| `reservation_settled` | The reservation already settled on chain. Nothing reported now can undo that. | Nothing to do; `my_positions` shows the lien. |
+| `reservation_not_quoted` | A transaction hash was reported for a reservation that never received a signed quote, so no purchase can exist for it. | Report it failed if you did not buy; otherwise call `confirm_purchase` first. |
+| `acknowledgment_invalid` | The acknowledgment signature did not verify for this wallet and lien. The reservation was released. | Prepare again and sign the typed data exactly as returned, from the agent wallet. |
+| `receipt_pending` | The transaction is not mined yet. | Retry `report_purchase` once it confirms. |
+| `receipt_unavailable` | The chain could not be read. The transaction MAY still be in flight. | Call `my_positions` before retrying anything. |
+| `receipt_mismatch` | The transaction mined but carries no purchase of this lien by this wallet — the `approve` hash, or someone else’s. | Report the `buyNFT` hash instead. |
+| `batch_not_allowed` | A purchase tool was called inside a JSON-RPC batch. | Send it as the only message in the request. |
+| `registration_refused` | `POST /agents/register` refused; the message carries its sentence and HTTP status. | Read the sentence. "This agent wallet already has a different active authorization": the operator revokes it first, then you register. "Another LienFi account holds the active authorization": the message names the wallet that signed yours; the operator either signs from the account that holds the binding, or signs in as that account, revokes there, and registers this one. |
+| `rate_limited` | This binding exceeded the purchase tools’ budget of 30 calls a minute. | Slow down and retry. |
+| `internal` | An unclassified fault on our side. The detail is in our logs, not in the answer. | Retry shortly; report it if it persists. |

--- a/lienfi/references/typed-data.md
+++ b/lienfi/references/typed-data.md
@@ -1,0 +1,76 @@
+# The typed data you sign
+
+Three EIP-712 envelopes, all signed by YOUR wallet with `eth_signTypedData_v4`
+(`POST https://api.bankr.bot/wallet/sign`). Every one has the same domain:
+
+```json
+{ "name": "LienFi", "version": "1", "chainId": 8453 }
+```
+
+`chainId` is Base mainnet and LienFi pins every signature to it — a signature made
+for another network is refused with nothing to suggest the network is the reason.
+
+The authorization page prints the first two envelopes for you with every field but
+`timestamp` filled in. **Do not edit any field except `message.timestamp`.** The
+`agreement` sentence is part of what is hashed; LienFi rebuilds the whole message
+from its own copy of that sentence and compares signatures, so a paraphrase does
+not verify. Timestamps are unix SECONDS and must be within 600 seconds of LienFi's
+clock when the request arrives — stamp them at the moment you sign, not earlier.
+
+## 1. Key proof — `agent-keyproof-v1`
+
+Proves you hold the key for the wallet the operator named, bound to that exact
+authorization through its digest. Fields, in order:
+
+| field | type | value |
+| --- | --- | --- |
+| `agentWallet` | address | your wallet, as the operator entered it |
+| `authorizationHash` | bytes32 | the EIP-712 digest of the operator's authorization — the page fills it in |
+| `timestamp` | uint256 | now, unix seconds |
+| `agreement` | string | the sentence below, verbatim |
+
+> I hold the private key for the agent wallet named in this message, and I am presenting it against the operator authorization identified by the hash in this message.
+
+## 2. Consent — `consent-v2`, one per required agreement
+
+The same acceptance a person signs when they connect a wallet, signed by your
+wallet over the version LienFi currently publishes. The page prints one envelope
+per required document (today: `terms-and-conditions` and `wallet-connection-consent`).
+
+| field | type | value |
+| --- | --- | --- |
+| `documentType` | string | the agreement's type, e.g. `terms-and-conditions` |
+| `version` | uint256 | the published version the page printed |
+| `walletAddress` | address | your wallet |
+| `timestamp` | uint256 | now, unix seconds |
+| `agreement` | string | the sentence below, verbatim |
+
+> I agree to the LienFi Policies identified by the document type and version in this message, including any policy they incorporate by reference.
+
+A replay of `register_agent` with freshly signed consents is how you absorb a
+republished document: `agent_consent_required` means sign these again and register
+again.
+
+## 3. Purchase acknowledgment — `agent-purchase-consent-v1`
+
+Returned by `prepare_purchase` as `acknowledgment.typed_data`, one per purchase.
+Sign it exactly as returned — `confirm_purchase` rebuilds the message from the
+timestamp it stored, so a changed timestamp fails `acknowledgment_invalid`.
+
+| field | type | value |
+| --- | --- | --- |
+| `agentWallet` | address | your wallet |
+| `lienId` | string | the lien's uuid |
+| `action` | string | `log` |
+| `timestamp` | uint256 | chosen by LienFi at prepare time |
+| `agreement` | string | the sentence below, verbatim |
+
+> I am acting for the operator who authorized this agent wallet, and I am recording the acknowledgment for the lien named in this message under that standing authorization.
+
+## The operator's authorization — `agent-authorization-v2` (you do not sign this)
+
+Signed by your operator in the browser. You carry it, base64url-encoded, as
+`Authorization: Bearer <blob>` on every LienFi call; it names your wallet, the
+per-lien cap (enforced when a price is signed), a cumulative total (recorded and
+reported, not enforced) and an expiry of at most 90 days. The bearer IS the
+credential: never print it, never send it anywhere but `api.lienfi.com`.


### PR DESCRIPTION
## Summary

Adds **lienfi** — research and buy tokenized US tax lien certificates and redeemable tax deeds on [LienFi](https://app.lienfi.com), settled in USDC on Base (chain 8453).

The skill teaches the agent to:

- **Research with no credential** over LienFi's hosted MCP endpoint (`POST https://api.lienfi.com/api/v1/mcp`, JSON-RPC 2.0, nothing to install, no session): `market_overview`, `search_liens` (ranked on NET yield, after LienFi's share of the gain, with the same arithmetic the site displays) and `get_lien`.
- **Get authorized once, by a human.** The operator signs an authorization in a browser at `app.lienfi.com/agents/authorize` and hands the agent what that page prints; the agent signs a key proof and the consent agreements with its own wallet and registers. The skill has the agent check whether it is already registered before asking, have a stale authorization revoked first (a second one does not replace the first), and receive the bearer privately — never in a public X reply.
- **Buy from the wallet it controls**: `prepare_purchase` → sign the acknowledgment → `confirm_purchase` → submit `approve`, `buyNFT` and `setApprovalForAll` from its own wallet → `report_purchase` → `my_positions`. LienFi signs only the price quote; it never holds a key and never submits a transaction.

Both ways of holding a Bankr wallet are covered: Bankr's own agent (terminal, X, Telegram) signs and submits with its native wallet tools and needs no Wallet API key; an agent running elsewhere uses `/wallet/sign` and `/wallet/submit` with a key that has `readOnly` off and `allowedRecipients` empty.

## Contents

- `SKILL.md` — prerequisites, the money conventions that are not guessable from field names, six steps with a copy-ready request body for each, hard rules, refusals, what is verified and what is not, troubleshooting.
- `catalog.json` — `slug: lienfi`, demo prompts, setup steps, `install.type: bankr`.
- `logo.svg`
- `references/refusal-codes.md` — every `error.code` the server can answer and what to do about it, generated from the server's own table.
- `references/typed-data.md` — the EIP-712 envelopes the agent signs, field by field.

## How it was tested

- **2026-09-07, against a real Bankr wallet** (every agent-side signature from Bankr's `/wallet/sign`; nothing submitted): Bankr signs with its funded address — on Base an EOA with an EIP-7702 delegation — and plain ECDSA recovers it, so LienFi's verifier accepts the signatures directly. A Bankr-signed key proof and consents registered (201), a Bankr-signed purchase acknowledgment was recorded, and `confirm_purchase` returned the `approve`, `buyNFT` and `setApprovalForAll` transactions for that wallet.
- **2026-09-08, from Bankr's own terminal agent, with the account's only Wallet API key revoked**: registered against production with a fresh key proof and two consents signed by its own wallet tools, then answered `agent_status` with balances in a later conversation, carrying the operator's bearer unaided.
- **2026-09-08, from X**: Bankr ran the research step from a tweet — `search_liens` under a $500 budget — and reported the top lien by net yield with figures matching LienFi's own pipeline exactly (net 4.28%/yr, gross 4.76%/yr, 262 days to maturity). That run also exposed two gaps in an earlier draft of Step 2, closed here: check for an existing registration before asking the operator to sign again, and have the bearer pasted privately rather than in a public reply.

**Still unverified**, and stated in the skill under "Verified and unverified": whether Bankr's submission preflight accepts LienFi's `approve` and `buyNFT` calldata unchanged, and how Bankr's $500 per-transaction and 24-hour limits count an ERC-20 `approve`. The skill tells the agent to report a refused submission to its operator verbatim, and never to edit the calldata or retry with a different amount.

## Install

After merge:

```
install the lienfi skill from https://github.com/BankrBot/skills/tree/main/lienfi
```

Until then, from this branch:

```
install the lienfi skill from https://github.com/jackdishman/moltbot-skills/tree/add-lienfi-skill/lienfi
```

## Checklist

- [x] SKILL.md is clear and documented
- [x] catalog.json validated (`schemaVersion` 1, `slug` equals the folder name, `install.repoPath` is `lienfi`, logo present)
- [x] Tested before submitting (above)

Links: [walkthrough with every request body](https://app.lienfi.com/docs/api#mcp-walkthrough) · [refusal codes](https://app.lienfi.com/docs/api#mcp-refusals) · [llms.txt](https://app.lienfi.com/llms.txt) · [operator setup](https://app.lienfi.com/agents) · [OpenAPI](https://api.lienfi.com/api/v1/openapi.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
