### PR TITLE
Sync the bankr skill with current platform capabilities

### DIFF
--- a/bankr/SKILL.md
+++ b/bankr/SKILL.md
@@ -542,7 +542,7 @@ The [Bankr LLM Gateway](https://docs.bankr.bot/llm-gateway/overview) is a unifie
 - In OpenClaw config, prefix model IDs with `bankr/` (e.g. `bankr/claude-sonnet-5`). In direct API calls, use bare IDs (e.g. `claude-sonnet-5`). Run `bankr llm models` for the current model list
 - **Claude Code's `[1m]` context-tier suffix is optional through the gateway** — it's stripped before model lookup and the 1M window comes from the model's own context window, so `claude-opus-5` and `claude-opus-5[1m]` behave identically. If you do use it, quote it (`--model "claude-opus-5[1m]"`) — in zsh it's a glob character class and the command aborts before the CLI runs
 - **Per-model discounts** available for Bankr Club members and partners — applied automatically at billing time
-- **Image generation**: generate images via the OpenAI-native `/v1/images/generations` endpoint (model `gpt-image-2`), billed from the same LLM credit balance — see the reference
+- **Image generation**: generate images via the OpenAI-native `/v1/images/generations` endpoint — the `gpt-image-2.5` line (`-flare` for speed, `-sunburst` for precision) plus the previous `gpt-image-2`, all priced identically and billed from the same LLM credit balance — see the reference
 - **Expiring credit grants**: promotional or developer grants may carry an expiry date. Your spendable balance is your permanent (purchased) credits plus any unexpired grants — grants are spent first (soonest-expiring first) and drop off automatically at expiry
 - **Privacy tiers**: every request is served at `standard`, `zdr` (zero data retention), or `private` (TEE). Ask for a tier per request, per model, per base URL, or account-wide — see below
 
@@ -787,11 +787,13 @@ Spot stocks work with swaps, transfers, limit orders, and DCA. Only issuer-token
 |------|-------|
 | Counted launch attempts | **3 per Bankr wallet per rolling 24 hours** — identical for Standard, Bankr Club, partner organization and provisioned partner wallets |
 | Launch rate | At most **one token per minute** |
-| Launch-wallet age | Wallet must be **≥ 24 hours old** (measured from when Bankr created it, not from your X/social account's age) |
+| Launch-wallet age | Wallet must be **≥ 24 hours old** (measured from when Bankr created it, not from your X/social account's age) — **≥ 72 hours** if the wallet's only linked account is an email |
 | Launch-wallet balance | Must hold **≥ 0.002 native ETH on the launch chain** — required even on Base, where deploy gas is sponsored |
+| Simulations | **20 per wallet per 24 hours** — capped separately from the launch quota, and still never consumes a launch slot |
 | Same name, per account | 3 launches of the same token name per hour → `429` |
 | Same name, all accounts | 10 launches of the same name per hour → `429` |
 | Per fee-recipient address | 20 launches per 24 hours across *all* accounts → `429` |
+| Per client IP | ~10 **successful** deploys per 24 hours → `429` — non-partner only, approximate; the ceiling a single deploying host hits first |
 
 - **Only launches that actually went out consume budget.** Quota is reserved just before metadata pinning, and an attempt Bankr can prove never reached the chain hands its slot — and its name/fee-recipient allowance — back. Anything that was broadcast, or that Bankr can't prove wasn't, keeps counting: the classification fails safe, so never assume a failed deploy was free.
 - Validation, resolution and pricing failures before that reservation point never consume a slot, and **simulations don't either** (`--simulate` / `simulateOnly`). Retail simulations still require the 24h-old wallet; the balance minimum is skipped.
@@ -1180,6 +1182,8 @@ See [references/safety.md](references/safety.md) for comprehensive safety guidan
 - "What's my ETH balance?"
 - "Total portfolio value"
 - "Holdings on Base"
+
+> **Balance lists are filtered, including through the agent.** Low-value holdings are hidden by default on every balance surface — the wallet's `showLowValueTokens` preference and its $1 threshold — and the agent reports how many it dropped as `hiddenLowValueTokens`. Native gas rows are never hidden, and a filtered list is never proof the wallet holds nothing else; ask with `includeLowValueTokens` when you need everything. Selling and transferring by ticker resolve against your actual holdings with no floor, so a dust-sized position is still tradeable. See [references/portfolio.md](references/portfolio.md).
 
 ### Market Research
 

--- a/bankr/references/agent-profiles.md
+++ b/bankr/references/agent-profiles.md
@@ -147,6 +147,7 @@ Add a project update entry.
 | `limit` | 20 | Results per page (1-100) |
 | `offset` | 0 | Pagination offset |
 | `sort` | marketCap | Sort: `marketCap` or `newest` |
+| `includeFeatured` | — | `1` also returns every ops-featured profile on the first unfiltered page. That page may then exceed `limit`, so size your buffer off the array you get back rather than off `limit` |
 
 ## Approval Workflow
 

--- a/bankr/references/llm-gateway.md
+++ b/bankr/references/llm-gateway.md
@@ -55,16 +55,17 @@ bankr config get llmKey
 | `gemini-3.7-flash` | Google | Previous Flash, coding and agents (1M, image input) |
 | `gemini-3.6-flash` | Google | Fast, cost-effective multimodal (1M, image input) |
 | `gemini-3.5-flash` | Google | Fast general-purpose (1M) |
-| `gemini-3.5-flash-lite` | Google | Ultra-fast, lowest cost (1M) |
+| ~~`gemini-3.5-flash-lite`~~ | Google | **Deprecated** — use `gemini-3.8-flash` |
 | `gemini-3.1-pro` | Google | Long context, reasoning (1M) |
-| `gemini-3.1-flash-lite` | Google | Ultra-fast, lowest cost (1M) |
+| ~~`gemini-3.1-flash-lite`~~ | Google | **Deprecated** — use `gemini-3.8-flash` |
 | ~~`gemini-3-pro`~~ | Google | **Deprecated** — use `gemini-3.1-pro` |
 | `gemini-3-flash` | Google | High throughput (1M) |
 | `gemini-2.5-pro` | Google | Long context, multimodal |
 | `gemini-2.5-flash` | Google | Speed, high throughput |
 | `gemma-4-31b-it` | Google | Multimodal, cost-effective (262K) |
 | `gemma-4-26b-a4b-it` | Google | MoE, cost-effective (262K) |
-| `gpt-5.6-sol` | OpenAI | Latest flagship, most capable (1M context, image input) |
+| `gpt-6-astra` | OpenAI | Latest frontier, most capable (1M context, image input) |
+| `gpt-5.6-sol` | OpenAI | Previous frontier flagship (1M context, image input) |
 | `gpt-5.6-terra` | OpenAI | Latest balanced tier (1M context, image input) |
 | `gpt-5.6-luna` | OpenAI | Latest fast/economical tier (1M context, image input) |
 | `gpt-5.5` | OpenAI | Previous flagship (1M context, image input) |
@@ -79,9 +80,10 @@ bankr config get llmKey
 | `grok-4.5` | xAI | Latest, balanced multimodal (500K context, image input) |
 | `grok-4.3` | xAI | Balanced performance (1M context) |
 | `grok-4.1-fast` | xAI | Fast, economical, largest context (2M) |
-| `deepseek-v4-pro-0813` | DeepSeek | Latest frontier, high-capacity reasoning (1M) |
+| `deepseek-v4.1-flash` | DeepSeek | Latest Flash — agents, coding, vision (1M, image input) |
+| `deepseek-v4-pro-0813` | DeepSeek | Frontier, high-capacity reasoning (1M) |
 | `deepseek-v4-pro` | DeepSeek | Previous V4 Pro build, 0423 (1M, 384K output) |
-| `deepseek-v4-flash` | DeepSeek | High throughput, cost-effective (1M) |
+| `deepseek-v4-flash` | DeepSeek | Previous Flash — high throughput, cost-effective (1M) |
 | `deepseek-v3.2` | DeepSeek | Cost-effective (164K context) |
 | `qwen3.8-max` | Alibaba | Flagship Qwen, multimodal (1M, image input) |
 | `qwen3.8-flash` | Alibaba | Latest fast tier, multimodal (1M, image input) |
@@ -185,7 +187,9 @@ Only a **trailing** tier token counts as the opt-in, so unrelated model IDs cont
 
 ### Max Mode — Choose the Agent's Model
 
-Max Mode replaces the Bankr agent's default model (`gemini-3.8-flash`) with any gateway model, billed per token from your **LLM credit balance**. It's the pay-per-use alternative to a Bankr Club subscription for unlimited terminal messages, and unlike Club checkout it works with external/connected wallets.
+Max Mode replaces the Bankr agent's default model (`gemini-3.8-flash`) with a more capable gateway model, billed per token from your **LLM credit balance**. It's the pay-per-use alternative to a Bankr Club subscription for unlimited terminal messages, and unlike Club checkout it works with external/connected wallets.
+
+**Not every gateway model is a Max Mode choice.** Only the **frontier, flagship and balanced** lines are offered. Light models — `claude-haiku-4.5`, the GPT mini/nano tiers and similar — stay available through the gateway API but are not selectable as the agent's model, since swapping the default for something weaker isn't the point of Max Mode.
 
 ```bash
 bankr agent "analyze my portfolio" --model claude-opus-5
@@ -193,7 +197,9 @@ bankr agent "what are the top memecoins today?" -m gemini-3.1-pro
 bankr agent prompt "tell me more" --continue --model claude-sonnet-5
 ```
 
-The selection is stored on your wallet and applies across every surface — CLI, web terminal, Farcaster, X, Telegram, XMTP, and automations. In the web terminal, toggle the **Max** button and pick a model from the picker; a usage badge under each response shows model, tokens, and cost.
+The selection is stored on your wallet and applies across every surface — CLI, web terminal, Farcaster, X, Telegram, and automations, which all offer the same ranks. In the web terminal, toggle the **Max** button and pick a model from the picker; a usage badge under each response shows model, tokens, and cost.
+
+**Superseded releases collapse out of the pickers.** The web picker and `bankr llm models` list the two newest releases of each frontier/flagship/balanced line, so an older release stops being offered once two newer ones ship. The API still accepts that older id for as long as the gateway serves it — pin one explicitly if you depend on it, and don't assume a model is gone just because it dropped off a picker.
 
 **How credits are enforced:**
 
@@ -600,23 +606,31 @@ message = client.messages.create(
 
 ## Image Generation
 
-The gateway supports image generation through an OpenAI-native `POST /v1/images/generations` endpoint (model `gpt-image-2`). The request and response mirror OpenAI's images API, so the OpenAI SDK's `images.generate()` works against the gateway with just a base-URL swap:
+The gateway supports image generation through an OpenAI-native `POST /v1/images/generations` endpoint. The request and response mirror OpenAI's images API, so the OpenAI SDK's `images.generate()` works against the gateway with just a base-URL swap:
+
+| Model | Best for |
+|-------|----------|
+| `gpt-image-2.5-flare` | Speed and high-volume work — the default choice |
+| `gpt-image-2.5-sunburst` | Precision |
+| `gpt-image-2` | Previous generation |
 
 ```bash
 curl -X POST "https://llm.bankr.bot/v1/images/generations" \
   -H "Authorization: Bearer $BANKR_LLM_KEY" \
   -H "Content-Type: application/json" \
-  -d '{"model": "gpt-image-2", "prompt": "a neon city skyline at dusk"}'
+  -d '{"model": "gpt-image-2.5-flare", "prompt": "a neon city skyline at dusk"}'
 ```
 
 ```python
 from openai import OpenAI
 
 client = OpenAI(base_url="https://llm.bankr.bot/v1", api_key="your_bankr_key")
-img = client.images.generate(model="gpt-image-2", prompt="a neon city skyline at dusk")
+img = client.images.generate(model="gpt-image-2.5-flare", prompt="a neon city skyline at dusk")
 ```
 
-Image-output models are billed from the same LLM credit balance as text models, priced per image (image-output usage is metered separately). Image-capable models advertise an `image` output modality and per-image pricing in `GET /v1/models` (`output_modalities`, `pricing.image_output`); run `bankr llm models` for the current list.
+**Generation only.** The gateway exposes `/v1/images/generations` but not `/v1/images/edits`, so both 2.5 models are used for generation here — Sunburst's editing-accuracy advantage isn't reachable through the gateway yet. Streaming is not supported and `n` is capped at 4.
+
+Image-output models are billed from the same LLM credit balance as text models, priced per image (image-output usage is metered separately). The whole image line is priced identically, so the choice between them is about output, not cost. Image-capable models advertise an `image` output modality and per-image pricing in `GET /v1/models` (`output_modalities`, `pricing.image_output`); run `bankr llm models` for the current list.
 
 ## Model Deprecation
 

--- a/bankr/references/portfolio.md
+++ b/bankr/references/portfolio.md
@@ -72,6 +72,23 @@ All chains: Base, Polygon, Ethereum, Unichain, Solana, World Chain, Arbitrum, BN
 - **Exact Balances**: token `balance` is the exact decimal amount in plain notation, carried as a string — never rounded, and never in scientific notation for very small or very large holdings. If you do arithmetic on it, parse it with a decimal-safe library rather than relying on a float
 - **Partial-Failure Resilient**: the native balance and the token-list lookup are fetched independently per chain, so an indexer failure on the token side no longer takes the chain's native row down with it. A degraded chain returns the native balance it did retrieve rather than reporting the wallet as empty of it
 
+## Low-Value Tokens Are Filtered
+
+**A balance list you get back from the agent is filtered by default, and you must not read it as the whole wallet.** The agent's balance tools apply the same low-value rule as the web portfolio — the wallet's `showLowValueTokens` preference and its **$1** threshold — so a wallet holding airdrop dust on a thinly-indexed chain answers with its real holdings instead of a wall of `$0.00` rows.
+
+What that means when you consume the result:
+
+- **Native gas rows are never hidden.** "How much ETH do I have?" still answers on a near-empty wallet, whatever the balance is worth.
+- **The filtering is reported, not silent.** A filtered response carries `hiddenLowValueTokens` — a count of what was dropped — so "the list didn't mention token X" is never evidence the wallet doesn't hold it. Check the count before concluding anything about absence.
+- **Ask for everything explicitly** with `includeLowValueTokens` when you genuinely need the full list (dust sweeps, auditing an airdrop, reconciling against an indexer).
+- **Trading paths are unfiltered.** Swap and transfer resolution reads balances directly, so a token too small to show in a balance listing is still sellable and transferable — see below.
+
+## Selling and Transferring by Ticker
+
+Ticker resolution for sells and transfers runs against **what you actually hold**, with no USD floor, so a holding worth a few cents resolves the same way a large one does. "Sell all my WOLF for ETH" finds the WOLF in your wallet rather than falling through to a global market-cap search that doesn't know what you own.
+
+Holdings form the *candidate set*, not the answer — an airdropped token sharing a real one's symbol can't win by being held. If several tokens on the chain match the ticker you named, the agent returns a disambiguation listing **your own contracts and balances** to choose from. If none match, it falls back to the global search, so buying a token you don't yet hold is unchanged. Security checks run on whichever contract is finally selected.
+
 ## Common Tokens Tracked
 
 - **Stablecoins**: USDC, USDT, DAI

--- a/bankr/references/token-deployment.md
+++ b/bankr/references/token-deployment.md
@@ -387,14 +387,22 @@ After the third counted attempt, wait for the oldest one to age out of the 24-ho
 | Same token name | Across all accounts, per hour | 10 |
 | Fee-recipient address | Across all accounts, per 24 hours | 20 |
 
+**Per-network (IP) cap.** Separately from the wallet quota, non-partner deploys are capped at roughly **10 successful deploys per 24 hours per client IP**; exceeding it returns `429` with "Too many token deployments from this network." Only deploys that succeed count — failed attempts and rate-limited requests don't — and partner deploys are exempt, since many end-users share one partner server's IP.
+
+Treat the number as approximate rather than a contract: the counter lives in the API process serving you, and its 24-hour window starts at your first counted deploy instead of each deploy ageing out individually. If you deploy programmatically from one host, this is the ceiling you'll hit first — well before the per-wallet quota — so pace deploys rather than retrying into the `429`.
+
 ### Launch-Wallet Requirements (anti-sybil)
 
 Standard and Bankr Club launches require the Bankr wallet to be:
 
-- **At least 24 hours old**, measured from when Bankr created the wallet — not from the age of the linked X or other social account
+- **At least 24 hours old**, measured from when Bankr created the wallet — not from the age of the linked X or other social account. **A wallet whose only linked account is an email needs 72 hours**, not 24; linking a real social account puts it back on the 24-hour gate
 - Holding **at least 0.002 native ETH on the launch chain**
 
-Both checks run *before* quota is reserved, metadata is pinned, or a transaction is submitted, so a rejection here costs neither a launch attempt nor gas. The balance minimum applies even on Base, where Bankr sponsors deploy gas; on Robinhood Chain and Arbitrum it also has to cover the launch's own gas. Validated active partner-organization and provisioned-wallet launch paths are exempt from both requirements — only while the organization is active with token launching enabled, and (for a provisioned wallet) while the wallet stays active and linked to that organization. Retail **simulations** still require the 24-hour wallet age, but skip the balance check.
+Both checks run *before* quota is reserved, metadata is pinned, or a transaction is submitted, so a rejection here costs neither a launch attempt nor gas. The balance minimum applies even on Base, where Bankr sponsors deploy gas; on Robinhood Chain and Arbitrum it also has to cover the launch's own gas. Validated active partner-organization and provisioned-wallet launch paths are exempt from both requirements — only while the organization is active with token launching enabled, and (for a provisioned wallet) while the wallet stays active and linked to that organization. Retail **simulations** still require the wallet-age gate, but skip the balance check.
+
+**Simulations have their own cap: 20 per wallet per 24 hours.** It is counted separately from the launch quota — a simulation still never consumes a launch slot — but it does mean `--simulate` / `simulateOnly: true` is not free to loop over. Budget it if you simulate before every deploy. Partner deploys are exempt from the simulate cap, as they are from the other retail gates.
+
+**Launches are also geo-gated**, and every eligibility gate above runs on *every* launch path — REST deploy, the web terminal, the Agent API and the social surfaces alike — not only the REST endpoints. A blocked launch answers with one generic "token launch not available" message rather than naming the reason, so don't try to branch your automation on the specific cause; treat it as a terminal refusal for that wallet and region.
 
 ### Gas Sponsorship
 

--- a/bankr/references/x402-cloud.md
+++ b/bankr/references/x402-cloud.md
@@ -252,6 +252,10 @@ https://x402.bankr.bot/<walletAddress>/<serviceName>[/path]
 
 Payments only settle if your handler returns a successful response (status < 400). Failed requests are never charged.
 
+**Verification and settlement are Bankr's to drive, not yours.** Steps 4 and 5 run through a dedicated facilitator service — your handler code never touches payment logic, and neither payers nor handlers call `verify`/`settle` directly. Both operations are authenticated and rate-limited: each call carries a short-lived token bound to the specific endpoint being paid for, and settlement pays out to the address on that endpoint's record rather than anything supplied in the request, so a payout target can't be swapped by a crafted request.
+
+The `facilitator` URL that comes back in a `402` response is informational — it tells payment clients which facilitator quoted the price. Don't build a flow that posts to it yourself; use the `X-PAYMENT` retry above (or a client like `x402-fetch`) and let the router handle the rest. The verified payer's wallet address reaches your handler as the `x-402-payer` header.
+
 ## Limits
 
 | Resource | Limit |


### PR DESCRIPTION
Weekly sync of the `bankr` skill against the current state of the platform. Two groups below: what changed on the platform this week, and gaps the sync surfaced that predate it.

Docs-only — no behavior, no new files, and no change to the skill's frontmatter or `catalog.json`.

## Shipped this week

**LLM gateway — model registry**
- Added `gpt-6-astra` (latest frontier OpenAI) and `deepseek-v4.1-flash` (latest DeepSeek Flash, now vision-capable), and demoted the releases each supersedes so "latest" in the table means latest.
- Marked `gemini-3.5-flash-lite` and `gemini-3.1-flash-lite` deprecated, pointing at `gemini-3.8-flash`.

**LLM gateway — image generation**
- Image generation now runs on the `gpt-image-2.5` line: `-flare` for speed and high-volume work, `-sunburst` for precision, with `gpt-image-2` as the previous generation. Examples updated to `flare`.
- Documented that the gateway exposes `/v1/images/generations` but not `/v1/images/edits`, so Sunburst's editing advantage isn't reachable here; plus the `n` ≤ 4 cap and that the whole line is priced identically, so the choice is about output rather than cost.

**Max Mode**
- The skill claimed Max Mode accepts *any* gateway model. It doesn't: only the frontier, flagship and balanced lines are selectable. Light models stay reachable through the gateway API but aren't offered as the agent's model.
- Documented that the pickers list the two newest releases per line while the API still accepts older ids for as long as they're served — so dropping off a picker isn't the same as being gone. Removed XMTP from the surface list.

**Balance reads through the agent**

This is the one most likely to bite an agent consuming the skill. Agent balance tools now apply the wallet's low-value token preference and its $1 threshold, so a returned balance list is filtered by default and **is not the whole wallet**. Documented the `hiddenLowValueTokens` count, the `includeLowValueTokens` opt-out, and that native gas rows are never hidden — with the explicit warning that a token's absence from the list is not evidence the wallet doesn't hold it.

**Selling and transferring by ticker**

Ticker resolution for sells and transfers now runs against actual holdings with no USD floor, so a dust-sized position resolves like any other rather than falling through to a global search. Holdings form the candidate set rather than the answer, and ambiguity is resolved against the user's own contracts and balances.

**Token launch gates**
- A wallet whose only linked account is an email needs 72 hours of age rather than 24.
- Simulations are capped at 20 per wallet per 24 hours — still never consuming a launch slot, but no longer free to loop over.
- Gates apply on every launch path, not just the REST endpoints, and a blocked launch returns one generic message — so automation shouldn't branch on the reason.

**Agent profiles**
- Documented the `includeFeatured` query parameter on the list endpoint, including that the first page can then exceed `limit`.

## Gaps caught while syncing

These predate this week; the sync just surfaced them.

- **Per-IP deploy cap was missing entirely.** Non-partner deploys are capped at roughly 10 *successful* deploys per 24 hours per client IP, returning `429`. For anyone deploying programmatically from one host this is the ceiling they hit first — well before the per-wallet quota — so its absence was a real trap. Documented with the caveat that the figure is approximate.
- **x402 facilitator trust boundary was undocumented.** Verify and settle are authenticated, rate-limited and bound to the specific endpoint being paid for, and settlement pays the address on that endpoint's record rather than anything in the request. Added a note that the `facilitator` URL in a `402` response is informational and shouldn't be posted to directly.

## Verification

Checked the whole skill for stale references to anything retired this week — nothing left. Confirmed the pre-existing gaps above weren't recent regressions before labelling them as such. Reviewed the rendered Markdown for list and table breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fh4pWnuc5PBsWWKPxidnxh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fh4pWnuc5PBsWWKPxidnxh)_